### PR TITLE
TASK-022: implement IdentityStack

### DIFF
--- a/infra/cdk/jest.config.cjs
+++ b/infra/cdk/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/infra/cdk/lib/identity-stack.ts
+++ b/infra/cdk/lib/identity-stack.ts
@@ -9,11 +9,272 @@
  * ADRs: ADR-002
  */
 import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type PipelineRoleKey = 'validate' | 'deployDev' | 'deployStaging' | 'deployProd';
+
+interface PipelineRoleDefinition {
+  readonly id: string;
+  readonly roleName: string;
+  readonly allowedSubPatterns: string[];
+  readonly assumableCdkBootstrapRoles: string[];
+}
 
 export class IdentityStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-    // TODO: Implemented in TASK-022
+
+    const envName = this.requiredContext('env');
+    const gitlabProjectPath = this.optionalContext('gitlabProjectPath') ?? 'j3brns/tf-acore-aas';
+    const gitlabOidcAudience = this.optionalContext('gitlabOidcAudience') ?? 'sts.amazonaws.com';
+    const cdkBootstrapQualifier = this.optionalContext('cdkBootstrapQualifier') ?? 'hnb659fds';
+    const deployBranch = this.optionalContext('gitlabDeployBranch') ?? 'main';
+    const entraJwksUrl = this.resolveEntraJwksUrl();
+
+    const gitlabOidcProvider = new iam.OpenIdConnectProvider(this, 'GitLabOidcProvider', {
+      url: 'https://gitlab.com',
+      clientIds: [gitlabOidcAudience],
+    });
+
+    const cdkBootstrapRoles = {
+      lookup: this.cdkBootstrapRoleArn(cdkBootstrapQualifier, 'lookup'),
+      deploy: this.cdkBootstrapRoleArn(cdkBootstrapQualifier, 'deploy'),
+      filePublishing: this.cdkBootstrapRoleArn(cdkBootstrapQualifier, 'file-publishing'),
+      imagePublishing: this.cdkBootstrapRoleArn(cdkBootstrapQualifier, 'image-publishing'),
+    };
+
+    const pipelineRoleDefinitions: Record<PipelineRoleKey, PipelineRoleDefinition> = {
+      validate: {
+        id: 'PipelineValidateRole',
+        roleName: `platform-pipeline-validate-${envName}`,
+        allowedSubPatterns: [`project_path:${gitlabProjectPath}:*`],
+        assumableCdkBootstrapRoles: [cdkBootstrapRoles.lookup],
+      },
+      deployDev: {
+        id: 'PipelineDeployDevRole',
+        roleName: 'platform-pipeline-deploy-dev',
+        allowedSubPatterns: [
+          `project_path:${gitlabProjectPath}:ref_type:branch:ref:${deployBranch}`,
+        ],
+        assumableCdkBootstrapRoles: [
+          cdkBootstrapRoles.lookup,
+          cdkBootstrapRoles.deploy,
+          cdkBootstrapRoles.filePublishing,
+          cdkBootstrapRoles.imagePublishing,
+        ],
+      },
+      deployStaging: {
+        id: 'PipelineDeployStagingRole',
+        roleName: 'platform-pipeline-deploy-staging',
+        allowedSubPatterns: [
+          `project_path:${gitlabProjectPath}:ref_type:branch:ref:${deployBranch}`,
+        ],
+        assumableCdkBootstrapRoles: [
+          cdkBootstrapRoles.lookup,
+          cdkBootstrapRoles.deploy,
+          cdkBootstrapRoles.filePublishing,
+          cdkBootstrapRoles.imagePublishing,
+        ],
+      },
+      deployProd: {
+        id: 'PipelineDeployProdRole',
+        roleName: 'platform-pipeline-deploy-prod',
+        allowedSubPatterns: [
+          `project_path:${gitlabProjectPath}:ref_type:branch:ref:${deployBranch}`,
+        ],
+        assumableCdkBootstrapRoles: [
+          cdkBootstrapRoles.lookup,
+          cdkBootstrapRoles.deploy,
+          cdkBootstrapRoles.filePublishing,
+          cdkBootstrapRoles.imagePublishing,
+        ],
+      },
+    };
+
+    const pipelineRoles = Object.fromEntries(
+      (Object.entries(pipelineRoleDefinitions) as Array<[PipelineRoleKey, PipelineRoleDefinition]>).map(
+        ([key, definition]) => [
+          key,
+          this.createGitLabPipelineRole({
+            definition,
+            provider: gitlabOidcProvider,
+            audience: gitlabOidcAudience,
+          }),
+        ],
+      ),
+    ) as Record<PipelineRoleKey, iam.Role>;
+
+    const entraJwksLayer = this.createEntraJwksLayer({
+      envName,
+      jwksUrl: entraJwksUrl,
+    });
+
+    const tenantDataKey = this.createPlatformKey({
+      id: 'TenantDataKey',
+      aliasName: `alias/platform-tenant-data-${envName}`,
+      description: `Platform tenant data KMS key (${envName})`,
+    });
+    const platformConfigKey = this.createPlatformKey({
+      id: 'PlatformConfigKey',
+      aliasName: `alias/platform-config-${envName}`,
+      description: `Platform config KMS key (${envName})`,
+    });
+    const logsKey = this.createPlatformKey({
+      id: 'LogsKey',
+      aliasName: `alias/platform-logs-${envName}`,
+      description: `Platform logs KMS key (${envName})`,
+    });
+
+    new cdk.CfnOutput(this, 'GitLabOidcProviderArn', {
+      description: 'IAM OIDC provider ARN for GitLab WIF',
+      value: gitlabOidcProvider.openIdConnectProviderArn,
+    });
+    new cdk.CfnOutput(this, 'PipelineValidateRoleArn', {
+      description: 'GitLab CI validate stage role ARN',
+      value: pipelineRoles.validate.roleArn,
+    });
+    new cdk.CfnOutput(this, 'PipelineDeployDevRoleArn', {
+      description: 'GitLab CI deploy-dev stage role ARN',
+      value: pipelineRoles.deployDev.roleArn,
+    });
+    new cdk.CfnOutput(this, 'PipelineDeployStagingRoleArn', {
+      description: 'GitLab CI deploy-staging stage role ARN',
+      value: pipelineRoles.deployStaging.roleArn,
+    });
+    new cdk.CfnOutput(this, 'PipelineDeployProdRoleArn', {
+      description: 'GitLab CI deploy-prod stage role ARN',
+      value: pipelineRoles.deployProd.roleArn,
+    });
+    new cdk.CfnOutput(this, 'EntraJwksLayerArn', {
+      description: 'Lambda layer ARN containing baked Entra JWKS config',
+      value: entraJwksLayer.layerVersionArn,
+    });
+    new cdk.CfnOutput(this, 'EntraJwksUrl', {
+      description: 'Resolved Entra JWKS URL baked into the Lambda layer',
+      value: entraJwksUrl,
+    });
+    new cdk.CfnOutput(this, 'TenantDataKmsKeyArn', {
+      value: tenantDataKey.keyArn,
+    });
+    new cdk.CfnOutput(this, 'PlatformConfigKmsKeyArn', {
+      value: platformConfigKey.keyArn,
+    });
+    new cdk.CfnOutput(this, 'LogsKmsKeyArn', {
+      value: logsKey.keyArn,
+    });
+  }
+
+  private requiredContext(name: string): string {
+    const value = this.node.tryGetContext(name);
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new Error(`CDK context "${name}" is required`);
+    }
+    return value;
+  }
+
+  private optionalContext(name: string): string | undefined {
+    const value = this.node.tryGetContext(name);
+    if (typeof value !== 'string' || value.trim() === '') {
+      return undefined;
+    }
+    return value;
+  }
+
+  private resolveEntraJwksUrl(): string {
+    const explicitJwksUrl = this.optionalContext('entraJwksUrl');
+    if (explicitJwksUrl) {
+      return explicitJwksUrl;
+    }
+
+    const entraTenantId = this.optionalContext('entraTenantId') ?? 'common';
+    return `https://login.microsoftonline.com/${entraTenantId}/discovery/v2.0/keys`;
+  }
+
+  private cdkBootstrapRoleArn(qualifier: string, roleType: string): string {
+    return `arn:${cdk.Aws.PARTITION}:iam::${cdk.Aws.ACCOUNT_ID}:role/cdk-${qualifier}-${roleType}-role-${cdk.Aws.ACCOUNT_ID}-${cdk.Aws.REGION}`;
+  }
+
+  private createGitLabPipelineRole(args: {
+    definition: PipelineRoleDefinition;
+    provider: iam.OpenIdConnectProvider;
+    audience: string;
+  }): iam.Role {
+    const { definition, provider, audience } = args;
+
+    const assumedBy = new iam.OpenIdConnectPrincipal(provider).withConditions({
+      StringEquals: {
+        'gitlab.com:aud': audience,
+      },
+      StringLike: {
+        'gitlab.com:sub': definition.allowedSubPatterns,
+      },
+    });
+
+    const role = new iam.Role(this, definition.id, {
+      roleName: definition.roleName,
+      description: `GitLab CI pipeline role for ${definition.roleName}`,
+      assumedBy,
+      inlinePolicies: {
+        AssumeCdkBootstrapRoles: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              sid: 'AssumeCdkBootstrapRoles',
+              effect: iam.Effect.ALLOW,
+              actions: ['sts:AssumeRole'],
+              resources: definition.assumableCdkBootstrapRoles,
+            }),
+          ],
+        }),
+      },
+    });
+
+    return role;
+  }
+
+  private createEntraJwksLayer(args: { envName: string; jwksUrl: string }): lambda.LayerVersion {
+    const { envName, jwksUrl } = args;
+    const assetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'platform-entra-jwks-layer-'));
+    const pythonDir = path.join(assetDir, 'python');
+    fs.mkdirSync(pythonDir, { recursive: true });
+
+    const moduleSource = [
+      '"""Generated by IdentityStack (TASK-022)."""',
+      `JWKS_URL = ${JSON.stringify(jwksUrl)}`,
+      '',
+      'def get_jwks_url() -> str:',
+      '    return JWKS_URL',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(pythonDir, 'platform_entra_jwks_config.py'), moduleSource, 'utf8');
+
+    return new lambda.LayerVersion(this, 'EntraJwksConfigLayer', {
+      layerVersionName: `platform-entra-jwks-${envName}`,
+      description: `Entra JWKS config layer (${envName})`,
+      code: lambda.Code.fromAsset(assetDir),
+      compatibleRuntimes: [lambda.Runtime.PYTHON_3_12],
+    });
+  }
+
+  private createPlatformKey(args: { id: string; aliasName: string; description: string }): kms.Key {
+    const key = new kms.Key(this, args.id, {
+      description: args.description,
+      enableKeyRotation: true,
+      pendingWindow: cdk.Duration.days(30),
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    new kms.Alias(this, `${args.id}Alias`, {
+      aliasName: args.aliasName,
+      targetKey: key,
+    });
+
+    return key;
   }
 }

--- a/infra/cdk/test/identity-stack.test.ts
+++ b/infra/cdk/test/identity-stack.test.ts
@@ -1,0 +1,145 @@
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { IdentityStack } from '../lib/identity-stack';
+
+function synthTemplate(): Template {
+  const app = new cdk.App({
+    context: {
+      env: 'dev',
+      gitlabProjectPath: 'j3brns/tf-acore-aas',
+      entraTenantId: '00000000-0000-0000-0000-000000000000',
+    },
+  });
+
+  const stack = new IdentityStack(app, 'platform-identity-dev');
+  return Template.fromStack(stack);
+}
+
+describe('IdentityStack', () => {
+  let template: Template;
+
+  beforeAll(() => {
+    template = synthTemplate();
+  });
+
+  test('creates GitLab OIDC provider with sts audience', () => {
+    template.resourceCountIs('Custom::AWSCDKOpenIdConnectProvider', 1);
+    template.hasResourceProperties('Custom::AWSCDKOpenIdConnectProvider', {
+      Url: 'https://gitlab.com',
+      ClientIDList: ['sts.amazonaws.com'],
+    });
+  });
+
+  test('creates four pipeline roles with GitLab OIDC trust conditions', () => {
+    const roleResources = Object.values(template.findResources('AWS::IAM::Role'));
+    const pipelineRoles = roleResources.filter((resource) => {
+      const roleName = resource.Properties?.RoleName;
+      return typeof roleName === 'string' && roleName.startsWith('platform-pipeline-');
+    });
+    expect(pipelineRoles).toHaveLength(4);
+
+    template.hasResourceProperties('AWS::IAM::Role', {
+      RoleName: 'platform-pipeline-validate-dev',
+      AssumeRolePolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'sts:AssumeRoleWithWebIdentity',
+            Condition: Match.objectLike({
+              StringEquals: Match.objectLike({
+                'gitlab.com:aud': 'sts.amazonaws.com',
+              }),
+              StringLike: Match.objectLike({
+                'gitlab.com:sub': ['project_path:j3brns/tf-acore-aas:*'],
+              }),
+            }),
+          }),
+        ]),
+      }),
+    });
+
+    for (const roleName of [
+      'platform-pipeline-deploy-dev',
+      'platform-pipeline-deploy-staging',
+      'platform-pipeline-deploy-prod',
+    ]) {
+      template.hasResourceProperties('AWS::IAM::Role', {
+        RoleName: roleName,
+        AssumeRolePolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Condition: Match.objectLike({
+                StringLike: Match.objectLike({
+                  'gitlab.com:sub': [
+                    'project_path:j3brns/tf-acore-aas:ref_type:branch:ref:main',
+                  ],
+                }),
+              }),
+            }),
+          ]),
+        }),
+        Policies: Match.arrayWith([
+          Match.objectLike({
+            PolicyDocument: Match.objectLike({
+              Statement: Match.arrayWith([
+                Match.objectLike({
+                  Action: 'sts:AssumeRole',
+                }),
+              ]),
+            }),
+          }),
+        ]),
+      });
+    }
+  });
+
+  test('creates Entra JWKS layer and exposes resolved JWKS URL output', () => {
+    template.resourceCountIs('AWS::Lambda::LayerVersion', 1);
+    template.hasResourceProperties('AWS::Lambda::LayerVersion', {
+      LayerName: 'platform-entra-jwks-dev',
+      Description: 'Entra JWKS config layer (dev)',
+      CompatibleRuntimes: ['python3.12'],
+    });
+
+    template.hasOutput('EntraJwksUrl', {
+      Value:
+        'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys',
+    });
+  });
+
+  test('creates three KMS keys and key policies do not use wildcard principals', () => {
+    template.resourceCountIs('AWS::KMS::Key', 3);
+    template.resourceCountIs('AWS::KMS::Alias', 3);
+    template.hasResourceProperties('AWS::KMS::Alias', {
+      AliasName: 'alias/platform-tenant-data-dev',
+    });
+    template.hasResourceProperties('AWS::KMS::Alias', {
+      AliasName: 'alias/platform-config-dev',
+    });
+    template.hasResourceProperties('AWS::KMS::Alias', {
+      AliasName: 'alias/platform-logs-dev',
+    });
+
+    const keys = template.findResources('AWS::KMS::Key');
+    for (const resource of Object.values(keys)) {
+      const statements = (resource.Properties?.KeyPolicy?.Statement ?? []) as Array<{
+        Principal?: unknown;
+      }>;
+
+      for (const statement of statements) {
+        const principal = statement.Principal;
+        expect(principal).not.toBe('*');
+
+        if (!principal || typeof principal !== 'object') {
+          continue;
+        }
+
+        const awsPrincipal = (principal as Record<string, unknown>)['AWS'];
+        if (Array.isArray(awsPrincipal)) {
+          expect(awsPrincipal).not.toContain('*');
+        } else {
+          expect(awsPrincipal).not.toBe('*');
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #29

## Summary
- implement `IdentityStack` resources for GitLab OIDC WIF, pipeline roles, Entra JWKS config layer, and KMS keys
- add CDK Jest construct tests for OIDC trust, pipeline role policies, JWKS layer output, and KMS key policy principals
- add `infra/cdk` Jest config for TypeScript CDK tests

## Validation Evidence
- `make preflight-session` (initial): PASS
- `make validate-cdk-synth`: PASS
- `make validate-local`: PASS
- `cd infra/cdk && npx --no-install jest --config jest.config.cjs --runInBand`: PASS (4 tests)
- `make preflight-session` (before commit): PASS
- `make preflight-session` (before push): PASS
- `make pre-validate-session` (before push): PASS
- `make worktree-push-issue`: PASS (includes helper pre-validation + pre-push hook validation + push)

## Notes
- GitLab OIDC trust defaults to project `j3brns/tf-acore-aas` and `main` deploy branch, with CDK context overrides available (`gitlabProjectPath`, `gitlabDeployBranch`, `gitlabOidcAudience`, `entraJwksUrl`, `entraTenantId`, `cdkBootstrapQualifier`).