### PR TITLE
TASK-024: AgentCoreStack

### DIFF
--- a/infra/cdk/bin/app.ts
+++ b/infra/cdk/bin/app.ts
@@ -30,10 +30,15 @@ if (!env) {
 // eu-west-2 is the platform home region (see ARCHITECTURE.md, ADR-009).
 // This is an architectural constant, not runtime configuration.
 const HOME_REGION = 'eu-west-2';
+const RUNTIME_REGION = 'eu-west-1';
 
 const awsEnv: cdk.Environment = {
   account: process.env['CDK_DEFAULT_ACCOUNT'],
   region: HOME_REGION,
+};
+const runtimeEnv: cdk.Environment = {
+  account: process.env['CDK_DEFAULT_ACCOUNT'],
+  region: RUNTIME_REGION,
 };
 
 // 1. NetworkStack
@@ -68,6 +73,7 @@ new ObservabilityStack(app, `platform-observability-${env}`, {
 
 // 6. AgentCoreStack (cross-region: deploys config for eu-west-1 Runtime)
 new AgentCoreStack(app, `platform-agentcore-${env}`, {
-  env: awsEnv,
-  description: `Platform AgentCore configuration — ${env}`,
+  env: runtimeEnv,
+  description: `Platform AgentCore configuration (${RUNTIME_REGION}) — ${env}`,
+  homeRegion: HOME_REGION,
 });

--- a/infra/cdk/lib/agentcore-stack.ts
+++ b/infra/cdk/lib/agentcore-stack.ts
@@ -10,11 +10,213 @@
  * ADRs: ADR-001, ADR-009
  */
 import * as cdk from 'aws-cdk-lib';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
+export interface AgentCoreStackProps extends cdk.StackProps {
+  readonly homeRegion: string;
+}
+
 export class AgentCoreStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props: AgentCoreStackProps) {
     super(scope, id, props);
-    // TODO: Implemented in TASK-024
+
+    const envName = this.requiredContext('env');
+    const entraTenantId = this.optionalContext('entraTenantId') ?? 'common';
+    const entraAudience = this.optionalContext('entraAudience') ?? 'platform-api';
+    const runtimeRegion = cdk.Stack.of(this).region;
+
+    if (!cdk.Token.isUnresolved(runtimeRegion) && runtimeRegion !== 'eu-west-1') {
+      throw new Error('AgentCoreStack must be deployed in eu-west-1');
+    }
+
+    const runtimeExecutionRoleArn = new cdk.CfnParameter(this, 'RuntimeExecutionRoleArn', {
+      type: 'String',
+      description: 'IAM role ARN used by AWS::BedrockAgentCore::Runtime',
+    });
+    const runtimeArtifactBucketName = new cdk.CfnParameter(this, 'RuntimeArtifactBucketName', {
+      type: 'String',
+      description: 'S3 bucket containing zipped AgentCore runtime artifacts',
+    });
+    const runtimeArtifactPrefix = new cdk.CfnParameter(this, 'RuntimeArtifactPrefix', {
+      type: 'String',
+      description: 'S3 key prefix for the runtime artifact object',
+    });
+    const metricStreamFirehoseArn = new cdk.CfnParameter(this, 'AgentCoreMetricStreamFirehoseArn', {
+      type: 'String',
+      description:
+        'Firehose delivery stream ARN in eu-west-1 that forwards AgentCore metrics to eu-west-2 observability sinks',
+    });
+    const metricStreamRoleArn = new cdk.CfnParameter(this, 'AgentCoreMetricStreamRoleArn', {
+      type: 'String',
+      description:
+        'IAM role ARN assumed by CloudWatch metric streams for firehose:PutRecord and firehose:PutRecordBatch',
+    });
+
+    const runtimeName = this.runtimeName(envName);
+    const runtimeEndpointName = this.runtimeEndpointName(envName);
+    const entraJwksUrl = this.resolveEntraJwksUrl(entraTenantId);
+
+    const runtime = new cdk.CfnResource(this, 'AgentCoreRuntime', {
+      type: 'AWS::BedrockAgentCore::Runtime',
+      properties: {
+        AgentRuntimeName: runtimeName,
+        Description: `Primary AgentCore runtime for ${envName} (${runtimeRegion})`,
+        RoleArn: runtimeExecutionRoleArn.valueAsString,
+        AgentRuntimeArtifact: {
+          CodeConfiguration: {
+            Runtime: 'PYTHON_3_12',
+            EntryPoint: ['handler.py'],
+            Code: {
+              S3: {
+                Bucket: runtimeArtifactBucketName.valueAsString,
+                Prefix: runtimeArtifactPrefix.valueAsString,
+              },
+            },
+          },
+        },
+        NetworkConfiguration: {
+          NetworkMode: 'PUBLIC',
+        },
+        ProtocolConfiguration: 'HTTP',
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: this.resolveEntraDiscoveryUrl(entraTenantId),
+            AllowedAudience: [entraAudience],
+          },
+        },
+        RequestHeaderConfiguration: {
+          RequestHeaderAllowlist: ['authorization', 'x-tenant-id', 'x-app-id'],
+        },
+        EnvironmentVariables: {
+          HOME_REGION: props.homeRegion,
+          RUNTIME_REGION: runtimeRegion,
+        },
+        Tags: {
+          component: 'agentcore-runtime',
+          environment: envName,
+          homeRegion: props.homeRegion,
+        },
+      },
+    });
+
+    const runtimeEndpoint = new cdk.CfnResource(this, 'AgentCoreRuntimeEndpoint', {
+      type: 'AWS::BedrockAgentCore::RuntimeEndpoint',
+      properties: {
+        Name: runtimeEndpointName,
+        Description: `Live endpoint for ${runtimeName}`,
+        AgentRuntimeId: runtime.getAtt('AgentRuntimeId').toString(),
+        AgentRuntimeVersion: runtime.getAtt('AgentRuntimeVersion').toString(),
+        Tags: {
+          component: 'agentcore-runtime-endpoint',
+          environment: envName,
+        },
+      },
+    });
+    runtimeEndpoint.addDependency(runtime);
+
+    const memoryTemplateParameter = new ssm.StringParameter(this, 'TenantMemoryTemplateParameter', {
+      parameterName: '/platform/agentcore/memory/template/default',
+      description:
+        'Template used by TenantStack when provisioning per-tenant AWS::BedrockAgentCore::Memory resources',
+      stringValue: JSON.stringify({
+        provisionedBy: 'TenantStack',
+        eventExpiryDurationDays: 90,
+        strategy: 'SEMANTIC',
+        namespaceTemplate: 'tenant/{tenantId}',
+        descriptionTemplate: 'Per-tenant AgentCore memory',
+      }),
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'EntraJwksUrlParameter', {
+      parameterName: '/platform/auth/jwks-url',
+      description: 'Entra JWKS URL consumed by platform identity and runtime integrations',
+      stringValue: entraJwksUrl,
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    const metricStream = new cdk.CfnResource(this, 'AgentCoreMetricStream', {
+      type: 'AWS::CloudWatch::MetricStream',
+      properties: {
+        Name: `${this.stackName}-agentcore-metrics`,
+        OutputFormat: 'json',
+        FirehoseArn: metricStreamFirehoseArn.valueAsString,
+        RoleArn: metricStreamRoleArn.valueAsString,
+        IncludeFilters: [
+          {
+            Namespace: 'AWS/BedrockAgentCore',
+          },
+        ],
+        Tags: [
+          {
+            Key: 'component',
+            Value: 'agentcore-observability',
+          },
+          {
+            Key: 'source-region',
+            Value: runtimeRegion,
+          },
+          {
+            Key: 'destination-region',
+            Value: props.homeRegion,
+          },
+        ],
+      },
+    });
+
+    new cdk.CfnOutput(this, 'AgentCoreRuntimeRegion', {
+      value: runtimeRegion,
+      description: 'Runtime compute region for AgentCore execution',
+    });
+    new cdk.CfnOutput(this, 'AgentCoreRuntimeName', {
+      value: runtimeName,
+    });
+    new cdk.CfnOutput(this, 'AgentCoreRuntimeEndpointName', {
+      value: runtimeEndpointName,
+    });
+    new cdk.CfnOutput(this, 'TenantMemoryTemplateParameterName', {
+      value: memoryTemplateParameter.parameterName,
+    });
+    new cdk.CfnOutput(this, 'AgentCoreMetricStreamName', {
+      value: metricStream.ref,
+    });
+    new cdk.CfnOutput(this, 'EntraJwksUrl', {
+      value: entraJwksUrl,
+    });
+  }
+
+  private requiredContext(name: string): string {
+    const value = this.node.tryGetContext(name);
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new Error(`CDK context "${name}" is required`);
+    }
+    return value;
+  }
+
+  private optionalContext(name: string): string | undefined {
+    const value = this.node.tryGetContext(name);
+    if (typeof value !== 'string' || value.trim() === '') {
+      return undefined;
+    }
+    return value;
+  }
+
+  private resolveEntraJwksUrl(entraTenantId: string): string {
+    return `https://login.microsoftonline.com/${entraTenantId}/discovery/v2.0/keys`;
+  }
+
+  private resolveEntraDiscoveryUrl(entraTenantId: string): string {
+    return `https://login.microsoftonline.com/${entraTenantId}/v2.0/.well-known/openid-configuration`;
+  }
+
+  private runtimeName(envName: string): string {
+    const clean = envName.replace(/[^a-zA-Z0-9]/g, '');
+    return `Platform${clean}Runtime`;
+  }
+
+  private runtimeEndpointName(envName: string): string {
+    const clean = envName.replace(/[^a-zA-Z0-9]/g, '');
+    return `Platform${clean}Endpoint`;
   }
 }

--- a/infra/cdk/test/agentcore-stack.test.ts
+++ b/infra/cdk/test/agentcore-stack.test.ts
@@ -1,0 +1,95 @@
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { AgentCoreStack } from '../lib/agentcore-stack';
+
+describe('AgentCoreStack (TASK-024)', () => {
+  const synthTemplate = () => {
+    const app = new cdk.App({
+      context: {
+        env: 'dev',
+        entraTenantId: '00000000-0000-0000-0000-000000000000',
+        entraAudience: 'api://platform-dev',
+      },
+    });
+
+    const stack = new AgentCoreStack(app, 'platform-agentcore-dev', {
+      env: { region: 'eu-west-1' },
+      homeRegion: 'eu-west-2',
+    });
+
+    return Template.fromStack(stack);
+  };
+
+  const template = synthTemplate();
+
+  test('creates runtime and endpoint with Entra JWT authorizer wiring', () => {
+    template.resourceCountIs('AWS::BedrockAgentCore::Runtime', 1);
+    template.resourceCountIs('AWS::BedrockAgentCore::RuntimeEndpoint', 1);
+
+    template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
+      AgentRuntimeName: 'PlatformdevRuntime',
+      NetworkConfiguration: {
+        NetworkMode: 'PUBLIC',
+      },
+      ProtocolConfiguration: 'HTTP',
+      AuthorizerConfiguration: {
+        CustomJWTAuthorizer: {
+          DiscoveryUrl:
+            'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration',
+          AllowedAudience: ['api://platform-dev'],
+        },
+      },
+      RequestHeaderConfiguration: {
+        RequestHeaderAllowlist: ['authorization', 'x-tenant-id', 'x-app-id'],
+      },
+    });
+  });
+
+  test('creates SSM parameters for memory template and Entra JWKS URL', () => {
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/platform/agentcore/memory/template/default',
+      Type: 'String',
+      Value: Match.serializedJson(
+        Match.objectLike({
+          provisionedBy: 'TenantStack',
+          eventExpiryDurationDays: 90,
+          strategy: 'SEMANTIC',
+        }),
+      ),
+    });
+
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/platform/auth/jwks-url',
+      Type: 'String',
+      Value: 'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys',
+    });
+  });
+
+  test('creates AgentCore metric stream scoped to AgentCore namespace', () => {
+    template.resourceCountIs('AWS::CloudWatch::MetricStream', 1);
+    template.hasResourceProperties('AWS::CloudWatch::MetricStream', {
+      OutputFormat: 'json',
+      IncludeFilters: [
+        {
+          Namespace: 'AWS/BedrockAgentCore',
+        },
+      ],
+      FirehoseArn: {
+        Ref: 'AgentCoreMetricStreamFirehoseArn',
+      },
+      RoleArn: {
+        Ref: 'AgentCoreMetricStreamRoleArn',
+      },
+    });
+  });
+
+  test('exports runtime region and memory template parameter name', () => {
+    template.hasOutput('AgentCoreRuntimeRegion', {
+      Value: 'eu-west-1',
+    });
+
+    template.hasOutput('TenantMemoryTemplateParameterName', {
+      Value: Match.anyValue(),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `AgentCoreStack` with AgentCore runtime + runtime endpoint resources
- wire runtime auth to Entra discovery/audience and publish JWKS + memory-template SSM parameters
- add AgentCore CloudWatch metric stream resource for eu-west-1 observability forwarding
- deploy AgentCoreStack in `eu-west-1` from `bin/app.ts` while retaining `eu-west-2` as home region
- add Jest construct tests for TASK-024 acceptance criteria

## Validation Evidence
- `make validate-local` ✅
- `make preflight-session` ✅ (run before commit and again before push)
- `make pre-validate-session` ✅ (run before push)
- `cd infra/cdk && npx --no-install jest --config jest.config.cjs --runInBand` ✅ (4 suites, 15 tests)
- `cd infra/cdk && npx --no-install jest --config jest.config.cjs --runInBand test/agentcore-stack.test.ts` ✅ (4 tests)

Closes #31
