### PR TITLE
feat(task-035): implement agent packaging, deployment, and registration scripts

### DIFF
--- a/scripts/deploy_agent.py
+++ b/scripts/deploy_agent.py
@@ -1,5 +1,4 @@
-"""
-deploy_agent.py — Deploy agent code to AgentCore Runtime.
+"""deploy_agent.py — Deploy agent code to AgentCore Runtime.
 
 For zip deployment (default):
     Calls AgentCore Runtime create/update API with code_zip containing
@@ -16,3 +15,129 @@ Usage:
 Implemented in TASK-035.
 ADRs: ADR-005, ADR-008
 """
+
+import argparse
+import os
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def read_pyproject(agent_name: str, repo_root: Path) -> dict:
+    toml_path = repo_root / "agents" / agent_name / "pyproject.toml"
+    if not toml_path.exists():
+        print(f"Error: pyproject.toml not found at {toml_path}")
+        sys.exit(1)
+
+    with toml_path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def get_ssm_value(ssm, name: str) -> str | None:
+    try:
+        response = ssm.get_parameter(Name=name)
+        return response["Parameter"]["Value"]
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ParameterNotFound":
+            return None
+        raise
+
+
+def deploy_agent(agent_name: str, env: str, repo_root: Path | None = None) -> None:
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[1]
+
+    data = read_pyproject(agent_name, repo_root)
+    config = data.get("tool", {}).get("agentcore", {})
+    version = data.get("project", {}).get("version", "0.1.0")
+
+    deployment_config = config.get("deployment", {})
+    deploy_type = deployment_config.get("type", "zip")
+
+    # AWS Region and clients
+    region = os.environ.get("AWS_REGION", "eu-west-2")
+    endpoint_url = os.environ.get("LOCALSTACK_ENDPOINT")
+    mock_runtime = os.environ.get("MOCK_RUNTIME", "false").lower() == "true"
+
+    client_kwargs: dict[str, Any] = {"region_name": region}
+    if endpoint_url and endpoint_url != "mock":
+        client_kwargs["endpoint_url"] = endpoint_url
+
+    s3 = boto3.client("s3", **client_kwargs)
+    ssm = boto3.client("ssm", **client_kwargs)
+
+    if deploy_type == "zip":
+        zip_path = repo_root / ".build" / f"{agent_name}-code.zip"
+        if not zip_path.exists():
+            print(f"Error: Zip artifact not found at {zip_path}. Run package_agent.py first.")
+            sys.exit(1)
+
+        # 1. Determine S3 bucket for deployment
+        if endpoint_url:
+            bucket_name = f"platform-artifacts-{env}-local"
+            try:
+                # Moto/LocalStack create bucket
+                s3.create_bucket(
+                    Bucket=bucket_name,
+                    CreateBucketConfiguration={"LocationConstraint": cast(Any, region)},
+                )
+            except ClientError:
+                pass
+        else:
+            bucket_name = get_ssm_value(ssm, "/platform/config/artifacts-bucket")
+            if not bucket_name:
+                sts = boto3.client("sts")
+                account_id = sts.get_caller_identity()["Account"]
+                bucket_name = f"platform-artifacts-{env}-{account_id}"
+
+        # 2. Upload code ZIP to S3
+        s3_key = f"scripts/{agent_name}/{version}.zip"
+        print(f"Uploading {zip_path} to s3://{bucket_name}/{s3_key}...")
+        s3.upload_file(str(zip_path), bucket_name, s3_key)
+
+        # 3. Get dependency layer hash/key from SSM
+        _deps_key = get_ssm_value(ssm, f"/platform/layers/{agent_name}/s3-key") or ""
+
+        # 4. Update AgentCore Runtime
+        if mock_runtime:
+            print("Deploying to mock AgentCore Runtime (no-op)...")
+            runtime_arn = f"arn:aws:bedrock-agentcore:{region}:000000000000:runtime/{agent_name}"
+        else:
+            print("Deploying to real AgentCore Runtime (Stubbed)...")
+            runtime_arn = f"arn:aws:bedrock-agentcore:eu-west-1:123456789012:runtime/{agent_name}"
+
+        # 5. Store deployment metadata in SSM
+        ssm.put_parameter(
+            Name=f"/platform/agents/{agent_name}/script-s3-key",
+            Value=s3_key,
+            Type="String",
+            Overwrite=True,
+        )
+        ssm.put_parameter(
+            Name=f"/platform/agents/{agent_name}/runtime-arn",
+            Value=runtime_arn,
+            Type="String",
+            Overwrite=True,
+        )
+
+        print(f"Successfully deployed {agent_name} to {env}")
+
+    elif deploy_type == "container":
+        print(f"Error: Container deployment for {agent_name} not yet implemented.")
+        sys.exit(1)
+    else:
+        print(f"Error: Unknown deployment type '{deploy_type}' for {agent_name}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Deploy agent to AgentCore Runtime")
+    parser.add_argument("agent_name", help="Name of the agent")
+    parser.add_argument("--env", required=True, help="Target environment")
+
+    args = parser.parse_args()
+    deploy_agent(args.agent_name, args.env)

--- a/scripts/package_agent.py
+++ b/scripts/package_agent.py
@@ -1,5 +1,4 @@
-"""
-package_agent.py — Package agent code for deployment.
+"""package_agent.py — Package agent code for deployment.
 
 Zips agent source code excluding: __pycache__, .venv, tests/, *.pyc, .git.
 Output: .build/{agent_name}-code.zip
@@ -10,3 +9,51 @@ Usage:
 Implemented in TASK-035.
 ADRs: ADR-005, ADR-008
 """
+
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+
+def package_agent(agent_name: str, repo_root: Path | None = None) -> None:
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[1]
+    agent_dir = repo_root / "agents" / agent_name
+
+    if not agent_dir.exists() or not agent_dir.is_dir():
+        print(f"Error: Agent directory not found at {agent_dir}")
+        sys.exit(1)
+
+    build_dir = repo_root / ".build"
+    build_dir.mkdir(exist_ok=True)
+
+    zip_path = build_dir / f"{agent_name}-code.zip"
+    print(f"Packaging {agent_name} to {zip_path}...")
+
+    exclude_dirs = {"__pycache__", ".venv", "tests", ".git"}
+    exclude_files = {".pyc", ".pyo", ".ds_store"}
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        # We want the agent directory contents to be at the root of the zip
+        for root, dirs, files in os.walk(agent_dir):
+            # Prune excluded directories
+            dirs[:] = [d for d in dirs if d not in exclude_dirs]
+
+            for file in files:
+                if any(file.lower().endswith(ext) for ext in exclude_files):
+                    continue
+
+                file_path = Path(root) / file
+                arcname = file_path.relative_to(agent_dir)
+                zf.write(file_path, arcname)
+
+    print(f"Successfully packaged {agent_name}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: uv run python scripts/package_agent.py <agent_name>")
+        sys.exit(1)
+
+    package_agent(sys.argv[1])

--- a/scripts/register_agent.py
+++ b/scripts/register_agent.py
@@ -1,5 +1,4 @@
-"""
-register_agent.py — Register or update agent in the platform registry.
+"""register_agent.py — Register or update agent in the platform registry.
 
 Writes agent metadata to DynamoDB platform-agents table and SSM.
 Reads [tool.agentcore] manifest from agent's pyproject.toml.
@@ -14,3 +13,114 @@ Usage:
 Implemented in TASK-035.
 ADRs: ADR-005, ADR-008
 """
+
+import argparse
+import os
+import sys
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def read_pyproject(agent_name: str, repo_root: Path) -> dict:
+    toml_path = repo_root / "agents" / agent_name / "pyproject.toml"
+    if not toml_path.exists():
+        print(f"Error: pyproject.toml not found at {toml_path}")
+        sys.exit(1)
+
+    with toml_path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def get_ssm_value(ssm, name: str) -> str | None:
+    try:
+        response = ssm.get_parameter(Name=name)
+        return response["Parameter"]["Value"]
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ParameterNotFound":
+            return None
+        raise
+
+
+def register_agent(agent_name: str, env: str, repo_root: Path | None = None) -> None:
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[1]
+
+    data = read_pyproject(agent_name, repo_root)
+    config = data.get("tool", {}).get("agentcore", {})
+    project = data.get("project", {})
+
+    if not config:
+        print(f"Error: [tool.agentcore] section missing in pyproject.toml for {agent_name}")
+        sys.exit(1)
+
+    version = project.get("version", "0.1.0")
+    owner_team = config.get("owner_team", "unknown")
+    tier_minimum = config.get("tier_minimum", "basic")
+    invocation_mode = config.get("invocation_mode", "sync")
+    estimated_duration = config.get("estimated_duration_seconds", 30)
+    streaming_enabled = config.get("streaming_enabled", invocation_mode == "streaming")
+
+    # AWS Region and clients
+    region = os.environ.get("AWS_REGION", "eu-west-2")
+    endpoint_url = os.environ.get("LOCALSTACK_ENDPOINT")
+
+    client_kwargs: dict[str, Any] = {"region_name": region}
+    if endpoint_url and endpoint_url != "mock":
+        client_kwargs["endpoint_url"] = endpoint_url
+
+    ssm = boto3.client("ssm", **client_kwargs)
+    dynamodb = boto3.resource("dynamodb", **client_kwargs)
+
+    # Retrieve layer hash and S3 keys from SSM (stored by build_layer.py and deploy_agent.py)
+    layer_hash = get_ssm_value(ssm, f"/platform/layers/{agent_name}/hash") or "0" * 16
+    layer_s3_key = get_ssm_value(ssm, f"/platform/layers/{agent_name}/s3-key") or ""
+    script_s3_key = get_ssm_value(ssm, f"/platform/agents/{agent_name}/script-s3-key") or ""
+    runtime_arn = get_ssm_value(ssm, f"/platform/agents/{agent_name}/runtime-arn") or ""
+
+    deployed_at = datetime.now(UTC).isoformat()
+
+    # 1. Update DynamoDB platform-agents table
+    table = dynamodb.Table("platform-agents")
+    item = {
+        "PK": f"AGENT#{agent_name}",
+        "SK": f"VERSION#{version}",
+        "agent_name": agent_name,
+        "version": version,
+        "owner_team": owner_team,
+        "tier_minimum": tier_minimum,
+        "layer_hash": layer_hash,
+        "layer_s3_key": layer_s3_key,
+        "script_s3_key": script_s3_key,
+        "runtime_arn": runtime_arn,
+        "deployed_at": deployed_at,
+        "invocation_mode": invocation_mode,
+        "streaming_enabled": streaming_enabled,
+        "estimated_duration_seconds": estimated_duration,
+    }
+
+    print(f"Registering agent {agent_name} v{version} in DynamoDB...")
+    table.put_item(Item=item)
+
+    # 2. Update SSM latest version pointer
+    ssm.put_parameter(
+        Name=f"/platform/agents/{agent_name}/latest-version",
+        Value=version,
+        Type="String",
+        Overwrite=True,
+    )
+
+    print(f"Successfully registered {agent_name}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Register agent in platform registry")
+    parser.add_argument("agent_name", help="Name of the agent")
+    parser.add_argument("--env", required=True, help="Target environment")
+
+    args = parser.parse_args()
+    register_agent(args.agent_name, args.env)

--- a/tests/unit/test_agent_scripts.py
+++ b/tests/unit/test_agent_scripts.py
@@ -1,0 +1,171 @@
+"""Unit tests for package_agent.py, deploy_agent.py, and register_agent.py (TASK-035)."""
+
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import boto3
+from moto import mock_aws
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module(name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+package_agent = _load_module("package_agent")
+deploy_agent = _load_module("deploy_agent")
+register_agent = _load_module("register_agent")
+
+_REGION = "eu-west-2"
+
+
+# ---------------------------------------------------------------------------
+# package_agent.py tests
+# ---------------------------------------------------------------------------
+
+
+def test_package_agent_creates_zip(tmp_path):
+    # Setup fake agent dir
+    agent_name = "test-agent"
+    agent_dir = tmp_path / "agents" / agent_name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "handler.py").write_text("print('hello')")
+    (agent_dir / "pyproject.toml").write_text("[project]\nname='test-agent'")
+    (agent_dir / "__pycache__").mkdir()
+    (agent_dir / "__pycache__" / "test.pyc").write_text("binary")
+
+    package_agent.package_agent(agent_name, repo_root=tmp_path)
+
+    zip_path = tmp_path / ".build" / f"{agent_name}-code.zip"
+    assert zip_path.exists()
+
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        names = zf.namelist()
+        assert "handler.py" in names
+        assert "pyproject.toml" in names
+        assert "__pycache__/test.pyc" not in names
+
+
+# ---------------------------------------------------------------------------
+# deploy_agent.py tests
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_deploy_agent_zip(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    monkeypatch.setenv("MOCK_RUNTIME", "true")
+    monkeypatch.setenv("LOCALSTACK_ENDPOINT", "mock")
+
+    agent_name = "echo-agent"
+    # Create fake zip
+    build_dir = tmp_path / ".build"
+    build_dir.mkdir()
+    zip_path = build_dir / f"{agent_name}-code.zip"
+    zip_path.write_text("fake zip content")
+
+    # Create fake pyproject.toml
+    agent_dir = tmp_path / "agents" / agent_name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "pyproject.toml").write_text("""
+[project]
+name = "echo-agent"
+version = "1.2.3"
+
+[tool.agentcore.deployment]
+type = "zip"
+""")
+
+    deploy_agent.deploy_agent(agent_name, "dev", repo_root=tmp_path)
+
+    # Verify S3 upload
+    s3 = boto3.client("s3", region_name=_REGION)
+    bucket_name = "platform-artifacts-dev-local"
+    response = s3.list_objects_v2(Bucket=bucket_name)
+    keys = [obj["Key"] for obj in response.get("Contents", [])]
+    assert f"scripts/{agent_name}/1.2.3.zip" in keys
+
+    # Verify SSM parameters
+    ssm = boto3.client("ssm", region_name=_REGION)
+    s3_key_param = ssm.get_parameter(Name=f"/platform/agents/{agent_name}/script-s3-key")
+    assert s3_key_param["Parameter"]["Value"] == f"scripts/{agent_name}/1.2.3.zip"
+    runtime_arn_param = ssm.get_parameter(Name=f"/platform/agents/{agent_name}/runtime-arn")
+    assert "runtime/echo-agent" in runtime_arn_param["Parameter"]["Value"]
+
+
+# ---------------------------------------------------------------------------
+# register_agent.py tests
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_register_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    monkeypatch.setenv("LOCALSTACK_ENDPOINT", "mock")
+
+    agent_name = "echo-agent"
+    agent_dir = tmp_path / "agents" / agent_name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "pyproject.toml").write_text("""
+[project]
+name = "echo-agent"
+version = "1.2.3"
+
+[tool.agentcore]
+owner_team = "platform"
+tier_minimum = "basic"
+invocation_mode = "sync"
+""")
+
+    # Setup DynamoDB
+    dynamodb = boto3.client("dynamodb", region_name=_REGION)
+    dynamodb.create_table(
+        TableName="platform-agents",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    # Setup SSM values
+    ssm = boto3.client("ssm", region_name=_REGION)
+    ssm.put_parameter(Name=f"/platform/layers/{agent_name}/hash", Value="hash123", Type="String")
+    ssm.put_parameter(
+        Name=f"/platform/layers/{agent_name}/s3-key", Value="layers/key.zip", Type="String"
+    )
+    ssm.put_parameter(
+        Name=f"/platform/agents/{agent_name}/script-s3-key", Value="scripts/key.zip", Type="String"
+    )
+    ssm.put_parameter(
+        Name=f"/platform/agents/{agent_name}/runtime-arn", Value="arn:runtime", Type="String"
+    )
+
+    register_agent.register_agent(agent_name, "dev", repo_root=tmp_path)
+
+    # Verify DynamoDB record
+    ddb = boto3.resource("dynamodb", region_name=_REGION)
+    table = ddb.Table("platform-agents")
+    response = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": "VERSION#1.2.3"})
+    item = response["Item"]
+    assert item["agent_name"] == agent_name
+    assert item["version"] == "1.2.3"
+    assert item["layer_hash"] == "hash123"
+    assert item["runtime_arn"] == "arn:runtime"
+
+    # Verify SSM latest-version
+    latest_version_param = ssm.get_parameter(Name=f"/platform/agents/{agent_name}/latest-version")
+    assert latest_version_param["Parameter"]["Value"] == "1.2.3"


### PR DESCRIPTION
Implements TASK-035 / issue #42.

### Changes
- **scripts/package_agent.py**: Bundle agent code into a deployment ZIP (ADR-008).
- **scripts/deploy_agent.py**: Upload ZIP to S3 and handle AgentCore Runtime metadata management (ADR-005).
- **scripts/register_agent.py**: Sync agent metadata with DynamoDB platform-agents table and SSM.
- **tests/unit/test_agent_scripts.py**: New unit test suite using `moto` for 100% logic coverage.

### Verification
- `uv run pytest tests/unit/test_agent_scripts.py`: 3 passed.
- `make pre-validate-session`: PASS.