### PR TITLE
TASK-036: implement gateway request interceptor

### DIFF
--- a/gateway/interceptors/request_interceptor.py
+++ b/gateway/interceptors/request_interceptor.py
@@ -13,3 +13,466 @@ The original user JWT never reaches a tool Lambda (see ADR-004).
 Implemented in TASK-036.
 ADRs: ADR-004
 """
+
+import hashlib
+import json
+import os
+import time
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import boto3
+import jwt
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.utilities.idempotency import (
+    DynamoDBPersistenceLayer,
+    IdempotencyConfig,
+    idempotent_function,
+)
+from jwt import PyJWKClient
+
+logger = Logger(service="gateway-request-interceptor")
+tracer = Tracer()
+
+ENTRA_JWKS_URL = os.environ.get("ENTRA_JWKS_URL")
+ENTRA_AUDIENCE = os.environ.get("ENTRA_AUDIENCE")
+ENTRA_ISSUER = os.environ.get("ENTRA_ISSUER")
+TOOLS_TABLE = os.environ.get("TOOLS_TABLE", "platform-tools")
+SCOPED_TOKEN_ISSUER = os.environ.get("SCOPED_TOKEN_ISSUER", "platform-gateway")
+
+_TIER_ORDER = {"basic": 0, "standard": 1, "premium": 2}
+_jwk_client: PyJWKClient | None = None
+_dynamodb_resource: Any | None = None
+_warned_fallback_signing_key = False
+_idempotency_handler: Callable[..., dict[str, Any]] | None = None
+_idempotency_handler_table: str | None = None
+
+
+def _scoped_token_ttl_seconds() -> int:
+    value = os.environ.get("SCOPED_TOKEN_TTL_SECONDS", "300")
+    try:
+        ttl = int(value)
+    except ValueError:
+        logger.warning(
+            "Invalid SCOPED_TOKEN_TTL_SECONDS, falling back to 300",
+            extra={"value": value},
+        )
+        return 300
+    return max(1, ttl)
+
+
+def get_jwk_client() -> PyJWKClient | None:
+    """Lazily initialize JWKS client with 5-minute cache."""
+    global _jwk_client
+    if _jwk_client is None and ENTRA_JWKS_URL:
+        _jwk_client = PyJWKClient(ENTRA_JWKS_URL, cache_jwk_set=True, lifespan=300)
+    return _jwk_client
+
+
+def get_dynamodb():
+    """Lazily initialize DynamoDB resource."""
+    global _dynamodb_resource
+    if _dynamodb_resource is None:
+        region = os.environ.get("AWS_REGION")
+        if region:
+            _dynamodb_resource = boto3.resource("dynamodb", region_name=region)
+        else:
+            _dynamodb_resource = boto3.resource("dynamodb")
+    return _dynamodb_resource
+
+
+def _get_header(headers: dict[str, str], key: str) -> str | None:
+    key_lower = key.lower()
+    for header_key, value in headers.items():
+        if header_key.lower() == key_lower:
+            return value
+    return None
+
+
+def _normalized_headers(headers: Any) -> dict[str, str]:
+    if not isinstance(headers, dict):
+        return {}
+    output: dict[str, str] = {}
+    for key, value in headers.items():
+        output[str(key)] = str(value)
+    return output
+
+
+def _parse_body(body: Any) -> dict[str, Any]:
+    if isinstance(body, dict):
+        return dict(body)
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _build_interceptor_response(
+    *,
+    transformed_gateway_request: dict[str, Any],
+    transformed_gateway_response: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    mcp: dict[str, Any] = {"transformedGatewayRequest": transformed_gateway_request}
+    if transformed_gateway_response is not None:
+        mcp["transformedGatewayResponse"] = transformed_gateway_response
+    return {"interceptorOutputVersion": "1.0", "mcp": mcp}
+
+
+def _error_response(
+    *,
+    gateway_request: dict[str, Any],
+    request_id: Any,
+    status_code: int,
+    code: int,
+    message: str,
+) -> dict[str, Any]:
+    transformed_request = {
+        "body": _parse_body(gateway_request.get("body")),
+        "headers": _normalized_headers(gateway_request.get("headers", {})),
+    }
+    transformed_gateway_response = {
+        "statusCode": status_code,
+        "body": {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        },
+    }
+    return _build_interceptor_response(
+        transformed_gateway_request=transformed_request,
+        transformed_gateway_response=transformed_gateway_response,
+    )
+
+
+def _extract_tool_name(method: str, body: dict[str, Any]) -> str | None:
+    if method != "tools/call":
+        return None
+    params = body.get("params", {})
+    if not isinstance(params, dict):
+        return None
+    name = params.get("name") or params.get("toolName")
+    if not name:
+        return None
+    return str(name)
+
+
+def _build_idempotency_key(headers: dict[str, str], body: dict[str, Any]) -> str | None:
+    session_id = _get_header(headers, "Mcp-Session-Id")
+    request_id = body.get("id")
+    if not session_id or request_id is None:
+        return None
+    return f"{session_id}:{request_id}"
+
+
+def _is_tier_allowed(tenant_tier: str, minimum_tier: str) -> bool:
+    tenant_rank = _TIER_ORDER.get(tenant_tier, -1)
+    minimum_rank = _TIER_ORDER.get(minimum_tier, 100)
+    return tenant_rank >= minimum_rank
+
+
+def get_tool_record(tool_name: str, tenant_id: str) -> dict[str, Any] | None:
+    """Fetch tenant-specific tool first, then global."""
+    table = get_dynamodb().Table(TOOLS_TABLE)
+    primary_key = {"PK": f"TOOL#{tool_name}"}
+    candidate_sort_keys = [f"TENANT#{tenant_id}", "GLOBAL"]
+    for sort_key in candidate_sort_keys:
+        response = table.get_item(Key={**primary_key, "SK": sort_key}, ConsistentRead=True)
+        item = response.get("Item")
+        if item and bool(item.get("enabled", False)):
+            return dict(item)
+    return None
+
+
+def _validate_bearer_token(token: str) -> dict[str, Any] | None:
+    if not ENTRA_AUDIENCE or not ENTRA_ISSUER:
+        logger.error("ENTRA_AUDIENCE and ENTRA_ISSUER must be configured for JWT validation")
+        return None
+
+    jwk_client = get_jwk_client()
+    if jwk_client is None:
+        logger.error("JWK client unavailable (ENTRA_JWKS_URL missing)")
+        return None
+
+    signing_key = jwk_client.get_signing_key_from_jwt(token)
+    payload = jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        audience=ENTRA_AUDIENCE,
+        issuer=ENTRA_ISSUER,
+    )
+    return payload if isinstance(payload, dict) else None
+
+
+def _get_scoped_token_signing_key() -> str:
+    global _warned_fallback_signing_key
+    explicit = os.environ.get("SCOPED_TOKEN_SIGNING_KEY")
+    if explicit:
+        return explicit
+
+    # Deterministic fallback for local/dev environments where no key is configured.
+    # Production should provide SCOPED_TOKEN_SIGNING_KEY via secret-backed injection.
+    seed = "|".join(
+        [
+            os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "gateway-request-interceptor"),
+            os.environ.get("AWS_REGION", ""),
+            SCOPED_TOKEN_ISSUER,
+        ]
+    )
+    if not _warned_fallback_signing_key:
+        logger.warning(
+            "Using fallback scoped token signing key; configure SCOPED_TOKEN_SIGNING_KEY"
+        )
+        _warned_fallback_signing_key = True
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _issue_scoped_token(
+    *,
+    tenant_id: str,
+    app_id: str,
+    tier: str,
+    acting_sub: str,
+    scope_tool: str,
+    mcp_session_id: str | None,
+    mcp_request_id: Any,
+) -> str:
+    now = int(time.time())
+    ttl = _scoped_token_ttl_seconds()
+    claims = {
+        "iss": SCOPED_TOKEN_ISSUER,
+        "aud": f"tool:{scope_tool}",
+        "iat": now,
+        "exp": now + ttl,
+        "jti": str(uuid.uuid4()),
+        "tenantid": tenant_id,
+        "appid": app_id,
+        "tier": tier,
+        "acting_sub": acting_sub,
+        "scope_tool": scope_tool,
+        "mcp_session_id": mcp_session_id,
+        "mcp_request_id": str(mcp_request_id),
+    }
+    return str(jwt.encode(claims, _get_scoped_token_signing_key(), algorithm="HS256"))
+
+
+def _get_idempotency_handler() -> Callable[..., dict[str, Any]] | None:
+    """Create a Powertools idempotent wrapper when IDEMPOTENCY_TABLE is configured."""
+    global _idempotency_handler, _idempotency_handler_table
+    table_name = os.environ.get("IDEMPOTENCY_TABLE")
+    if not table_name:
+        return None
+
+    if _idempotency_handler is not None and _idempotency_handler_table == table_name:
+        return _idempotency_handler
+
+    config = IdempotencyConfig(
+        event_key_jmespath="idempotency_key",
+        expires_after_seconds=_scoped_token_ttl_seconds(),
+        use_local_cache=True,
+    )
+    persistence = DynamoDBPersistenceLayer(table_name=table_name)
+
+    @idempotent_function(
+        data_keyword_argument="idempotency_data",
+        persistence_store=persistence,
+        config=config,
+    )
+    def _wrapper(
+        *,
+        idempotency_data: dict[str, str],
+        interceptor_event: dict[str, Any],
+    ) -> dict[str, Any]:
+        return _process_request(interceptor_event)
+
+    _idempotency_handler = _wrapper
+    _idempotency_handler_table = table_name
+    return _idempotency_handler
+
+
+def _process_request(event: dict[str, Any]) -> dict[str, Any]:
+    mcp = event.get("mcp", {})
+    if not isinstance(mcp, dict):
+        mcp = {}
+    gateway_request = mcp.get("gatewayRequest", {})
+    if not isinstance(gateway_request, dict):
+        gateway_request = {}
+
+    request_body = _parse_body(gateway_request.get("body"))
+    request_headers = _normalized_headers(gateway_request.get("headers", {}))
+    jsonrpc_id = request_body.get("id")
+
+    authorization = _get_header(request_headers, "Authorization")
+    if not authorization or not authorization.startswith("Bearer "):
+        return _error_response(
+            gateway_request=gateway_request,
+            request_id=jsonrpc_id,
+            status_code=401,
+            code=-32001,
+            message="Missing or invalid Bearer token",
+        )
+
+    user_token = authorization.split(" ", 1)[1]
+    try:
+        payload = _validate_bearer_token(user_token)
+    except jwt.ExpiredSignatureError:
+        return _error_response(
+            gateway_request=gateway_request,
+            request_id=jsonrpc_id,
+            status_code=401,
+            code=-32001,
+            message="Bearer token expired",
+        )
+    except jwt.InvalidTokenError:
+        return _error_response(
+            gateway_request=gateway_request,
+            request_id=jsonrpc_id,
+            status_code=401,
+            code=-32001,
+            message="Bearer token validation failed",
+        )
+    except Exception:
+        logger.exception("Unexpected JWT validation error")
+        return _error_response(
+            gateway_request=gateway_request,
+            request_id=jsonrpc_id,
+            status_code=401,
+            code=-32001,
+            message="Bearer token validation failed",
+        )
+
+    if payload is None:
+        return _error_response(
+            gateway_request=gateway_request,
+            request_id=jsonrpc_id,
+            status_code=401,
+            code=-32001,
+            message="Bearer token validation failed",
+        )
+
+    tenant_id = str(payload.get("tenantid") or "")
+    app_id = str(payload.get("appid") or "")
+    tier = str(payload.get("tier") or "basic")
+    acting_sub = str(payload.get("sub") or "unknown")
+    if not tenant_id or not app_id:
+        return _error_response(
+            gateway_request=gateway_request,
+            request_id=jsonrpc_id,
+            status_code=401,
+            code=-32001,
+            message="Missing tenant context in token",
+        )
+
+    logger.append_keys(tenant_id=tenant_id, app_id=app_id)
+
+    method = str(request_body.get("method") or "")
+    tool_name = _extract_tool_name(method, request_body)
+    if method == "tools/call":
+        if not tool_name:
+            return _error_response(
+                gateway_request=gateway_request,
+                request_id=jsonrpc_id,
+                status_code=400,
+                code=-32600,
+                message="tools/call missing params.name",
+            )
+
+        try:
+            tool_record = get_tool_record(tool_name, tenant_id)
+        except Exception:
+            logger.exception("Failed to read tool registry", extra={"tool_name": tool_name})
+            return _error_response(
+                gateway_request=gateway_request,
+                request_id=jsonrpc_id,
+                status_code=500,
+                code=-32603,
+                message="Failed to resolve tool policy",
+            )
+
+        if tool_record is None:
+            return _error_response(
+                gateway_request=gateway_request,
+                request_id=jsonrpc_id,
+                status_code=403,
+                code=-32003,
+                message="Tool is unavailable for this tenant",
+            )
+
+        minimum_tier = str(tool_record.get("tier_minimum") or "basic")
+        if not _is_tier_allowed(tier, minimum_tier):
+            return _error_response(
+                gateway_request=gateway_request,
+                request_id=jsonrpc_id,
+                status_code=403,
+                code=-32003,
+                message="Tenant tier is insufficient for this tool",
+            )
+
+    scope_tool = tool_name if tool_name else method
+    scoped_token = _issue_scoped_token(
+        tenant_id=tenant_id,
+        app_id=app_id,
+        tier=tier,
+        acting_sub=acting_sub,
+        scope_tool=scope_tool,
+        mcp_session_id=_get_header(request_headers, "Mcp-Session-Id"),
+        mcp_request_id=jsonrpc_id,
+    )
+
+    transformed_headers = {
+        key: value for key, value in request_headers.items() if key.lower() != "authorization"
+    }
+    transformed_headers["Authorization"] = f"Bearer {scoped_token}"
+    transformed_headers["x-tenant-id"] = tenant_id
+    transformed_headers["x-app-id"] = app_id
+    transformed_headers["x-tier"] = tier
+    transformed_headers["x-acting-sub"] = acting_sub
+
+    transformed_request = dict(gateway_request)
+    transformed_request["headers"] = transformed_headers
+    transformed_request["body"] = request_body
+
+    return _build_interceptor_response(transformed_gateway_request=transformed_request)
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """AgentCore Gateway REQUEST interceptor entrypoint."""
+    mcp = event.get("mcp", {})
+    if not isinstance(mcp, dict):
+        return _error_response(
+            gateway_request={},
+            request_id=None,
+            status_code=400,
+            code=-32600,
+            message="Invalid interceptor input",
+        )
+
+    gateway_request = mcp.get("gatewayRequest", {})
+    if not isinstance(gateway_request, dict):
+        return _error_response(
+            gateway_request={},
+            request_id=None,
+            status_code=400,
+            code=-32600,
+            message="Invalid gateway request",
+        )
+
+    request_body = _parse_body(gateway_request.get("body"))
+    request_headers = _normalized_headers(gateway_request.get("headers", {}))
+    idempotency_key = _build_idempotency_key(request_headers, request_body)
+    idempotency_handler = _get_idempotency_handler()
+
+    if idempotency_handler and idempotency_key:
+        return idempotency_handler(
+            idempotency_data={"idempotency_key": idempotency_key},
+            interceptor_event=event,
+        )
+
+    return _process_request(event)

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -49,6 +49,7 @@ export class PlatformStack extends cdk.Stack {
   public readonly sessionsTable: dynamodb.Table;
   public readonly toolsTable: dynamodb.Table;
   public readonly opsLocksTable: dynamodb.Table;
+  public readonly gatewayIdempotencyTable: dynamodb.Table;
 
   public readonly bridgeFn: lambda.Function;
   public readonly bffFn: lambda.Function;
@@ -119,6 +120,17 @@ export class PlatformStack extends cdk.Stack {
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: props.platformConfigKey,
       timeToLiveAttribute: 'ttl',
+      pointInTimeRecovery: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    this.gatewayIdempotencyTable = new dynamodb.Table(this, 'GatewayIdempotencyTable', {
+      tableName: 'platform-gateway-idempotency',
+      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey: props.platformConfigKey,
+      timeToLiveAttribute: 'expiration',
       pointInTimeRecovery: true,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
@@ -241,6 +253,12 @@ export class PlatformStack extends cdk.Stack {
       memorySize: 512,
       environment: {
         POWERTOOLS_SERVICE_NAME: 'gateway-request-interceptor',
+        TOOLS_TABLE: this.toolsTable.tableName,
+        ENTRA_JWKS_URL: 'https://login.microsoftonline.com/common/discovery/v2.0/keys',
+        ENTRA_AUDIENCE: 'platform-api',
+        ENTRA_ISSUER: 'https://login.microsoftonline.com/common/v2.0',
+        SCOPED_TOKEN_ISSUER: 'platform-gateway',
+        IDEMPOTENCY_TABLE: this.gatewayIdempotencyTable.tableName,
       },
     });
 
@@ -254,6 +272,9 @@ export class PlatformStack extends cdk.Stack {
         POWERTOOLS_SERVICE_NAME: 'gateway-response-interceptor',
       },
     });
+
+    this.toolsTable.grantReadData(this.requestInterceptorFn);
+    this.gatewayIdempotencyTable.grantReadWriteData(this.requestInterceptorFn);
 
     const authoriserAlias = new lambda.Alias(this, 'AuthoriserLiveAlias', {
       aliasName: 'live',

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -36,7 +36,7 @@ describe('PlatformStack (TASK-023)', () => {
   const template = synthTemplate();
 
   test('creates all required DynamoDB tables with PITR and encryption', () => {
-    template.resourceCountIs('AWS::DynamoDB::Table', 7);
+    template.resourceCountIs('AWS::DynamoDB::Table', 8);
 
     template.hasResourceProperties('AWS::DynamoDB::Table', {
       TableName: 'platform-tenants',

--- a/tests/unit/test_request_interceptor.py
+++ b/tests/unit/test_request_interceptor.py
@@ -1,0 +1,169 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+
+from gateway.interceptors import request_interceptor
+
+OS_ENV = {
+    "AWS_REGION": "eu-west-2",
+    "ENTRA_JWKS_URL": "http://localhost:8766/.well-known/jwks.json",
+    "ENTRA_AUDIENCE": "api://platform-local",
+    "ENTRA_ISSUER": "http://localhost:8766",
+    "TOOLS_TABLE": "platform-tools-dev",
+    "SCOPED_TOKEN_SIGNING_KEY": "unit-test-signing-key-with-32-bytes-minimum",
+    "SCOPED_TOKEN_ISSUER": "platform-gateway",
+}
+
+
+@pytest.fixture
+def mock_env():
+    with patch.dict(os.environ, OS_ENV, clear=False):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_module_constants():
+    with (
+        patch("gateway.interceptors.request_interceptor.ENTRA_JWKS_URL", OS_ENV["ENTRA_JWKS_URL"]),
+        patch("gateway.interceptors.request_interceptor.ENTRA_AUDIENCE", OS_ENV["ENTRA_AUDIENCE"]),
+        patch("gateway.interceptors.request_interceptor.ENTRA_ISSUER", OS_ENV["ENTRA_ISSUER"]),
+        patch("gateway.interceptors.request_interceptor.TOOLS_TABLE", OS_ENV["TOOLS_TABLE"]),
+        patch(
+            "gateway.interceptors.request_interceptor.SCOPED_TOKEN_ISSUER",
+            OS_ENV["SCOPED_TOKEN_ISSUER"],
+        ),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def reset_globals():
+    request_interceptor._jwk_client = None
+    request_interceptor._dynamodb_resource = None
+    request_interceptor._idempotency_handler = None
+    request_interceptor._idempotency_handler_table = None
+    request_interceptor._warned_fallback_signing_key = False
+    yield
+
+
+class MockContext:
+    function_name = "request-interceptor"
+    memory_limit_in_mb = 128
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:000000000000:function:request-interceptor"
+    aws_request_id = "request-id"
+
+
+@pytest.fixture
+def lambda_context():
+    return MockContext()
+
+
+def _base_event() -> dict:
+    return {
+        "interceptorInputVersion": "1.0",
+        "mcp": {
+            "gatewayRequest": {
+                "path": "/mcp",
+                "httpMethod": "POST",
+                "headers": {
+                    "Authorization": "Bearer original.user.token",
+                    "Mcp-Session-Id": "mcp-session-123",
+                    "Accept": "application/json",
+                },
+                "body": {
+                    "jsonrpc": "2.0",
+                    "id": "rpc-1",
+                    "method": "tools/call",
+                    "params": {"name": "echo", "arguments": {"text": "hello"}},
+                },
+            }
+        },
+    }
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+@patch("gateway.interceptors.request_interceptor.get_tool_record")
+def test_request_interceptor_enforces_tier(
+    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
+):
+    event = _base_event()
+    payload = {
+        "tenantid": "t-basic-001",
+        "appid": "platform-local",
+        "tier": "basic",
+        "sub": "user-123",
+        "iss": OS_ENV["ENTRA_ISSUER"],
+        "aud": OS_ENV["ENTRA_AUDIENCE"],
+    }
+    mock_get_tool_record.return_value = {
+        "tool_name": "echo",
+        "tier_minimum": "premium",
+        "enabled": True,
+    }
+    mock_get_jwk_client.return_value = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with patch("jwt.decode", return_value=payload):
+        result = request_interceptor.handler(event, lambda_context)
+
+    response = result["mcp"]["transformedGatewayResponse"]
+    assert response["statusCode"] == 403
+    assert response["body"]["error"]["message"] == "Tenant tier is insufficient for this tool"
+    mock_get_tool_record.assert_called_once_with("echo", "t-basic-001")
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+@patch("gateway.interceptors.request_interceptor.get_tool_record")
+def test_request_interceptor_issues_scoped_token_and_headers(
+    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
+):
+    event = _base_event()
+    payload = {
+        "tenantid": "t-basic-001",
+        "appid": "platform-local",
+        "tier": "basic",
+        "sub": "user-123",
+        "iss": OS_ENV["ENTRA_ISSUER"],
+        "aud": OS_ENV["ENTRA_AUDIENCE"],
+    }
+    mock_get_tool_record.return_value = {
+        "tool_name": "echo",
+        "tier_minimum": "basic",
+        "enabled": True,
+    }
+    mock_get_jwk_client.return_value = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with patch("jwt.decode", return_value=payload):
+        result = request_interceptor.handler(event, lambda_context)
+
+    transformed = result["mcp"]["transformedGatewayRequest"]
+    headers = transformed["headers"]
+    assert headers["x-tenant-id"] == "t-basic-001"
+    assert headers["x-app-id"] == "platform-local"
+    assert headers["x-tier"] == "basic"
+    assert headers["x-acting-sub"] == "user-123"
+
+    auth_header = headers["Authorization"]
+    assert auth_header.startswith("Bearer ")
+    assert auth_header != "Bearer original.user.token"
+
+    scoped_token = auth_header.split(" ", 1)[1]
+    scoped_claims = jwt.decode(
+        scoped_token,
+        OS_ENV["SCOPED_TOKEN_SIGNING_KEY"],
+        algorithms=["HS256"],
+        options={"verify_aud": False},
+    )
+    assert scoped_claims["tenantid"] == "t-basic-001"
+    assert scoped_claims["appid"] == "platform-local"
+    assert scoped_claims["tier"] == "basic"
+    assert scoped_claims["acting_sub"] == "user-123"
+    assert scoped_claims["scope_tool"] == "echo"
+    assert scoped_claims["aud"] == "tool:echo"
+    assert scoped_claims["exp"] > scoped_claims["iat"]
+    assert scoped_claims["exp"] - scoped_claims["iat"] <= 300


### PR DESCRIPTION
## Summary
- implement `gateway/interceptors/request_interceptor.py` for TASK-036 / issue #43
- validate Bearer JWT via Entra JWKS, enforce tool tier minimum using `platform-tools`, return 403 for insufficient tier
- issue 5-minute scoped act-on-behalf JWT and inject `x-tenant-id`, `x-app-id`, `x-tier`, `x-acting-sub`
- add Powertools idempotency wiring keyed by `Mcp-Session-Id + body.id` (DynamoDB-backed via `platform-gateway-idempotency`)
- add unit tests for tier enforcement and scoped token structure
- wire request-interceptor env/permissions in CDK and update platform stack table-count test

## Validation Evidence
- `make preflight-session` (PASS)
- `make pre-validate-session` (PASS)
- `make validate-local` (PASS)
- `PYTHONPATH=. uv run pytest tests/unit/test_request_interceptor.py -q` (PASS, 2 passed)
- `cd infra/cdk && npx --no-install jest test/platform-stack.test.ts --runInBand` (PASS, 5 passed)
- `make test-unit` currently fails during collection in existing `src/data-access-lib/tests/test_client.py` with `ModuleNotFoundError: No module named 'tests.test_client'` (pre-existing/unrelated to this change)

Closes #43
