### PR TITLE
TASK-043: CloudFront CSP/CORS hardening

### DIFF
--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -267,10 +267,156 @@ export class PlatformStack extends cdk.Stack {
       resultsCacheTtl: cdk.Duration.minutes(5),
     });
 
+    const spaBucket = new s3.Bucket(this, 'SpaBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      versioned: true,
+    });
+
+    const resultsBucket = new s3.Bucket(this, 'ResultsBucket', {
+      bucketName: `platform-results-${env}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      versioned: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    new ssm.StringParameter(this, 'ResultsBucketArnParam', {
+      parameterName: `/platform/core/${env}/results-bucket-arn`,
+      stringValue: resultsBucket.bucketArn,
+      description: 'ARN for the platform results S3 bucket',
+    });
+
+    const spaResponseHeadersPolicy = new cloudfront.CfnResponseHeadersPolicy(
+      this,
+      'SpaCspResponseHeadersPolicy',
+      {
+        responseHeadersPolicyConfig: {
+          name: `${this.stackName}-spa-security-headers`,
+          comment: 'Security headers for platform SPA',
+          securityHeadersConfig: {
+            contentSecurityPolicy: {
+              contentSecurityPolicy:
+                "default-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; connect-src 'self' https:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self';",
+              override: true,
+            },
+            frameOptions: {
+              frameOption: 'DENY',
+              override: true,
+            },
+            strictTransportSecurity: {
+              accessControlMaxAgeSec: 31536000,
+              includeSubdomains: true,
+              preload: true,
+              override: true,
+            },
+            contentTypeOptions: {
+              override: true,
+            },
+            referrerPolicy: {
+              referrerPolicy: 'same-origin',
+              override: true,
+            },
+            xssProtection: {
+              protection: true,
+              modeBlock: true,
+              override: true,
+            },
+          },
+        },
+      },
+    );
+
+    const spaOriginAccessControl = new cloudfront.CfnOriginAccessControl(this, 'SpaOriginAccessControl', {
+      originAccessControlConfig: {
+        name: `${this.stackName}-spa-oac`,
+        description: 'OAC for SPA bucket origin',
+        originAccessControlOriginType: 's3',
+        signingBehavior: 'always',
+        signingProtocol: 'sigv4',
+      },
+    });
+
+    this.spaDistribution = new cloudfront.CfnDistribution(this, 'SpaDistribution', {
+      distributionConfig: {
+        enabled: true,
+        comment: 'Platform SPA distribution',
+        defaultRootObject: 'index.html',
+        httpVersion: 'http2',
+        priceClass: 'PriceClass_100',
+        ipv6Enabled: true,
+        origins: [
+          {
+            id: 'SpaS3Origin',
+            domainName: spaBucket.bucketRegionalDomainName,
+            originAccessControlId: spaOriginAccessControl.attrId,
+            s3OriginConfig: {
+              originAccessIdentity: '',
+            },
+          },
+        ],
+        defaultCacheBehavior: {
+          targetOriginId: 'SpaS3Origin',
+          viewerProtocolPolicy: 'redirect-to-https',
+          compress: true,
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachePolicyId: cloudfront.CachePolicy.CACHING_OPTIMIZED.cachePolicyId,
+          responseHeadersPolicyId: spaResponseHeadersPolicy.attrId,
+        },
+        restrictions: {
+          geoRestriction: {
+            restrictionType: 'none',
+          },
+        },
+        viewerCertificate: {
+          cloudFrontDefaultCertificate: true,
+        },
+      },
+    });
+
+    spaBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        sid: 'AllowCloudFrontOacRead',
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+        actions: ['s3:GetObject'],
+        resources: [spaBucket.arnForObjects('*')],
+        conditions: {
+          StringEquals: {
+            'AWS:SourceArn': cdk.Fn.join('', [
+              'arn:',
+              cdk.Aws.PARTITION,
+              ':cloudfront::',
+              cdk.Aws.ACCOUNT_ID,
+              ':distribution/',
+              this.spaDistribution.ref,
+            ]),
+          },
+        },
+      }),
+    );
+
+    const spaAllowedOrigin = cdk.Fn.join('', ['https://', this.spaDistribution.attrDomainName]);
+
     this.api = new apigateway.RestApi(this, 'PlatformRestApi', {
       restApiName: `${this.stackName}-rest-api`,
       description: 'Platform northbound REST API (ADR-003)',
       apiKeySourceType: apigateway.ApiKeySourceType.AUTHORIZER,
+      defaultCorsPreflightOptions: {
+        allowOrigins: [spaAllowedOrigin],
+        allowMethods: apigateway.Cors.ALL_METHODS,
+        allowHeaders: [
+          'Authorization',
+          'Content-Type',
+          'X-Api-Key',
+          'X-Amz-Date',
+          'X-Amz-Security-Token',
+          'X-Amz-User-Agent',
+        ],
+      },
       deployOptions: {
         stageName: 'prod',
         tracingEnabled: true,
@@ -534,115 +680,6 @@ export class PlatformStack extends cdk.Stack {
       resourceArn: this.api.deploymentStage.stageArn,
       webAclArn: this.apiWebAcl.attrArn,
     });
-
-    const spaBucket = new s3.Bucket(this, 'SpaBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-      versioned: true,
-    });
-
-    const resultsBucket = new s3.Bucket(this, 'ResultsBucket', {
-      bucketName: `platform-results-${env}`,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-      versioned: true,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
-    });
-
-    new ssm.StringParameter(this, 'ResultsBucketArnParam', {
-      parameterName: `/platform/core/${env}/results-bucket-arn`,
-      stringValue: resultsBucket.bucketArn,
-      description: 'ARN for the platform results S3 bucket',
-    });
-
-    const spaCspPolicy = new cloudfront.CfnResponseHeadersPolicy(this, 'SpaCspResponseHeadersPolicy', {
-      responseHeadersPolicyConfig: {
-        name: `${this.stackName}-spa-csp`,
-        comment: 'CSP headers for platform SPA',
-        customHeadersConfig: {
-          items: [
-            {
-              header: 'Content-Security-Policy',
-              value:
-                "default-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; connect-src 'self' https:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self';",
-              override: true,
-            },
-          ],
-        },
-      },
-    });
-
-    const spaOriginAccessControl = new cloudfront.CfnOriginAccessControl(this, 'SpaOriginAccessControl', {
-      originAccessControlConfig: {
-        name: `${this.stackName}-spa-oac`,
-        description: 'OAC for SPA bucket origin',
-        originAccessControlOriginType: 's3',
-        signingBehavior: 'always',
-        signingProtocol: 'sigv4',
-      },
-    });
-
-    this.spaDistribution = new cloudfront.CfnDistribution(this, 'SpaDistribution', {
-      distributionConfig: {
-        enabled: true,
-        comment: 'Platform SPA distribution',
-        defaultRootObject: 'index.html',
-        httpVersion: 'http2',
-        priceClass: 'PriceClass_100',
-        ipv6Enabled: true,
-        origins: [
-          {
-            id: 'SpaS3Origin',
-            domainName: spaBucket.bucketRegionalDomainName,
-            originAccessControlId: spaOriginAccessControl.attrId,
-            s3OriginConfig: {
-              originAccessIdentity: '',
-            },
-          },
-        ],
-        defaultCacheBehavior: {
-          targetOriginId: 'SpaS3Origin',
-          viewerProtocolPolicy: 'redirect-to-https',
-          compress: true,
-          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
-          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
-          cachePolicyId: cloudfront.CachePolicy.CACHING_OPTIMIZED.cachePolicyId,
-          responseHeadersPolicyId: spaCspPolicy.attrId,
-        },
-        restrictions: {
-          geoRestriction: {
-            restrictionType: 'none',
-          },
-        },
-        viewerCertificate: {
-          cloudFrontDefaultCertificate: true,
-        },
-      },
-    });
-
-    spaBucket.addToResourcePolicy(
-      new iam.PolicyStatement({
-        sid: 'AllowCloudFrontOacRead',
-        effect: iam.Effect.ALLOW,
-        principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
-        actions: ['s3:GetObject'],
-        resources: [spaBucket.arnForObjects('*')],
-        conditions: {
-          StringEquals: {
-            'AWS:SourceArn': cdk.Fn.join('', [
-              'arn:',
-              cdk.Aws.PARTITION,
-              ':cloudfront::',
-              cdk.Aws.ACCOUNT_ID,
-              ':distribution/',
-              this.spaDistribution.ref,
-            ]),
-          },
-        },
-      }),
-    );
 
     const agentCoreGatewayRole = new iam.Role(this, 'AgentCoreGatewayExecutionRole', {
       assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com'),

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -114,13 +114,20 @@ describe('PlatformStack (TASK-023)', () => {
 
     template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
       ResponseHeadersPolicyConfig: Match.objectLike({
-        CustomHeadersConfig: Match.objectLike({
-          Items: Match.arrayWith([
-            Match.objectLike({
-              Header: 'Content-Security-Policy',
-              Override: true,
-            }),
-          ]),
+        SecurityHeadersConfig: Match.objectLike({
+          ContentSecurityPolicy: Match.objectLike({
+            Override: true,
+          }),
+          FrameOptions: Match.objectLike({
+            FrameOption: 'DENY',
+            Override: true,
+          }),
+          StrictTransportSecurity: Match.objectLike({
+            AccessControlMaxAgeSec: 31536000,
+            IncludeSubdomains: true,
+            Preload: true,
+            Override: true,
+          }),
         }),
       }),
     });
@@ -137,6 +144,31 @@ describe('PlatformStack (TASK-023)', () => {
         }),
       }),
     });
+  });
+
+  test('configures API Gateway CORS preflight to CloudFront origin only', () => {
+    const optionsMethods = template.findResources('AWS::ApiGateway::Method', {
+      Properties: {
+        HttpMethod: 'OPTIONS',
+      },
+    });
+
+    expect(Object.keys(optionsMethods).length).toBeGreaterThan(0);
+
+    for (const method of Object.values(optionsMethods) as Array<{ Properties?: unknown }>) {
+      const properties = method.Properties as {
+        Integration?: { IntegrationResponses?: Array<{ ResponseParameters?: Record<string, unknown> }> };
+      };
+      const responseParameters =
+        properties.Integration?.IntegrationResponses?.[0]?.ResponseParameters ?? {};
+      const allowOrigin = responseParameters['method.response.header.Access-Control-Allow-Origin'];
+      const allowMethods = responseParameters['method.response.header.Access-Control-Allow-Methods'];
+
+      expect(allowOrigin).toBeDefined();
+      expect(JSON.stringify(allowOrigin)).toContain('DomainName');
+      expect(JSON.stringify(allowOrigin)).not.toContain("'*'");
+      expect(JSON.stringify(allowMethods)).toContain('OPTIONS');
+    }
   });
 
   test('creates AgentCore Gateway with request and response interceptor wiring', () => {


### PR DESCRIPTION
## Summary
- implement CloudFront SPA response headers policy using `SecurityHeadersConfig` with explicit CSP, `X-Frame-Options: DENY`, and HSTS (`max-age=31536000; includeSubDomains; preload`)
- configure REST API `defaultCorsPreflightOptions` to allow only `https://<SpaDistribution.DomainName>` (no wildcard)
- keep SPA distribution/OAC wiring intact and add CORS + security-header assertions in CDK unit tests

## Files
- infra/cdk/lib/platform-stack.ts
- infra/cdk/test/platform-stack.test.ts

## Validation Evidence
Validated on 2026-03-03 (UTC):
- `npx --no-install tsc --noEmit` (infra/cdk) ✅
- `npx --no-install jest --runInBand test/platform-stack.test.ts` (infra/cdk) ✅
- `make validate-local` ✅
- `make preflight-session` ✅
- `make pre-validate-session` ✅
- `make worktree-push-issue` (enforced preflight + pre-push validation + push) ✅

## Issue Link
Closes #50
