### PR TITLE
TASK-038: implement src/bff/handler.py

### DIFF
--- a/src/bff/handler.py
+++ b/src/bff/handler.py
@@ -10,3 +10,444 @@ Does NOT handle agent invocations.
 Implemented in TASK-038.
 ADRs: ADR-011
 """
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.logging import correlation_paths
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+logger = Logger(service="bff")
+tracer = Tracer()
+
+ENTRA_CLIENT_ID = os.environ.get("ENTRA_CLIENT_ID")
+ENTRA_CLIENT_SECRET = os.environ.get("ENTRA_CLIENT_SECRET")
+ENTRA_TENANT_ID = os.environ.get("ENTRA_TENANT_ID", "common")
+ENTRA_TOKEN_ENDPOINT = os.environ.get("ENTRA_TOKEN_ENDPOINT")
+RUNTIME_PING_URL = os.environ.get("RUNTIME_PING_URL") or os.environ.get("MOCK_RUNTIME_URL")
+RUNTIME_KEEPALIVE_WINDOW_SECONDS = 15 * 60
+RUNTIME_PING_TIMEOUT_SECONDS = 2.0
+
+
+@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
+@tracer.capture_lambda_handler
+def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
+    """Route BFF requests to token refresh or session keepalive handlers."""
+    request_id = _request_id(event, context)
+    tenant_id, app_id = _tenant_and_app(event)
+    if not tenant_id or not app_id:
+        logger.warning("Missing tenant context in authorizer")
+        return _error_response(401, "UNAUTHENTICATED", "Missing tenant context", request_id)
+
+    logger.append_keys(tenantid=tenant_id, appid=app_id)
+
+    method = _http_method(event)
+    path = _path(event)
+
+    if method != "POST":
+        return _error_response(404, "NOT_FOUND", "Route not found", request_id)
+
+    if path.endswith("/v1/bff/token-refresh"):
+        return _handle_token_refresh(event, request_id=request_id)
+
+    if path.endswith("/v1/bff/session-keepalive"):
+        return _handle_session_keepalive(
+            event,
+            tenant_id=tenant_id,
+            app_id=app_id,
+            request_id=request_id,
+        )
+
+    return _error_response(404, "NOT_FOUND", "Route not found", request_id)
+
+
+def _handle_token_refresh(event: dict[str, Any], *, request_id: str) -> dict[str, Any]:
+    access_token = _bearer_token(event)
+    if access_token is None:
+        return _error_response(401, "UNAUTHENTICATED", "Missing Authorization header", request_id)
+
+    try:
+        body = _require_json_body(event)
+    except ValueError as exc:
+        return _error_response(400, "INVALID_REQUEST", str(exc), request_id)
+
+    raw_scopes = body.get("scopes")
+    if not isinstance(raw_scopes, list) or not raw_scopes:
+        return _error_response(
+            400,
+            "INVALID_REQUEST",
+            "scopes must be a non-empty array",
+            request_id,
+        )
+
+    scopes = [str(scope).strip() for scope in raw_scopes if str(scope).strip()]
+    if not scopes:
+        return _error_response(
+            400,
+            "INVALID_REQUEST",
+            "scopes must contain non-empty values",
+            request_id,
+        )
+
+    audience = _str_or_none(body.get("audience"))
+
+    try:
+        token_payload = _exchange_obo_token(
+            assertion_token=access_token,
+            scopes=scopes,
+            audience=audience,
+        )
+    except ValueError as exc:
+        return _error_response(503, "SERVICE_UNAVAILABLE", str(exc), request_id)
+    except urllib.error.HTTPError as exc:
+        detail = _extract_http_error_detail(exc)
+        if exc.code in {400, 401, 403, 429}:
+            error_code = {
+                400: "INVALID_REQUEST",
+                401: "UNAUTHENTICATED",
+                403: "FORBIDDEN",
+                429: "TOO_MANY_REQUESTS",
+            }[exc.code]
+            return _error_response(exc.code, error_code, detail, request_id)
+        return _error_response(503, "SERVICE_UNAVAILABLE", detail, request_id)
+    except urllib.error.URLError:
+        logger.exception("Token refresh endpoint unreachable")
+        return _error_response(
+            503,
+            "SERVICE_UNAVAILABLE",
+            "Token refresh service unavailable",
+            request_id,
+        )
+
+    expires_in_raw = token_payload.get("expires_in", 3600)
+    try:
+        expires_in = max(0, int(expires_in_raw))
+    except (TypeError, ValueError):
+        expires_in = 3600
+
+    access_token_out = _str_or_none(token_payload.get("access_token"))
+    if access_token_out is None:
+        return _error_response(
+            503,
+            "SERVICE_UNAVAILABLE",
+            "Token refresh response missing access_token",
+            request_id,
+        )
+
+    scope = _str_or_none(token_payload.get("scope")) or " ".join(scopes)
+
+    return _response(
+        200,
+        {
+            "accessToken": access_token_out,
+            "tokenType": "Bearer",
+            "expiresAt": _iso(_now_utc() + timedelta(seconds=expires_in)),
+            "scope": scope,
+        },
+    )
+
+
+def _handle_session_keepalive(
+    event: dict[str, Any],
+    *,
+    tenant_id: str,
+    app_id: str,
+    request_id: str,
+) -> dict[str, Any]:
+    try:
+        body = _require_json_body(event)
+    except ValueError as exc:
+        return _error_response(400, "INVALID_REQUEST", str(exc), request_id)
+
+    session_id = _str_or_none(body.get("sessionId"))
+    agent_name = _str_or_none(body.get("agentName"))
+
+    if session_id is None:
+        return _error_response(400, "INVALID_REQUEST", "sessionId is required", request_id)
+    if agent_name is None:
+        return _error_response(400, "INVALID_REQUEST", "agentName is required", request_id)
+
+    logger.append_keys(sessionid=session_id)
+
+    try:
+        _ping_runtime_session(
+            tenant_id=tenant_id,
+            app_id=app_id,
+            session_id=session_id,
+            agent_name=agent_name,
+        )
+    except ValueError as exc:
+        return _error_response(503, "SERVICE_UNAVAILABLE", str(exc), request_id)
+    except urllib.error.URLError:
+        logger.exception("Runtime keepalive ping failed")
+        return _error_response(
+            500,
+            "INTERNAL_ERROR",
+            "Failed to ping runtime session",
+            request_id,
+        )
+
+    return _response(
+        202,
+        {
+            "sessionId": session_id,
+            "status": "accepted",
+            "expiresAt": _iso(_now_utc() + timedelta(seconds=RUNTIME_KEEPALIVE_WINDOW_SECONDS)),
+        },
+    )
+
+
+def _exchange_obo_token(
+    *,
+    assertion_token: str,
+    scopes: list[str],
+    audience: str | None,
+) -> dict[str, Any]:
+    endpoint = _entra_token_endpoint()
+    scope_value = " ".join(scopes)
+    if audience and all(not scope.startswith(f"{audience}/") for scope in scopes):
+        scope_value = f"{scope_value} {audience}/.default".strip()
+
+    params = {
+        "client_id": _required_env_value("ENTRA_CLIENT_ID", ENTRA_CLIENT_ID),
+        "client_secret": _required_env_value("ENTRA_CLIENT_SECRET", ENTRA_CLIENT_SECRET),
+        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        "requested_token_use": "on_behalf_of",
+        "assertion": assertion_token,
+        "scope": scope_value,
+    }
+    return _http_post_form(endpoint, params)
+
+
+def _ping_runtime_session(*, tenant_id: str, app_id: str, session_id: str, agent_name: str) -> None:
+    base_url = _required_env_value("RUNTIME_PING_URL", RUNTIME_PING_URL)
+    if base_url.rstrip("/").endswith("/ping"):
+        ping_url = base_url
+    else:
+        ping_url = f"{base_url.rstrip('/')}/ping"
+
+    headers = {
+        "x-tenant-id": tenant_id,
+        "x-app-id": app_id,
+        "x-session-id": session_id,
+        "x-agent-name": agent_name,
+    }
+
+    _http_get(ping_url, headers=headers, timeout_seconds=RUNTIME_PING_TIMEOUT_SECONDS)
+
+
+def _http_post_form(url: str, form_data: dict[str, str]) -> dict[str, Any]:
+    encoded = urllib.parse.urlencode(form_data).encode("utf-8")
+    request = urllib.request.Request(
+        url=url,
+        data=encoded,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = response.read().decode("utf-8")
+        parsed = json.loads(payload) if payload else {}
+        if not isinstance(parsed, dict):
+            raise ValueError("Token refresh response must be a JSON object")
+        return parsed
+
+
+def _http_get(url: str, *, headers: dict[str, str], timeout_seconds: float) -> dict[str, Any]:
+    request = urllib.request.Request(url=url, headers=headers, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        payload = response.read().decode("utf-8")
+        parsed = json.loads(payload) if payload else {}
+        if not isinstance(parsed, dict):
+            return {}
+        return parsed
+
+
+def _extract_http_error_detail(exc: urllib.error.HTTPError) -> str:
+    try:
+        payload = exc.read().decode("utf-8")
+    except Exception:
+        payload = ""
+
+    if not payload:
+        return f"Token exchange failed with HTTP {exc.code}"
+
+    try:
+        parsed = json.loads(payload)
+        if isinstance(parsed, dict):
+            description = _str_or_none(parsed.get("error_description"))
+            if description:
+                return description
+            err = _str_or_none(parsed.get("error"))
+            if err:
+                return err
+    except json.JSONDecodeError:
+        pass
+
+    return payload[:500]
+
+
+def _require_json_body(event: dict[str, Any]) -> dict[str, Any]:
+    body = event.get("body")
+    if body is None:
+        raise ValueError("Request body is required")
+    if not isinstance(body, str):
+        raise ValueError("Request body must be a JSON string")
+
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Malformed JSON body") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("JSON body must be an object")
+    return parsed
+
+
+def _response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _error_response(status_code: int, code: str, message: str, request_id: str) -> dict[str, Any]:
+    return _response(
+        status_code,
+        {
+            "error": {
+                "code": code,
+                "message": message,
+                "requestId": request_id,
+            }
+        },
+    )
+
+
+def _tenant_and_app(event: dict[str, Any]) -> tuple[str | None, str | None]:
+    auth = _authorizer(event)
+    tenant_id = _str_or_none(auth.get("tenantid") or auth.get("tenantId"))
+    app_id = _str_or_none(auth.get("appid") or auth.get("appId"))
+    return tenant_id, app_id
+
+
+def _authorizer(event: dict[str, Any]) -> dict[str, Any]:
+    request_context = event.get("requestContext")
+    if not isinstance(request_context, dict):
+        return {}
+
+    authorizer = request_context.get("authorizer")
+    if not isinstance(authorizer, dict):
+        return {}
+
+    nested = authorizer.get("lambda")
+    if isinstance(nested, dict):
+        return nested
+
+    return authorizer
+
+
+def _bearer_token(event: dict[str, Any]) -> str | None:
+    headers = event.get("headers")
+    if not isinstance(headers, dict):
+        return None
+
+    auth_header: str | None = None
+    for key, value in headers.items():
+        if str(key).lower() == "authorization":
+            auth_header = _str_or_none(value)
+            break
+
+    if not auth_header:
+        return None
+
+    prefix = "bearer "
+    if not auth_header.lower().startswith(prefix):
+        return None
+
+    token = auth_header[len(prefix) :].strip()
+    return token or None
+
+
+def _http_method(event: dict[str, Any]) -> str:
+    method = event.get("httpMethod")
+    if method:
+        return str(method).upper()
+
+    request_context = event.get("requestContext")
+    if isinstance(request_context, dict):
+        http = request_context.get("http")
+        if isinstance(http, dict):
+            return str(http.get("method") or "").upper()
+
+    return ""
+
+
+def _path(event: dict[str, Any]) -> str:
+    path = event.get("path")
+    if path:
+        return str(path)
+
+    request_context = event.get("requestContext")
+    if isinstance(request_context, dict):
+        http = request_context.get("http")
+        if isinstance(http, dict) and http.get("path"):
+            return str(http["path"])
+
+        resource_path = request_context.get("resourcePath")
+        if resource_path:
+            return str(resource_path)
+
+    resource = event.get("resource")
+    if resource:
+        return str(resource)
+
+    return ""
+
+
+def _request_id(event: dict[str, Any], context: LambdaContext | None) -> str:
+    if context is not None and getattr(context, "aws_request_id", None):
+        return str(context.aws_request_id)
+
+    request_context = event.get("requestContext")
+    if isinstance(request_context, dict) and request_context.get("requestId"):
+        return str(request_context["requestId"])
+
+    return "unknown"
+
+
+def _required_env_value(name: str, value: str | None) -> str:
+    if value is None or not value.strip():
+        raise ValueError(f"{name} is not configured")
+    return value.strip()
+
+
+def _entra_token_endpoint() -> str:
+    if ENTRA_TOKEN_ENDPOINT:
+        return ENTRA_TOKEN_ENDPOINT
+
+    tenant_id = _required_env_value("ENTRA_TENANT_ID", ENTRA_TENANT_ID)
+    return f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(ts: datetime) -> str:
+    return ts.replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/tests/unit/test_bff_handler.py
+++ b/tests/unit/test_bff_handler.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.bff import handler as bff_handler
+
+
+class FakeContext:
+    function_name = "bff"
+    memory_limit_in_mb = 256
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:111111111111:function:bff"
+    aws_request_id = "req-123"
+
+
+def _event(
+    *,
+    path: str,
+    method: str = "POST",
+    body: dict[str, object] | None = None,
+    headers: dict[str, str] | None = None,
+    tenant_id: str | None = "t-001",
+    app_id: str | None = "app-001",
+) -> dict[str, object]:
+    authorizer = {}
+    if tenant_id is not None:
+        authorizer["tenantid"] = tenant_id
+    if app_id is not None:
+        authorizer["appid"] = app_id
+
+    return {
+        "httpMethod": method,
+        "path": path,
+        "headers": headers or {},
+        "body": None if body is None else json.dumps(body),
+        "requestContext": {
+            "authorizer": authorizer,
+        },
+    }
+
+
+def _body(response: dict[str, object]) -> dict[str, object]:
+    return json.loads(str(response["body"]))
+
+
+@pytest.fixture(autouse=True)
+def reset_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bff_handler, "ENTRA_CLIENT_ID", "client-id")
+    monkeypatch.setattr(bff_handler, "ENTRA_CLIENT_SECRET", "client-secret")
+    monkeypatch.setattr(bff_handler, "ENTRA_TENANT_ID", "tenant-guid")
+    monkeypatch.setattr(bff_handler, "ENTRA_TOKEN_ENDPOINT", None)
+    monkeypatch.setattr(bff_handler, "RUNTIME_PING_URL", "http://localhost:8765")
+
+
+def test_token_refresh_success() -> None:
+    event = _event(
+        path="/v1/bff/token-refresh",
+        body={"scopes": ["api://platform-dev/Agent.Invoke"]},
+        headers={"Authorization": "Bearer incoming-user-token"},
+    )
+
+    with (
+        patch.object(
+            bff_handler,
+            "_exchange_obo_token",
+            return_value={
+                "access_token": "new-token",
+                "token_type": "Bearer",
+                "expires_in": 1800,
+                "scope": "api://platform-dev/Agent.Invoke",
+            },
+        ) as exchange,
+        patch.object(
+            bff_handler,
+            "_now_utc",
+            return_value=datetime(2026, 2, 25, 12, 0, 0, tzinfo=UTC),
+        ),
+    ):
+        response = bff_handler.handler(event, FakeContext())
+
+    assert response["statusCode"] == 200
+    payload = _body(response)
+    assert payload["accessToken"] == "new-token"
+    assert payload["tokenType"] == "Bearer"
+    assert payload["scope"] == "api://platform-dev/Agent.Invoke"
+    assert payload["expiresAt"] == "2026-02-25T12:30:00Z"
+
+    exchange.assert_called_once_with(
+        assertion_token="incoming-user-token",
+        scopes=["api://platform-dev/Agent.Invoke"],
+        audience=None,
+    )
+
+
+def test_token_refresh_requires_authorization_header() -> None:
+    event = _event(path="/v1/bff/token-refresh", body={"scopes": ["s"]}, headers={})
+
+    response = bff_handler.handler(event, FakeContext())
+
+    assert response["statusCode"] == 401
+    error = _body(response)["error"]
+    assert error["code"] == "UNAUTHENTICATED"
+
+
+def test_token_refresh_rejects_invalid_scopes() -> None:
+    event = _event(
+        path="/v1/bff/token-refresh",
+        body={"scopes": ["", "  "]},
+        headers={"Authorization": "Bearer incoming-user-token"},
+    )
+
+    response = bff_handler.handler(event, FakeContext())
+
+    assert response["statusCode"] == 400
+    error = _body(response)["error"]
+    assert error["code"] == "INVALID_REQUEST"
+
+
+def test_keepalive_success_returns_accepted() -> None:
+    event = _event(
+        path="/v1/bff/session-keepalive",
+        body={"sessionId": "sess-123", "agentName": "echo-agent"},
+    )
+
+    with (
+        patch.object(bff_handler, "_ping_runtime_session") as ping,
+        patch.object(
+            bff_handler,
+            "_now_utc",
+            return_value=datetime(2026, 2, 25, 12, 0, 0, tzinfo=UTC),
+        ),
+    ):
+        response = bff_handler.handler(event, FakeContext())
+
+    assert response["statusCode"] == 202
+    payload = _body(response)
+    assert payload == {
+        "sessionId": "sess-123",
+        "status": "accepted",
+        "expiresAt": "2026-02-25T12:15:00Z",
+    }
+
+    ping.assert_called_once_with(
+        tenant_id="t-001",
+        app_id="app-001",
+        session_id="sess-123",
+        agent_name="echo-agent",
+    )
+
+
+def test_keepalive_runtime_unreachable_returns_500() -> None:
+    event = _event(
+        path="/v1/bff/session-keepalive",
+        body={"sessionId": "sess-123", "agentName": "echo-agent"},
+    )
+
+    with patch.object(
+        bff_handler,
+        "_ping_runtime_session",
+        side_effect=bff_handler.urllib.error.URLError("down"),
+    ):
+        response = bff_handler.handler(event, FakeContext())
+
+    assert response["statusCode"] == 500
+    error = _body(response)["error"]
+    assert error["code"] == "INTERNAL_ERROR"
+
+
+def test_keepalive_ping_targets_mock_runtime_contract() -> None:
+    with patch.object(bff_handler, "_http_get") as http_get:
+        bff_handler._ping_runtime_session(
+            tenant_id="t-001",
+            app_id="app-001",
+            session_id="sess-999",
+            agent_name="echo-agent",
+        )
+
+    http_get.assert_called_once_with(
+        "http://localhost:8765/ping",
+        headers={
+            "x-tenant-id": "t-001",
+            "x-app-id": "app-001",
+            "x-session-id": "sess-999",
+            "x-agent-name": "echo-agent",
+        },
+        timeout_seconds=bff_handler.RUNTIME_PING_TIMEOUT_SECONDS,
+    )
+
+
+def test_missing_authorizer_context_returns_401() -> None:
+    event = _event(
+        path="/v1/bff/token-refresh",
+        body={"scopes": ["api://platform-dev/Agent.Invoke"]},
+        headers={"Authorization": "Bearer incoming-user-token"},
+        tenant_id=None,
+        app_id=None,
+    )
+
+    response = bff_handler.handler(event, FakeContext())
+
+    assert response["statusCode"] == 401
+    error = _body(response)["error"]
+    assert error["code"] == "UNAUTHENTICATED"


### PR DESCRIPTION
## Summary
- implement `src/bff/handler.py` as a thin BFF Lambda with explicit routing for:
  - `POST /v1/bff/token-refresh` (Entra OBO token exchange)
  - `POST /v1/bff/session-keepalive` (runtime `/ping` keepalive)
- add consistent JSON responses with OpenAPI-aligned error payloads including `requestId`
- enforce tenant/app context from authorizer and include `tenantid`/`appid` structured log keys
- add unit tests for refresh + keepalive success and failure paths, including mock-runtime ping contract headers

## Validation Evidence
- `uv run pytest tests/unit/test_bff_handler.py`
  - `7 passed`
- `PYTHONPATH=. uv run pytest tests/unit -v --tb=short`
  - `172 passed`
- `make validate-local`
  - passed (ruff, formatting, pyright, tsc, cdk synth, detect-secrets)
- `make preflight-session`
  - PASS (run before commit/push)
- `make pre-validate-session`
  - PASS (run before push)
- `make worktree-push-issue`
  - PASS (enforced preflight + pre-push validation)

## Notes
- `make test-unit` currently fails at collection for `src/data-access-lib/tests/test_client.py` with `ModuleNotFoundError: tests.test_client` in this branch environment. This is outside this change set; core repo unit suite under `tests/unit` passes.

Closes #45
