### PR TITLE
TASK-023: Implement PlatformStack

### DIFF
--- a/infra/cdk/jest.config.js
+++ b/infra/cdk/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -1,0 +1,120 @@
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { PlatformStack } from '../lib/platform-stack';
+
+describe('PlatformStack (TASK-023)', () => {
+  const synthTemplate = () => {
+    const app = new cdk.App();
+    const stack = new PlatformStack(app, 'platform-core-dev', {
+      env: { region: 'eu-west-2' },
+    });
+    return Template.fromStack(stack);
+  };
+  const template = synthTemplate();
+
+  test('creates REST API with authorizer-backed API key source and usage plans', () => {
+    template.hasResourceProperties('AWS::ApiGateway::RestApi', {
+      ApiKeySourceType: 'AUTHORIZER', // pragma: allowlist secret
+    });
+
+    template.resourceCountIs('AWS::ApiGateway::UsagePlan', 3);
+
+    template.hasResourceProperties('AWS::Lambda::Alias', {
+      Name: 'live',
+      ProvisionedConcurrencyConfig: {
+        ProvisionedConcurrentExecutions: 10,
+      },
+    });
+  });
+
+  test('creates WAF WebACL with managed rules, UK rate limit, and API association', () => {
+    template.hasResourceProperties('AWS::WAFv2::WebACL', {
+      Scope: 'REGIONAL',
+      Rules: Match.arrayWith([
+        Match.objectLike({
+          Name: 'AWSManagedRulesCommonRuleSet',
+          Statement: Match.objectLike({
+            ManagedRuleGroupStatement: {
+              VendorName: 'AWS',
+              Name: 'AWSManagedRulesCommonRuleSet',
+            },
+          }),
+        }),
+        Match.objectLike({
+          Name: 'UkIpRateLimit',
+          Statement: Match.objectLike({
+            RateBasedStatement: Match.objectLike({
+              AggregateKeyType: 'IP',
+              ScopeDownStatement: Match.objectLike({
+                GeoMatchStatement: {
+                  CountryCodes: ['GB'],
+                },
+              }),
+            }),
+          }),
+        }),
+        Match.objectLike({
+          Name: 'BlockSqlmapUserAgent',
+        }),
+      ]),
+    });
+
+    template.resourceCountIs('AWS::WAFv2::WebACLAssociation', 1);
+  });
+
+  test('creates CloudFront distribution with OAC and CSP response headers policy', () => {
+    template.resourceCountIs('AWS::CloudFront::OriginAccessControl', 1);
+
+    template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: Match.objectLike({
+        CustomHeadersConfig: Match.objectLike({
+          Items: Match.arrayWith([
+            Match.objectLike({
+              Header: 'Content-Security-Policy',
+              Override: true,
+            }),
+          ]),
+        }),
+      }),
+    });
+
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        Origins: Match.arrayWith([
+          Match.objectLike({
+            OriginAccessControlId: Match.anyValue(),
+          }),
+        ]),
+        DefaultCacheBehavior: Match.objectLike({
+          ResponseHeadersPolicyId: Match.anyValue(),
+        }),
+      }),
+    });
+  });
+
+  test('creates AgentCore Gateway with request and response interceptor wiring', () => {
+    template.hasResourceProperties('AWS::BedrockAgentCore::Gateway', {
+      AuthorizerType: 'AWS_IAM',
+      ProtocolType: 'MCP',
+      InterceptorConfigurations: Match.arrayWith([
+        Match.objectLike({
+          InterceptionPoints: ['REQUEST'],
+          InputConfiguration: {
+            PassRequestHeaders: true,
+          },
+          Interceptor: Match.objectLike({
+            Lambda: Match.objectLike({
+              Arn: Match.anyValue(),
+            }),
+          }),
+        }),
+        Match.objectLike({
+          InterceptionPoints: ['RESPONSE'],
+          InputConfiguration: {
+            PassRequestHeaders: true,
+          },
+        }),
+      ]),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `PlatformStack` for TASK-023 / issue #30 with REST API Gateway (REST, usage plans, per-method throttles), WAF WebACL + API association, CloudFront + S3 OAC + CSP response headers policy
- add bridge/bff/authoriser Lambdas (authoriser alias with provisioned concurrency = 10) and AgentCore Gateway CFN resource wired to REQUEST/RESPONSE interceptor Lambdas
- add CDK Jest construct tests and `ts-jest` config covering the issue acceptance criteria

Closes #30

## Validation Evidence
- `cd infra/cdk && npx tsc --noEmit` ✅
- `cd infra/cdk && npm test -- --runTestsByPath test/platform-stack.test.ts` ✅ (4 tests passed)
- `cd infra/cdk && npx cdk synth --context env=dev --quiet` ✅
- `make preflight-session` ✅ PASS (branch `wt/infra/30-platformstack`)
- `make pre-validate-session` ✅ PASS (ruff, pyright, tsc, detect-secrets scan)
- `make worktree-push-issue` ✅ PASS (enforced validation + push)
