### PR TITLE
TASK-014: Write docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,16 @@
 # docker-compose.yml — Local development environment
 #
 # Services:
-#   localstack      AWS services mock (DynamoDB, S3, SQS, SSM, Secrets Manager)
+#   localstack      AWS services mock (DynamoDB, S3, SQS, SSM, Secrets Manager, EventBridge)
 #   mock-runtime    Mock AgentCore Runtime (POST /invocations, GET /ping)
 #   mock-jwks       Mock JWKS endpoint (issues test JWTs, serves /.well-known/jwks.json)
-#
-# Implemented in TASK-014.
 #
 # Usage:
 #   make dev        Start all services and seed fixtures
 #   make dev-stop   Stop all services
-
-version: "3.9"
+#   make dev-logs   Stream logs from all services
 
 services:
-  # Implemented in TASK-014
   localstack:
     image: localstack/localstack:latest
     ports:
@@ -25,11 +21,17 @@ services:
       - DEBUG=0
     volumes:
       - localstack-data:/var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 3s
+      start_period: 15s
+      retries: 10
 
   # Mock AgentCore Runtime — FastAPI on :8765
-  # POST /invocations — returns canned streaming response
-  # GET /ping — returns {"status": "Healthy"}
-  # Implemented in TASK-014
+  # POST /invocations — returns canned SSE streaming response
+  # GET  /ping        — returns {"status": "Healthy"}
+  # Logs tenant context headers (x-tenant-id, x-app-id, x-tier, etc.)
   mock-runtime:
     build:
       context: .
@@ -38,17 +40,31 @@ services:
       - "8765:8765"
     environment:
       - LOG_LEVEL=INFO
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8765/ping')"]
+      interval: 5s
+      timeout: 3s
+      start_period: 15s
+      retries: 6
 
   # Mock JWKS endpoint — FastAPI on :8766
-  # GET /.well-known/jwks.json — serves test public key
-  # POST /token — issues signed test JWTs
-  # Implemented in TASK-014
+  # GET  /.well-known/jwks.json — serves ephemeral RSA public key as JWK Set
+  # POST /token                 — issues signed RS256 test JWTs
+  # GET  /health                — service health check
   mock-jwks:
     build:
       context: .
       dockerfile: tests/mocks/mock-jwks.Dockerfile
     ports:
       - "8766:8766"
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8766/health')"]
+      interval: 5s
+      timeout: 3s
+      start_period: 15s
+      retries: 6
 
 volumes:
   localstack-data:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -135,7 +135,7 @@ Nothing in Phase 2 starts until written confirmation.
               Returns canned streaming response. Logs tenant context headers.
               Mock JWKS: FastAPI on :8766, issues test JWTs, serves /.well-known/jwks.json
               ADRs: none | Tests: make dev must start cleanly
-              Done: 2026-02-25, commit TBD
+              Done: 2026-02-25, commit 38a6dd5
 
 [ ] TASK-015  Write scripts/dev-bootstrap.py
               Seeds two test tenants (basic-tier, premium-tier)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -129,12 +129,13 @@ Nothing in Phase 2 starts until written confirmation.
 
 ## Phase 2 — Local Development Loop
 
-[~] TASK-014  Write docker-compose.yml
+[x] TASK-014  Write docker-compose.yml
               Services: LocalStack, mock AgentCore Runtime, mock JWKS endpoint
               Mock Runtime: FastAPI on :8765, POST /invocations, GET /ping
               Returns canned streaming response. Logs tenant context headers.
               Mock JWKS: FastAPI on :8766, issues test JWTs, serves /.well-known/jwks.json
               ADRs: none | Tests: make dev must start cleanly
+              Done: 2026-02-25, commit TBD
 
 [ ] TASK-015  Write scripts/dev-bootstrap.py
               Seeds two test tenants (basic-tier, premium-tier)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -129,7 +129,7 @@ Nothing in Phase 2 starts until written confirmation.
 
 ## Phase 2 — Local Development Loop
 
-[ ] TASK-014  Write docker-compose.yml
+[~] TASK-014  Write docker-compose.yml
               Services: LocalStack, mock AgentCore Runtime, mock JWKS endpoint
               Mock Runtime: FastAPI on :8765, POST /invocations, GET /ping
               Returns canned streaming response. Logs tenant context headers.

--- a/tests/mocks/mock-jwks.Dockerfile
+++ b/tests/mocks/mock-jwks.Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies separately for better layer caching
+COPY tests/mocks/mock_jwks/requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY tests/mocks/mock_jwks/main.py main.py
+
+EXPOSE 8766
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=15s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8766/health')"
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8766"]

--- a/tests/mocks/mock-runtime.Dockerfile
+++ b/tests/mocks/mock-runtime.Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies separately for better layer caching
+COPY tests/mocks/mock_runtime/requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY tests/mocks/mock_runtime/main.py main.py
+
+ENV LOG_LEVEL=INFO
+
+EXPOSE 8765
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8765/ping')"
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8765"]

--- a/tests/mocks/mock_jwks/main.py
+++ b/tests/mocks/mock_jwks/main.py
@@ -1,0 +1,114 @@
+"""Mock JWKS endpoint — FastAPI on :8766.
+
+Endpoints:
+    GET  /.well-known/jwks.json  Serve the test RSA public key as a JWK Set.
+    POST /token                  Issue a signed RS256 JWT for a given tenant.
+    GET  /health                 Service health check.
+
+The RSA key pair is generated once on startup and is ephemeral (not persisted).
+All JWTs issued by this service are valid only while the container is running.
+"""
+
+import base64
+import logging
+import time
+import uuid
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="mock-jwks")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger("mock-jwks")
+
+# Ephemeral RSA-2048 key pair — generated once per container lifetime
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PUBLIC_KEY = _PRIVATE_KEY.public_key()
+_KID = str(uuid.uuid4())
+
+# Issuer and audience used for all tokens from this mock
+ISSUER = "http://localhost:8766"
+AUDIENCE = "api://platform-local"
+
+
+def _int_to_base64url(n: int) -> str:
+    """Encode a big integer as a base64url string (for use in JWK 'n' and 'e')."""
+    byte_length = (n.bit_length() + 7) // 8
+    return base64.urlsafe_b64encode(n.to_bytes(byte_length, "big")).rstrip(b"=").decode()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/.well-known/jwks.json")
+def jwks() -> dict[str, list[dict[str, str]]]:
+    """Serve the RSA public key as a JWK Set (JWKS)."""
+    pub_numbers = _PUBLIC_KEY.public_numbers()
+    return {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": _KID,
+                "alg": "RS256",
+                "n": _int_to_base64url(pub_numbers.n),
+                "e": _int_to_base64url(pub_numbers.e),
+            }
+        ]
+    }
+
+
+class TokenRequest(BaseModel):
+    tenant_id: str
+    app_id: str = "platform-local"
+    tier: str = "basic"
+    sub: str = "test-user"
+    roles: list[str] = []
+    ttl: int = 3600
+
+
+@app.post("/token")
+def issue_token(req: TokenRequest) -> dict[str, object]:
+    """Issue a signed RS256 JWT containing tenant context claims."""
+    now = int(time.time())
+    payload: dict[str, object] = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "sub": req.sub,
+        "iat": now,
+        "nbf": now,
+        "exp": now + req.ttl,
+        # Tenant context claims — matched by authoriser Lambda
+        "tenantid": req.tenant_id,
+        "appid": req.app_id,
+        "tier": req.tier,
+        "roles": req.roles,
+    }
+    private_key_pem = _PRIVATE_KEY.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    token: str = jwt.encode(
+        payload,
+        private_key_pem,
+        algorithm="RS256",
+        headers={"kid": _KID},
+    )
+    logger.info(
+        "Issued token | tenant_id=%s app_id=%s tier=%s ttl=%d",
+        req.tenant_id,
+        req.app_id,
+        req.tier,
+        req.ttl,
+    )
+    return {"access_token": token, "token_type": "Bearer", "expires_in": req.ttl}

--- a/tests/mocks/mock_jwks/requirements.txt
+++ b/tests/mocks/mock_jwks/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+uvicorn[standard]==0.34.0
+cryptography==44.0.2
+PyJWT==2.10.1

--- a/tests/mocks/mock_runtime/main.py
+++ b/tests/mocks/mock_runtime/main.py
@@ -1,0 +1,75 @@
+"""Mock AgentCore Runtime — FastAPI on :8765.
+
+Endpoints:
+    GET  /ping         Health check, returns {"status": "Healthy"}
+    POST /invocations  Returns a canned SSE streaming response.
+                       Logs tenant context headers from the Bridge Lambda.
+"""
+
+import json
+import logging
+import os
+
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+app = FastAPI(title="mock-agentcore-runtime")
+
+_LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=_LOG_LEVEL,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger("mock-runtime")
+
+# Headers injected by Bridge Lambda carrying tenant context
+_TENANT_HEADERS = [
+    "x-tenant-id",
+    "x-app-id",
+    "x-tier",
+    "x-session-id",
+    "x-invocation-id",
+    "x-agent-name",
+]
+
+# Canned streaming chunks returned for every /invocations request
+_CANNED_CHUNKS = [
+    "Hello from mock AgentCore Runtime.",
+    " This is a canned streaming response.",
+    " Tenant context has been logged.",
+]
+
+
+@app.get("/ping")
+def ping() -> dict[str, str]:
+    """AgentCore Runtime health check."""
+    return {"status": "Healthy"}
+
+
+@app.post("/invocations")
+async def invocations(request: Request) -> StreamingResponse:
+    """Return a canned SSE streaming response and log tenant context headers."""
+    tenant_context: dict[str, str] = {}
+    for header in _TENANT_HEADERS:
+        value = request.headers.get(header)
+        if value:
+            tenant_context[header] = value
+
+    body = await request.body()
+    logger.info(
+        "Invocation received | tenant_context=%s body_bytes=%d",
+        json.dumps(tenant_context),
+        len(body),
+    )
+
+    async def _stream():
+        for chunk in _CANNED_CHUNKS:
+            event = json.dumps({"type": "text", "content": chunk})
+            yield f"data: {event}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        _stream(),
+        media_type="text/event-stream",
+        headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
+    )

--- a/tests/mocks/mock_runtime/requirements.txt
+++ b/tests/mocks/mock_runtime/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.6
+uvicorn[standard]==0.34.0


### PR DESCRIPTION
## What was implemented

Three local development services for Phase 2 of the local development loop:

**docker-compose.yml** (updated from stub):
- Added Docker-level health checks on all three services
- Removed deprecated `version: "3.9"` field (Docker Compose v2)
- LocalStack: `dynamodb,s3,sqs,ssm,secretsmanager,events`, `DEFAULT_REGION=eu-west-2`, persistent volume

**`tests/mocks/mock_runtime/`** — FastAPI service on `:8765`:
- `GET /ping` → `{"status": "Healthy"}` (AgentCore Runtime health contract)
- `POST /invocations` → canned SSE streaming response (`data: {...}\n\n` lines, terminated with `data: [DONE]\n\n`)
- Logs all tenant context headers injected by Bridge Lambda (`x-tenant-id`, `x-app-id`, `x-tier`, `x-session-id`, `x-invocation-id`, `x-agent-name`)
- `LOG_LEVEL` environment variable respected

**`tests/mocks/mock_jwks/`** — FastAPI service on `:8766`:
- `GET /.well-known/jwks.json` → RFC 7517 JWK Set with ephemeral RSA-2048 public key
- `POST /token` → RS256-signed JWT with `tenantid`, `appid`, `tier`, `roles`, `sub` claims matching architecture spec
- `GET /health` → health check endpoint
- RSA key pair is ephemeral — generated once per container startup, never persisted

## Security notes

- No hardcoded credentials anywhere
- JWKS key is ephemeral and generated at runtime
- `PrivateKeyDetector` and all other detect-secrets plugins pass clean
- Tokens include `kid` header so authoriser Lambda can locate the matching JWK

## Tests evidence

```
make validate-local
==> Running local validation (fast)
uv run ruff check .  → All checks passed!
uv run ruff format --check .  → 47 files already formatted
pyright  → 0 errors, 0 warnings, 0 informations
tsc --noEmit  → pass
cdk synth  → Successfully synthesized
detect-secrets (changed files only)  → detect-secrets diff scan passed
==> Validation passed
```

Docker is not available in the agent shell (WSL2 sandbox), so `make dev` was not run end-to-end by the agent. The implementation is verified via:
- YAML syntax validation (Python yaml.safe_load)
- Python AST syntax check on both mock apps
- Ruff lint (all checks passed)
- detect-secrets scan (clean)

The operator should run `make dev` in their local Docker environment to confirm it starts cleanly.

## validate-local output

All checks passed — see Tests evidence above.

## Review findings addressed

Senior engineer review identified no critical issues:
- No hardcoded secrets ✅
- All imports used (Ruff F401) ✅
- Correct JWK encoding (`n` and `e` as base64url big-endian) ✅
- Correct SSE format (`data: ...\n\n`, `[DONE]` terminator) ✅
- `localstack:latest` unpinned — acceptable for local dev tooling
- No non-root user in Dockerfiles — acceptable for local dev containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)