### PR TITLE
feat(issue-22): implement scripts/dev-bootstrap.py (TASK-015)

### DIFF
--- a/scripts/dev-bootstrap.py
+++ b/scripts/dev-bootstrap.py
@@ -4,7 +4,7 @@ dev-bootstrap.py — Local development environment seeding script.
 Seeds LocalStack with:
   - Two test tenants: basic-tier (t-basic-001) and premium-tier (t-premium-001)
   - All SSM parameters pointing to LocalStack endpoints
-  - DynamoDB tables with fixture data
+  - DynamoDB tables with fixture data (tables created if missing)
   - Test JWTs written to .env.test
 
 Idempotent — safe to run multiple times without creating duplicate records.
@@ -16,3 +16,422 @@ Called automatically by: make dev
 
 Implemented in TASK-015.
 """
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger("dev-bootstrap")
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via environment variables at call sites)
+# ---------------------------------------------------------------------------
+_DEFAULT_LOCALSTACK_ENDPOINT = "http://localhost:4566"
+_DEFAULT_MOCK_JWKS_URL = "http://localhost:8766"
+_DEFAULT_REGION = "eu-west-2"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_ENV_TEST_PATH = _REPO_ROOT / ".env.test"
+
+# ---------------------------------------------------------------------------
+# DynamoDB table definitions
+# ---------------------------------------------------------------------------
+TABLE_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "TableName": "platform-tenants",
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "platform-agents",
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "platform-invocations",
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "platform-jobs",
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "platform-sessions",
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "platform-tools",
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "platform-ops-locks",
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Fixture data — deterministic keys, stable timestamps
+# ---------------------------------------------------------------------------
+TENANT_FIXTURES: list[dict[str, Any]] = [
+    {
+        "PK": "TENANT#t-basic-001",
+        "SK": "METADATA",
+        "tenant_id": "t-basic-001",
+        "app_id": "platform-local",
+        "display_name": "Test Tenant Basic",
+        "tier": "basic",
+        "status": "active",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "owner_email": "basic-test@example.local",
+        "owner_team": "platform-test",
+        "account_id": "000000000000",
+        "monthly_budget_usd": Decimal("100"),
+    },
+    {
+        "PK": "TENANT#t-premium-001",
+        "SK": "METADATA",
+        "tenant_id": "t-premium-001",
+        "app_id": "platform-local",
+        "display_name": "Test Tenant Premium",
+        "tier": "premium",
+        "status": "active",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "owner_email": "premium-test@example.local",
+        "owner_team": "platform-test",
+        "account_id": "000000000000",
+        "monthly_budget_usd": Decimal("1000"),
+    },
+]
+
+AGENT_FIXTURES: list[dict[str, Any]] = [
+    {
+        "PK": "AGENT#echo-agent",
+        "SK": "VERSION#1.0.0",
+        "agent_name": "echo-agent",
+        "version": "1.0.0",
+        "owner_team": "platform-test",
+        "tier_minimum": "basic",
+        "layer_hash": "0000000000000000",
+        "layer_s3_key": "layers/echo-agent/1.0.0-0000000000000000.zip",
+        "script_s3_key": "scripts/echo-agent/1.0.0.zip",
+        "deployed_at": "2026-01-01T00:00:00+00:00",
+        "invocation_mode": "sync",
+        "streaming_enabled": True,
+    },
+]
+
+TOOL_FIXTURES: list[dict[str, Any]] = [
+    {
+        "PK": "TOOL#echo",
+        "SK": "GLOBAL",
+        "tool_name": "echo",
+        "tier_minimum": "basic",
+        "lambda_arn": ("arn:aws:lambda:eu-west-2:000000000000:function:platform-echo-tool-local"),
+        "gateway_target_id": "echo-target-local",
+        "enabled": True,
+    },
+]
+
+
+def _ssm_parameters(*, mock_jwks_url: str, localstack_endpoint: str) -> list[tuple[str, str]]:
+    """Return (name, value) pairs for all platform SSM parameters."""
+    pii_patterns = json.dumps(
+        [
+            r"\b[A-Z]{2}\d{6}[A-D]\b",  # UK NI number
+            r"\b\d{3}[-\s]\d{3}[-\s]\d{4}\b",  # NHS number (simplified)
+            r"\b\d{2}-\d{2}-\d{2}\b",  # Sort code
+            r"\b\d{8}\b",  # Bank account number
+            r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b",  # Email
+        ]
+    )
+    return [
+        ("/platform/config/runtime-region", "eu-west-1"),
+        ("/platform/config/fallback-region", "eu-central-1"),
+        ("/platform/config/jwks-url", f"{mock_jwks_url}/.well-known/jwks.json"),
+        ("/platform/config/api-audience", "api://platform-local"),
+        ("/platform/config/api-issuer", mock_jwks_url),
+        ("/platform/config/env", "local"),
+        ("/platform/config/mock-runtime-url", "http://localhost:8765"),
+        ("/platform/config/localstack-endpoint", localstack_endpoint),
+        ("/platform/gateway/pii-patterns/default", pii_patterns),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Step functions
+# ---------------------------------------------------------------------------
+
+
+def ensure_tables(ddb_client: Any) -> None:
+    """Create DynamoDB tables if they do not already exist. Idempotent."""
+    for defn in TABLE_DEFINITIONS:
+        table_name = defn["TableName"]
+        try:
+            ddb_client.create_table(**defn)
+            logger.info("Created table %s", table_name)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in ("ResourceInUseException", "TableAlreadyExistsException"):
+                logger.debug("Table %s already exists — skipping", table_name)
+            else:
+                raise
+
+
+def _seed_items(ddb_resource: Any, table_name: str, items: list[dict[str, Any]]) -> None:
+    """Upsert items into a DynamoDB table. put_item is idempotent by PK+SK key."""
+    table = ddb_resource.Table(table_name)
+    for item in items:
+        table.put_item(Item=item)
+    logger.info("Seeded %d item(s) into %s", len(items), table_name)
+
+
+def seed_tenants(ddb_resource: Any) -> None:
+    """Upsert two test tenant records (basic-tier and premium-tier)."""
+    _seed_items(ddb_resource, "platform-tenants", TENANT_FIXTURES)
+
+
+def seed_agents(ddb_resource: Any) -> None:
+    """Upsert echo-agent v1.0.0 fixture record."""
+    _seed_items(ddb_resource, "platform-agents", AGENT_FIXTURES)
+
+
+def seed_tools(ddb_resource: Any) -> None:
+    """Upsert echo tool fixture record."""
+    _seed_items(ddb_resource, "platform-tools", TOOL_FIXTURES)
+
+
+def seed_ssm_parameters(ssm_client: Any, *, mock_jwks_url: str, localstack_endpoint: str) -> None:
+    """Upsert all platform SSM parameters. Overwrites existing values."""
+    params = _ssm_parameters(mock_jwks_url=mock_jwks_url, localstack_endpoint=localstack_endpoint)
+    for name, value in params:
+        ssm_client.put_parameter(Name=name, Value=value, Type="String", Overwrite=True)
+    logger.info("Seeded %d SSM parameter(s)", len(params))
+
+
+def fetch_jwts(mock_jwks_url: str) -> dict[str, str]:
+    """Fetch test JWTs from the mock-jwks service.
+
+    Issues three tokens: basic, premium, and admin (Platform.Admin role).
+    Returns an empty dict if the service is unavailable — caller handles gracefully.
+    """
+    requests_to_make: list[tuple[str, dict[str, Any]]] = [
+        (
+            "basic",
+            {"tenant_id": "t-basic-001", "app_id": "platform-local", "tier": "basic", "ttl": 86400},
+        ),
+        (
+            "premium",
+            {
+                "tenant_id": "t-premium-001",
+                "app_id": "platform-local",
+                "tier": "premium",
+                "ttl": 86400,
+            },
+        ),
+        (
+            "admin",
+            {
+                "tenant_id": "t-basic-001",
+                "app_id": "platform-local",
+                "tier": "basic",
+                "sub": "admin-user",
+                "roles": ["Platform.Admin"],
+                "ttl": 86400,
+            },
+        ),
+    ]
+    tokens: dict[str, str] = {}
+    for role, payload in requests_to_make:
+        try:
+            data = json.dumps(payload).encode()
+            req = urllib.request.Request(
+                f"{mock_jwks_url}/token",
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                body = json.loads(resp.read())
+                tokens[role] = body["access_token"]
+        except (urllib.error.URLError, OSError, KeyError) as exc:
+            logger.warning("Could not fetch JWT for role=%s: %s", role, exc)
+    return tokens
+
+
+def write_env_test(tokens: dict[str, str], env_test_path: Path) -> None:
+    """Write test environment variables to .env.test. Overwrites on each run."""
+    lines: list[str] = [
+        "# Test environment variables — generated by scripts/dev-bootstrap.py",
+        "# Re-run `make bootstrap` (with dev services up) to refresh JWTs",
+        "#",
+        "AWS_REGION=eu-west-2",
+        "LOCALSTACK_ENDPOINT=http://localhost:4566",
+        "MOCK_RUNTIME_URL=http://localhost:8765",
+        "JWKS_URL=http://localhost:8766/.well-known/jwks.json",
+        "API_AUDIENCE=api://platform-local",
+        "API_ISSUER=http://localhost:8766",
+        "",
+    ]
+    if tokens:
+        lines += [
+            f"TEST_JWT_BASIC={tokens.get('basic', '')}",
+            f"TEST_JWT_PREMIUM={tokens.get('premium', '')}",
+            f"TEST_JWT_ADMIN={tokens.get('admin', '')}",
+        ]
+    else:
+        lines += [
+            "# JWTs not available (mock-jwks service was not running)",
+            "TEST_JWT_BASIC=",
+            "TEST_JWT_PREMIUM=",
+            "TEST_JWT_ADMIN=",
+        ]
+    env_test_path.write_text("\n".join(lines) + "\n")
+    logger.info("Written %s", env_test_path)
+
+
+def run_bootstrap(
+    *,
+    localstack_endpoint: str = _DEFAULT_LOCALSTACK_ENDPOINT,
+    mock_jwks_url: str = _DEFAULT_MOCK_JWKS_URL,
+    aws_region: str = _DEFAULT_REGION,
+    env_test_path: Path = _DEFAULT_ENV_TEST_PATH,
+    ddb_client: Any = None,
+    ddb_resource: Any = None,
+    ssm_client: Any = None,
+) -> None:
+    """Run the full dev bootstrap sequence.
+
+    AWS client parameters may be injected for testing (moto-backed clients).
+    When None, real boto3 clients are constructed pointing at localstack_endpoint.
+    """
+    # LocalStack accepts any credential values; read from env for CI compatibility.
+    _ls_key = os.environ.get("AWS_ACCESS_KEY_ID", "test")  # pragma: allowlist secret
+    _ls_secret = os.environ.get("AWS_SECRET_ACCESS_KEY", "test")  # pragma: allowlist secret
+    boto_kwargs: dict[str, Any] = {
+        "region_name": aws_region,
+        "endpoint_url": localstack_endpoint,
+        "aws_access_key_id": _ls_key,
+        "aws_secret_access_key": _ls_secret,
+    }
+    _ddb_client: Any = ddb_client or boto3.client("dynamodb", **boto_kwargs)
+    _ddb_resource: Any = ddb_resource or boto3.resource("dynamodb", **boto_kwargs)
+    _ssm_client: Any = ssm_client or boto3.client("ssm", **boto_kwargs)
+
+    logger.info("==> dev-bootstrap starting (localstack=%s)", localstack_endpoint)
+
+    logger.info("-- Step 1: Ensure DynamoDB tables")
+    ensure_tables(_ddb_client)
+
+    logger.info("-- Step 2: Seed tenants")
+    seed_tenants(_ddb_resource)
+
+    logger.info("-- Step 3: Seed agents")
+    seed_agents(_ddb_resource)
+
+    logger.info("-- Step 4: Seed tools")
+    seed_tools(_ddb_resource)
+
+    logger.info("-- Step 5: Seed SSM parameters")
+    seed_ssm_parameters(
+        _ssm_client,
+        mock_jwks_url=mock_jwks_url,
+        localstack_endpoint=localstack_endpoint,
+    )
+
+    logger.info("-- Step 6: Fetch test JWTs")
+    tokens = fetch_jwts(mock_jwks_url)
+
+    logger.info("-- Step 7: Write .env.test")
+    write_env_test(tokens, env_test_path)
+
+    logger.info("==> dev-bootstrap complete")
+
+
+if __name__ == "__main__":
+    _localstack = os.environ.get("LOCALSTACK_ENDPOINT", _DEFAULT_LOCALSTACK_ENDPOINT)
+    _mock_jwks = os.environ.get("MOCK_JWKS_URL", _DEFAULT_MOCK_JWKS_URL)
+    _region = os.environ.get("AWS_REGION", _DEFAULT_REGION)
+    _env_test = Path(os.environ.get("ENV_TEST_PATH", str(_DEFAULT_ENV_TEST_PATH)))
+    try:
+        run_bootstrap(
+            localstack_endpoint=_localstack,
+            mock_jwks_url=_mock_jwks,
+            aws_region=_region,
+            env_test_path=_env_test,
+        )
+    except Exception:
+        logger.exception("dev-bootstrap failed")
+        sys.exit(1)

--- a/tests/unit/test_dev_bootstrap.py
+++ b/tests/unit/test_dev_bootstrap.py
@@ -1,0 +1,394 @@
+"""
+tests/unit/test_dev_bootstrap.py — Tests for scripts/dev-bootstrap.py
+
+Validates:
+  - All DynamoDB tables are created on first run
+  - Tenant, agent, and tool fixture records are seeded correctly
+  - SSM parameters are seeded correctly
+  - .env.test is written with expected keys and values
+  - Idempotency: running twice produces no duplicate records (same item counts)
+  - JWT fetch failure: bootstrap still completes, .env.test written with empty JWTs
+
+Test requirement (TASK-015): run twice, verify no duplicate records.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import boto3
+from moto import mock_aws
+
+
+def _load_bootstrap_module() -> object:
+    """Load scripts/dev-bootstrap.py as a Python module via importlib."""
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "dev_bootstrap", repo_root / "scripts" / "dev-bootstrap.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+bootstrap = _load_bootstrap_module()
+
+_REGION = "eu-west-2"
+_EXPECTED_TABLE_NAMES = {d["TableName"] for d in bootstrap.TABLE_DEFINITIONS}  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_aws_clients() -> tuple[object, object, object]:
+    """Return moto-backed DynamoDB client, DynamoDB resource, and SSM client."""
+    ddb_client = boto3.client("dynamodb", region_name=_REGION)
+    ddb_resource = boto3.resource("dynamodb", region_name=_REGION)
+    ssm_client = boto3.client("ssm", region_name=_REGION)
+    return ddb_client, ddb_resource, ssm_client
+
+
+def _scan_table(ddb_resource: object, table_name: str) -> list[dict]:
+    """Scan all items from a DynamoDB table and return them."""
+    return ddb_resource.Table(table_name).scan()["Items"]  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Table creation
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_ensure_tables_creates_all_tables() -> None:
+    ddb_client, _, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    tables = set(ddb_client.list_tables()["TableNames"])  # type: ignore[union-attr]
+    assert _EXPECTED_TABLE_NAMES <= tables
+
+
+@mock_aws
+def test_ensure_tables_is_idempotent() -> None:
+    """Calling ensure_tables twice must not raise and must not duplicate tables."""
+    ddb_client, _, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    tables = [t for t in ddb_client.list_tables()["TableNames"] if t.startswith("platform-")]  # type: ignore[union-attr]
+    assert len(tables) == len(bootstrap.TABLE_DEFINITIONS)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Tenant seeding
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_seed_tenants_creates_two_records() -> None:
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_tenants(ddb_resource)  # type: ignore[attr-defined]
+    items = _scan_table(ddb_resource, "platform-tenants")
+    assert len(items) == 2
+
+
+@mock_aws
+def test_seed_tenants_correct_tiers() -> None:
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_tenants(ddb_resource)  # type: ignore[attr-defined]
+    items = {item["tenant_id"]: item for item in _scan_table(ddb_resource, "platform-tenants")}
+    assert items["t-basic-001"]["tier"] == "basic"
+    assert items["t-premium-001"]["tier"] == "premium"
+
+
+@mock_aws
+def test_seed_tenants_both_active() -> None:
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_tenants(ddb_resource)  # type: ignore[attr-defined]
+    items = _scan_table(ddb_resource, "platform-tenants")
+    assert all(item["status"] == "active" for item in items)
+
+
+@mock_aws
+def test_seed_tenants_idempotent_no_duplicates() -> None:
+    """Running seed_tenants twice must not create duplicate records."""
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_tenants(ddb_resource)  # type: ignore[attr-defined]
+    bootstrap.seed_tenants(ddb_resource)  # type: ignore[attr-defined]
+    items = _scan_table(ddb_resource, "platform-tenants")
+    assert len(items) == 2
+
+
+# ---------------------------------------------------------------------------
+# Agent seeding
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_seed_agents_creates_echo_agent() -> None:
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_agents(ddb_resource)  # type: ignore[attr-defined]
+    items = _scan_table(ddb_resource, "platform-agents")
+    assert len(items) == 1
+    assert items[0]["agent_name"] == "echo-agent"
+    assert items[0]["version"] == "1.0.0"
+
+
+@mock_aws
+def test_seed_agents_idempotent_no_duplicates() -> None:
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_agents(ddb_resource)  # type: ignore[attr-defined]
+    bootstrap.seed_agents(ddb_resource)  # type: ignore[attr-defined]
+    items = _scan_table(ddb_resource, "platform-agents")
+    assert len(items) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tool seeding
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_seed_tools_creates_echo_tool() -> None:
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_tools(ddb_resource)  # type: ignore[attr-defined]
+    items = _scan_table(ddb_resource, "platform-tools")
+    assert len(items) == 1
+    assert items[0]["tool_name"] == "echo"
+
+
+@mock_aws
+def test_seed_tools_idempotent_no_duplicates() -> None:
+    ddb_client, ddb_resource, _ = _make_aws_clients()
+    bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
+    bootstrap.seed_tools(ddb_resource)  # type: ignore[attr-defined]
+    bootstrap.seed_tools(ddb_resource)  # type: ignore[attr-defined]
+    items = _scan_table(ddb_resource, "platform-tools")
+    assert len(items) == 1
+
+
+# ---------------------------------------------------------------------------
+# SSM parameter seeding
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_seed_ssm_runtime_region() -> None:
+    _, _, ssm_client = _make_aws_clients()
+    bootstrap.seed_ssm_parameters(  # type: ignore[attr-defined]
+        ssm_client,
+        mock_jwks_url="http://localhost:8766",
+        localstack_endpoint="http://localhost:4566",
+    )
+    resp = ssm_client.get_parameter(Name="/platform/config/runtime-region")  # type: ignore[union-attr]
+    assert resp["Parameter"]["Value"] == "eu-west-1"
+
+
+@mock_aws
+def test_seed_ssm_jwks_url() -> None:
+    _, _, ssm_client = _make_aws_clients()
+    bootstrap.seed_ssm_parameters(  # type: ignore[attr-defined]
+        ssm_client,
+        mock_jwks_url="http://localhost:8766",
+        localstack_endpoint="http://localhost:4566",
+    )
+    resp = ssm_client.get_parameter(Name="/platform/config/jwks-url")  # type: ignore[union-attr]
+    assert resp["Parameter"]["Value"] == "http://localhost:8766/.well-known/jwks.json"
+
+
+@mock_aws
+def test_seed_ssm_api_audience() -> None:
+    _, _, ssm_client = _make_aws_clients()
+    bootstrap.seed_ssm_parameters(  # type: ignore[attr-defined]
+        ssm_client,
+        mock_jwks_url="http://localhost:8766",
+        localstack_endpoint="http://localhost:4566",
+    )
+    resp = ssm_client.get_parameter(Name="/platform/config/api-audience")  # type: ignore[union-attr]
+    assert resp["Parameter"]["Value"] == "api://platform-local"
+
+
+@mock_aws
+def test_seed_ssm_pii_patterns_is_valid_json() -> None:
+    _, _, ssm_client = _make_aws_clients()
+    bootstrap.seed_ssm_parameters(  # type: ignore[attr-defined]
+        ssm_client,
+        mock_jwks_url="http://localhost:8766",
+        localstack_endpoint="http://localhost:4566",
+    )
+    resp = ssm_client.get_parameter(Name="/platform/gateway/pii-patterns/default")  # type: ignore[union-attr]
+    patterns = json.loads(resp["Parameter"]["Value"])
+    assert isinstance(patterns, list)
+    assert len(patterns) > 0
+
+
+@mock_aws
+def test_seed_ssm_idempotent() -> None:
+    """Seeding SSM parameters twice must not raise."""
+    _, _, ssm_client = _make_aws_clients()
+    for _ in range(2):
+        bootstrap.seed_ssm_parameters(  # type: ignore[attr-defined]
+            ssm_client,
+            mock_jwks_url="http://localhost:8766",
+            localstack_endpoint="http://localhost:4566",
+        )
+    resp = ssm_client.get_parameter(Name="/platform/config/env")  # type: ignore[union-attr]
+    assert resp["Parameter"]["Value"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# JWT fetching
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_jwts_returns_empty_when_service_unavailable() -> None:
+    """When mock-jwks is not reachable, fetch_jwts must return an empty dict."""
+    import urllib.error
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        tokens = bootstrap.fetch_jwts("http://127.0.0.1:19997")  # type: ignore[attr-defined]
+    assert tokens == {}
+
+
+def test_fetch_jwts_returns_three_tokens_when_service_available() -> None:
+    """Mock the HTTP call and verify all three roles receive a token."""
+
+    def _make_response() -> MagicMock:
+        resp = MagicMock()
+        resp.read.return_value = json.dumps(
+            {"access_token": "mock-jwt", "token_type": "Bearer", "expires_in": 86400}
+        ).encode()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    with patch("urllib.request.urlopen", side_effect=[_make_response() for _ in range(3)]):
+        tokens = bootstrap.fetch_jwts("http://localhost:8766")  # type: ignore[attr-defined]
+
+    assert set(tokens.keys()) == {"basic", "premium", "admin"}
+    assert all(v == "mock-jwt" for v in tokens.values())
+
+
+# ---------------------------------------------------------------------------
+# .env.test writing
+# ---------------------------------------------------------------------------
+
+
+def test_write_env_test_with_tokens(tmp_path: Path) -> None:
+    env_test_path = tmp_path / ".env.test"
+    tokens = {"basic": "jwt-basic", "premium": "jwt-premium", "admin": "jwt-admin"}
+    bootstrap.write_env_test(tokens, env_test_path)  # type: ignore[attr-defined]
+    content = env_test_path.read_text()
+    assert "TEST_JWT_BASIC=jwt-basic" in content
+    assert "TEST_JWT_PREMIUM=jwt-premium" in content
+    assert "TEST_JWT_ADMIN=jwt-admin" in content
+    assert "AWS_REGION=eu-west-2" in content
+    assert "LOCALSTACK_ENDPOINT=http://localhost:4566" in content
+
+
+def test_write_env_test_without_tokens_writes_empty_values(tmp_path: Path) -> None:
+    env_test_path = tmp_path / ".env.test"
+    bootstrap.write_env_test({}, env_test_path)  # type: ignore[attr-defined]
+    content = env_test_path.read_text()
+    assert "TEST_JWT_BASIC=" in content
+    assert "TEST_JWT_PREMIUM=" in content
+    assert "mock-jwks service was not running" in content
+
+
+def test_write_env_test_is_idempotent(tmp_path: Path) -> None:
+    """Writing .env.test twice must produce stable output (no appending)."""
+    env_test_path = tmp_path / ".env.test"
+    tokens = {"basic": "jwt-b", "premium": "jwt-p", "admin": "jwt-a"}
+    bootstrap.write_env_test(tokens, env_test_path)  # type: ignore[attr-defined]
+    first_content = env_test_path.read_text()
+    bootstrap.write_env_test(tokens, env_test_path)  # type: ignore[attr-defined]
+    second_content = env_test_path.read_text()
+    assert first_content == second_content
+
+
+# ---------------------------------------------------------------------------
+# Full end-to-end idempotency (TASK-015 requirement: run twice, no duplicates)
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_run_bootstrap_full_first_run(tmp_path: Path) -> None:
+    """run_bootstrap produces all expected records on first run."""
+    import urllib.error
+
+    ddb_client = boto3.client("dynamodb", region_name=_REGION)
+    ddb_resource = boto3.resource("dynamodb", region_name=_REGION)
+    ssm_client = boto3.client("ssm", region_name=_REGION)
+    env_test_path = tmp_path / ".env.test"
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        bootstrap.run_bootstrap(  # type: ignore[attr-defined]
+            ddb_client=ddb_client,
+            ddb_resource=ddb_resource,
+            ssm_client=ssm_client,
+            env_test_path=env_test_path,
+        )
+
+    assert len(_scan_table(ddb_resource, "platform-tenants")) == 2
+    assert len(_scan_table(ddb_resource, "platform-agents")) == 1
+    assert len(_scan_table(ddb_resource, "platform-tools")) == 1
+    assert env_test_path.exists()
+
+
+@mock_aws
+def test_run_bootstrap_twice_no_duplicate_records(tmp_path: Path) -> None:
+    """TASK-015 acceptance: run twice, verify no duplicate records in any table."""
+    import urllib.error
+
+    ddb_client = boto3.client("dynamodb", region_name=_REGION)
+    ddb_resource = boto3.resource("dynamodb", region_name=_REGION)
+    ssm_client = boto3.client("ssm", region_name=_REGION)
+    env_test_path = tmp_path / ".env.test"
+
+    run_kwargs = {
+        "ddb_client": ddb_client,
+        "ddb_resource": ddb_resource,
+        "ssm_client": ssm_client,
+        "env_test_path": env_test_path,
+    }
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        bootstrap.run_bootstrap(**run_kwargs)  # type: ignore[attr-defined]
+        counts_after_first = {
+            "tenants": len(_scan_table(ddb_resource, "platform-tenants")),
+            "agents": len(_scan_table(ddb_resource, "platform-agents")),
+            "tools": len(_scan_table(ddb_resource, "platform-tools")),
+        }
+
+        bootstrap.run_bootstrap(**run_kwargs)  # type: ignore[attr-defined]
+        counts_after_second = {
+            "tenants": len(_scan_table(ddb_resource, "platform-tenants")),
+            "agents": len(_scan_table(ddb_resource, "platform-agents")),
+            "tools": len(_scan_table(ddb_resource, "platform-tools")),
+        }
+
+    assert counts_after_second == counts_after_first
+    assert counts_after_second["tenants"] == 2
+    assert counts_after_second["agents"] == 1
+    assert counts_after_second["tools"] == 1


### PR DESCRIPTION
## Summary

- Implements `scripts/dev-bootstrap.py` for the local development loop (TASK-015 / Issue #22)
- Creates all 7 platform DynamoDB tables in LocalStack (idempotent via `create_table`)
- Seeds 2 test tenants (`t-basic-001` basic-tier, `t-premium-001` premium-tier)
- Seeds echo-agent v1.0.0 and echo tool fixtures
- Seeds 9 SSM parameters (`/platform/config/runtime-region`, `/platform/config/jwks-url`, `/platform/config/api-audience`, PII patterns, etc.)
- Fetches test JWTs from mock-jwks service; writes `AWS_REGION`, `LOCALSTACK_ENDPOINT`, and `TEST_JWT_*` vars to `.env.test`
- Graceful JWT fallback: if mock-jwks is unavailable, bootstrap completes and writes empty JWT placeholders

## Idempotency

`put_item` upserts by PK+SK (no duplicates). SSM uses `Overwrite=True`. Tables use `ResourceInUseException` guard. `.env.test` is fully overwritten each run.

## Test plan

- [x] 22 unit tests (moto-backed DynamoDB + SSM, `urllib.request.urlopen` mocked)
- [x] `test_run_bootstrap_twice_no_duplicate_records` — TASK-015 acceptance criterion: run twice, counts stable
- [x] `ruff check` / `ruff format --check` — clean
- [x] `pyright` — 0 errors, 0 warnings
- [x] `detect-secrets` scan — 0 results
- [x] Pre-push hook: all checks passed

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)