### PR TITLE
TASK-034: implement scripts/build_layer.py

### DIFF
--- a/scripts/build_layer.py
+++ b/scripts/build_layer.py
@@ -19,3 +19,264 @@ Usage:
 Implemented in TASK-034.
 ADRs: ADR-006
 """
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+import tomllib
+import zipfile
+from pathlib import Path
+
+import boto3
+
+logger = logging.getLogger("build_layer")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_DIR = REPO_ROOT / ".build"
+HASH_LENGTH = 16
+PYTHON_PLATFORM = "aarch64-manylinux2014"
+PYTHON_VERSION = "3.12"
+ARM64_TOKENS = ("aarch64", "arm64")
+FORBIDDEN_ARCH_TOKENS = ("x86_64", "amd64", "i686")
+BINARY_SUFFIXES = (".so", ".pyd", ".dylib")
+BUCKET_PARAM_CANDIDATES = (
+    "/platform/core/{env}/agent-artifacts-bucket",
+    "/platform/core/{env}/runtime-artifact-bucket",
+    "/platform/core/{env}/artifacts-bucket",
+)
+
+
+def require_aws_region() -> str:
+    """Read AWS_REGION from environment and fail fast if missing."""
+    region = os.environ.get("AWS_REGION", "").strip()
+    if not region:
+        raise RuntimeError("AWS_REGION must be set")
+    return region
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Build and upload arm64 dependency layer for an agent"
+    )
+    parser.add_argument(
+        "agent_name",
+        help="Agent name (must match agents/<agent_name>/pyproject.toml)",
+    )
+    parser.add_argument(
+        "--env",
+        required=True,
+        choices=["dev", "staging", "prod"],
+        help="Target environment",
+    )
+    return parser.parse_args(argv)
+
+
+def read_agent_deps(agent_name: str) -> list[str]:
+    """Read [project.dependencies] from agents/{agent_name}/pyproject.toml."""
+    toml_path = REPO_ROOT / "agents" / agent_name / "pyproject.toml"
+    if not toml_path.exists():
+        raise FileNotFoundError(f"pyproject.toml not found: {toml_path}")
+
+    with toml_path.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    deps = data.get("project", {}).get("dependencies", [])
+    if not isinstance(deps, list):
+        raise ValueError(f"[project.dependencies] must be a list in {toml_path}")
+    return [str(dep) for dep in deps]
+
+
+def compute_dependency_hash(deps: list[str]) -> str:
+    """Return canonical dependency hash used for S3 key and SSM metadata."""
+    canonical = "\n".join(sorted(dep.strip() for dep in deps))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:HASH_LENGTH]
+
+
+def build_dependencies(dependencies: list[str], target_dir: Path) -> None:
+    """Cross-compile dependencies for arm64 using uv."""
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    command = [
+        "uv",
+        "pip",
+        "install",
+        "--python-platform",
+        PYTHON_PLATFORM,
+        "--python-version",
+        PYTHON_VERSION,
+        "--target",
+        str(target_dir),
+        "--only-binary=:all:",
+        *dependencies,
+    ]
+    logger.info("Building arm64 dependencies for %d packages", len(dependencies))
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def _extract_wheel_tags(wheel_text: str) -> list[str]:
+    tags: list[str] = []
+    for line in wheel_text.splitlines():
+        line = line.strip()
+        if line.startswith("Tag:"):
+            tags.append(line.split(":", 1)[1].strip())
+    return tags
+
+
+def _validate_wheel_tags(tags: list[str], source: str) -> None:
+    for tag in tags:
+        tag_lower = tag.lower()
+        if any(token in tag_lower for token in FORBIDDEN_ARCH_TOKENS):
+            raise RuntimeError(f"Non-arm64 wheel tag detected in {source}: {tag}")
+        is_linux_tag = "linux" in tag_lower or "manylinux" in tag_lower
+        is_pure_python = "any" in tag_lower
+        if (
+            is_linux_tag
+            and not is_pure_python
+            and not any(token in tag_lower for token in ARM64_TOKENS)
+        ):
+            raise RuntimeError(f"Wheel tag is not arm64 in {source}: {tag}")
+
+
+def verify_arm64_artifacts(deps_dir: Path) -> None:
+    """Verify built artifacts do not include x86 wheel tags or binary names."""
+    for wheel_file in sorted(deps_dir.rglob("*.dist-info/WHEEL")):
+        tags = _extract_wheel_tags(wheel_file.read_text(encoding="utf-8", errors="replace"))
+        _validate_wheel_tags(tags, str(wheel_file))
+
+    for binary_file in sorted(deps_dir.rglob("*")):
+        if not binary_file.is_file() or binary_file.suffix.lower() not in BINARY_SUFFIXES:
+            continue
+        name = binary_file.name.lower()
+        if any(token in name for token in FORBIDDEN_ARCH_TOKENS):
+            raise RuntimeError(f"Non-arm64 binary detected: {binary_file}")
+
+
+def create_layer_zip(deps_dir: Path, zip_path: Path) -> None:
+    """Zip dependency directory contents into zip_path."""
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    if zip_path.exists():
+        zip_path.unlink()
+
+    with zipfile.ZipFile(zip_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for item in sorted(deps_dir.rglob("*")):
+            if item.is_file():
+                archive.write(item, arcname=item.relative_to(deps_dir).as_posix())
+
+
+def verify_arm64_zip(zip_path: Path) -> None:
+    """Verify the packaged zip does not contain x86 artifacts."""
+    with zipfile.ZipFile(zip_path, mode="r") as archive:
+        for info in archive.infolist():
+            if info.is_dir():
+                continue
+            filename = info.filename
+            lower_name = Path(filename).name.lower()
+            if filename.endswith(".dist-info/WHEEL"):
+                text = archive.read(info).decode("utf-8", errors="replace")
+                tags = _extract_wheel_tags(text)
+                _validate_wheel_tags(tags, filename)
+            if lower_name.endswith(BINARY_SUFFIXES) and any(
+                token in lower_name for token in FORBIDDEN_ARCH_TOKENS
+            ):
+                raise RuntimeError(f"Non-arm64 binary in zip: {filename}")
+
+
+def resolve_layer_bucket(env: str, aws_region: str) -> str:
+    """Resolve layer artifact bucket from env var first, then SSM parameter."""
+    for env_var in ("PLATFORM_LAYER_BUCKET", "AGENT_LAYER_BUCKET", "LAYER_ARTIFACT_BUCKET"):
+        value = os.environ.get(env_var, "").strip()
+        if value:
+            return value
+
+    ssm = boto3.client("ssm", region_name=aws_region)
+    names = [template.format(env=env) for template in BUCKET_PARAM_CANDIDATES]
+    response = ssm.get_parameters(Names=names)
+    by_name: dict[str, str] = {}
+    for item in response.get("Parameters", []):
+        name = item.get("Name")
+        value = item.get("Value")
+        if not name or not value:
+            continue
+        by_name[str(name)] = str(value)
+    for name in names:
+        value = by_name.get(name, "").strip()
+        if value:
+            return value
+
+    joined = ", ".join(names)
+    raise RuntimeError(
+        "Layer artifact bucket not configured. "
+        f"Set PLATFORM_LAYER_BUCKET or one of SSM params: {joined}"
+    )
+
+
+def upload_layer_zip(zip_path: Path, *, bucket: str, key: str, aws_region: str) -> None:
+    """Upload layer zip to S3."""
+    s3 = boto3.client("s3", region_name=aws_region)
+    s3.upload_file(str(zip_path), bucket, key)
+
+
+def put_layer_metadata(agent_name: str, dep_hash: str, key: str, aws_region: str) -> None:
+    """Write hash and S3 key metadata to SSM."""
+    ssm = boto3.client("ssm", region_name=aws_region)
+    ssm.put_parameter(
+        Name=f"/platform/layers/{agent_name}/hash",
+        Value=dep_hash,
+        Type="String",
+        Overwrite=True,
+    )
+    ssm.put_parameter(
+        Name=f"/platform/layers/{agent_name}/s3-key",
+        Value=key,
+        Type="String",
+        Overwrite=True,
+    )
+
+
+def run(agent_name: str, env: str) -> int:
+    """Run dependency layer build and publish flow."""
+    aws_region = require_aws_region()
+    deps = read_agent_deps(agent_name)
+    dep_hash = compute_dependency_hash(deps)
+
+    deps_dir = BUILD_DIR / "deps"
+    zip_path = BUILD_DIR / f"{agent_name}-deps-{dep_hash}.zip"
+    build_dependencies(deps, deps_dir)
+    verify_arm64_artifacts(deps_dir)
+    create_layer_zip(deps_dir, zip_path)
+    verify_arm64_zip(zip_path)
+
+    bucket = resolve_layer_bucket(env, aws_region)
+    key = f"layers/{zip_path.name}"
+    upload_layer_zip(zip_path, bucket=bucket, key=key, aws_region=aws_region)
+    put_layer_metadata(agent_name, dep_hash, key, aws_region)
+
+    logger.info("Layer published for %s: s3://%s/%s", agent_name, bucket, key)
+    print(f"LAYER_BUILT agent={agent_name} hash={dep_hash} s3=s3://{bucket}/{key}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    try:
+        return run(agent_name=args.agent_name, env=args.env)
+    except Exception as exc:
+        logger.error("build_layer failed: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_build_layer.py
+++ b/tests/unit/test_build_layer.py
@@ -1,0 +1,153 @@
+"""Unit tests for scripts/build_layer.py (TASK-034)."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+def _load_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "build_layer_script", repo_root / "scripts" / "build_layer.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+bl: Any = _load_module()
+_REGION = "eu-west-2"
+
+
+def _create_bucket(bucket_name: str) -> None:
+    s3 = boto3.client("s3", region_name=_REGION)
+    s3.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": _REGION},
+    )
+
+
+def _write_arm64_deps_fixture(target_dir: Path) -> None:
+    package_dir = target_dir / "sample"
+    package_dir.mkdir(parents=True, exist_ok=True)
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "native.cpython-312-aarch64-linux-gnu.so").write_bytes(b"arm64")
+
+    dist_info = target_dir / "sample-1.0.0.dist-info"
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "WHEEL").write_text(
+        "Wheel-Version: 1.0\nGenerator: test\nTag: cp312-cp312-manylinux2014_aarch64\n",
+        encoding="utf-8",
+    )
+
+
+def test_parse_args_positional_and_env() -> None:
+    args = bl.parse_args(["echo-agent", "--env", "dev"])
+    assert args.agent_name == "echo-agent"
+    assert args.env == "dev"
+
+
+def test_parse_args_rejects_invalid_env() -> None:
+    with pytest.raises(SystemExit):
+        bl.parse_args(["echo-agent", "--env", "production"])
+
+
+def test_build_dependencies_uses_required_arm64_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(command: list[str], *, cwd: Path, check: bool) -> None:
+        captured["command"] = command
+        captured["cwd"] = cwd
+        captured["check"] = check
+
+    monkeypatch.setattr(bl.subprocess, "run", _fake_run)
+    target_dir = tmp_path / "deps"
+    bl.build_dependencies(["boto3>=1.37.0"], target_dir)
+
+    command = captured["command"]
+    assert command[:3] == ["uv", "pip", "install"]
+    assert "--python-platform" in command
+    assert bl.PYTHON_PLATFORM in command
+    assert "--python-version" in command
+    assert bl.PYTHON_VERSION in command
+    assert "--target" in command
+    assert str(target_dir) in command
+    assert "--only-binary=:all:" in command
+    assert "boto3>=1.37.0" in command
+    assert captured["cwd"] == bl.REPO_ROOT
+    assert captured["check"] is True
+
+
+def test_verify_arm64_zip_accepts_arm64_wheel_and_binary(tmp_path: Path) -> None:
+    deps_dir = tmp_path / "deps"
+    _write_arm64_deps_fixture(deps_dir)
+    zip_path = tmp_path / "deps.zip"
+
+    bl.create_layer_zip(deps_dir, zip_path)
+    bl.verify_arm64_zip(zip_path)
+
+
+def test_verify_arm64_zip_rejects_x86_wheel(tmp_path: Path) -> None:
+    deps_dir = tmp_path / "deps"
+    deps_dir.mkdir(parents=True, exist_ok=True)
+
+    dist_info = deps_dir / "bad-1.0.0.dist-info"
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "WHEEL").write_text(
+        "Wheel-Version: 1.0\nTag: cp312-cp312-manylinux2014_x86_64\n",
+        encoding="utf-8",
+    )
+    (deps_dir / "bad").mkdir(parents=True, exist_ok=True)
+    (deps_dir / "bad" / "module.cpython-312-x86_64-linux-gnu.so").write_bytes(b"x86")
+
+    zip_path = tmp_path / "deps-bad.zip"
+    bl.create_layer_zip(deps_dir, zip_path)
+
+    with pytest.raises(RuntimeError, match="Non-arm64"):
+        bl.verify_arm64_zip(zip_path)
+
+
+@mock_aws
+def test_run_uploads_zip_and_updates_ssm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bucket = "platform-agent-layer-dev"
+    _create_bucket(bucket)
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    monkeypatch.setenv("PLATFORM_LAYER_BUCKET", bucket)
+    monkeypatch.setattr(bl, "BUILD_DIR", tmp_path / ".build")
+
+    def _fake_build_dependencies(_deps: list[str], target_dir: Path) -> None:
+        _write_arm64_deps_fixture(target_dir)
+
+    monkeypatch.setattr(bl, "build_dependencies", _fake_build_dependencies)
+
+    exit_code = bl.run("echo-agent", "dev")
+    assert exit_code == 0
+
+    expected_hash = bl.compute_dependency_hash(bl.read_agent_deps("echo-agent"))
+    expected_key = f"layers/echo-agent-deps-{expected_hash}.zip"
+
+    ssm = boto3.client("ssm", region_name=_REGION)
+    hash_value = ssm.get_parameter(Name="/platform/layers/echo-agent/hash")["Parameter"]["Value"]
+    key_value = ssm.get_parameter(Name="/platform/layers/echo-agent/s3-key")["Parameter"]["Value"]
+    assert hash_value == expected_hash
+    assert key_value == expected_key
+
+    s3 = boto3.client("s3", region_name=_REGION)
+    obj = s3.get_object(Bucket=bucket, Key=expected_key)
+    body = obj["Body"].read()
+    with zipfile.ZipFile(io.BytesIO(body)) as archive:
+        wheel_text = archive.read("sample-1.0.0.dist-info/WHEEL").decode("utf-8")
+        assert "manylinux2014_aarch64" in wheel_text


### PR DESCRIPTION
## Summary
- implement `scripts/build_layer.py` end-to-end for TASK-034 / issue #41
- cross-compile dependencies with `uv pip install --python-platform aarch64-manylinux2014 --python-version 3.12 --only-binary=:all:`
- package `.build/deps` into `.build/{agent}-deps-{hash}.zip`
- verify packaged artifacts are arm64-compatible (reject x86 wheel/binary tags)
- upload layer zip to S3 and write SSM metadata:
  - `/platform/layers/{agent}/hash`
  - `/platform/layers/{agent}/s3-key`
- add unit tests in `tests/unit/test_build_layer.py`

## Validation Evidence
- `uv run pytest tests/unit/test_build_layer.py tests/unit/test_hash_layer.py`
  - result: `22 passed`
- `make preflight-session`
  - result: `Preflight result: PASS`
- `make pre-validate-session`
  - result: `Pre-push validation passed`
- pre-push hook on `git push`
  - result: `pre-push: validation passed`

Closes #41
