### PR TITLE
docs: mark TASK-019 Makefile task complete

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -184,7 +184,7 @@ Nothing in Phase 2 starts until written confirmation.
               Assumes tenant execution role via STS
               ADRs: ADR-005, ADR-009, ADR-010 | Tests: all three modes mocked
 
-[ ] TASK-019  Implement full Makefile
+[x] TASK-019  Implement full Makefile
               All targets from Makefile skeleton now actually work
               make dev, make dev-stop, make test-unit, make test-int
               make validate-local, make bootstrap, make worktree-*


### PR DESCRIPTION
## Summary
- mark `TASK-019` as complete in `docs/TASKS.md`
- close issue #26 as a tracking/completion update (the full `Makefile` implementation is already present on `main`)

## Validation evidence
- `make preflight-session` (session start): PASS
- `make validate-local`: PASS (after installing `infra/cdk` npm dependencies required for local `tsc`)
- `make preflight-session` (before commit): PASS
- `make preflight-session` (before push): PASS
- `make pre-validate-session` (before push): PASS
- `make worktree-push-issue`: PASS (enforced preflight + pre-push validation + push)

## Notes
- Initial `make validate-local` failed due missing local `infra/cdk` npm dependencies (`npx tsc` unavailable). No repo code changes were needed; installing dependencies resolved it.
- Issue reference: #26
