### PR TITLE
TASK-046: Implement async runner job status handler

### DIFF
--- a/src/async_runner/handler.py
+++ b/src/async_runner/handler.py
@@ -1,12 +1,250 @@
 """
 async_runner.handler — Async job tracking Lambda.
 
-Monitors AgentCore Runtime sessions running background tasks.
-Polls /ping for HealthyBusy status and updates JOB records in DynamoDB.
-
-NOTE: This is NOT an SQS consumer. Async work runs inside the Runtime session
-via app.add_async_task / app.complete_async_task (see ADR-010).
+Tracks async AgentCore sessions by polling Runtime /ping and updating JOB records.
+This function is event-driven (not SQS-triggered) and enforces ADR-010 semantics:
+HealthyBusy means work is still running; Healthy means work is complete.
 
 Implemented in TASK-046.
 ADRs: ADR-010
 """
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from typing import Any
+
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from data_access import TenantScopedDynamoDB
+from data_access.models import JobStatus, TenantContext, TenantTier
+
+logger = Logger(service="async-runner")
+tracer = Tracer()
+
+JOBS_TABLE = os.environ.get("JOBS_TABLE", "platform-jobs")
+RUNTIME_PING_URL = os.environ.get("RUNTIME_PING_URL") or os.environ.get("MOCK_RUNTIME_URL")
+RUNTIME_PING_TIMEOUT_SECONDS = float(os.environ.get("RUNTIME_PING_TIMEOUT_SECONDS", "2.0"))
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
+    """Process one async job status poll event."""
+    del context  # Not used by this handler implementation.
+
+    payload = _payload(event)
+
+    try:
+        job_id = _required_str(payload, "jobId")
+        tenant_id = _required_str(payload, "tenantId")
+        app_id = _required_str(payload, "appId")
+        session_id = _required_str(payload, "sessionId")
+        agent_name = _required_str(payload, "agentName")
+    except ValueError as exc:
+        return _error_response(400, "INVALID_REQUEST", str(exc))
+
+    logger.append_keys(
+        tenantid=tenant_id,
+        appid=app_id,
+        jobid=job_id,
+        sessionid=session_id,
+    )
+
+    tier = _tenant_tier(payload.get("tier"))
+    tenant_context = TenantContext(
+        tenant_id=tenant_id,
+        app_id=app_id,
+        tier=tier,
+        sub="async-runner",
+    )
+    db = TenantScopedDynamoDB(tenant_context)
+    key = {"PK": f"JOB#{job_id}", "SK": "METADATA"}
+    job = db.get_item(JOBS_TABLE, key)
+    if job is None:
+        return _error_response(404, "NOT_FOUND", f"Job '{job_id}' not found")
+
+    current_status = str(job.get("status", "pending")).lower()
+    if current_status in {str(JobStatus.COMPLETED), str(JobStatus.FAILED)}:
+        return _response(
+            200,
+            {
+                "jobId": job_id,
+                "status": current_status,
+                "runtimeStatus": None,
+                "checkedAt": _utc_now_iso(),
+            },
+        )
+
+    ping_url = _ping_url(payload.get("runtimePingUrl"))
+    if ping_url is None:
+        return _error_response(503, "SERVICE_UNAVAILABLE", "RUNTIME_PING_URL is not configured")
+
+    headers = {
+        "x-tenant-id": tenant_id,
+        "x-app-id": app_id,
+        "x-session-id": session_id,
+        "x-agent-name": agent_name,
+    }
+
+    try:
+        ping_payload = _http_get_json(
+            ping_url,
+            headers=headers,
+            timeout_seconds=RUNTIME_PING_TIMEOUT_SECONDS,
+        )
+    except urllib.error.URLError:
+        logger.exception("Runtime /ping request failed")
+        return _error_response(
+            502,
+            "BAD_GATEWAY",
+            "Failed to query runtime /ping",
+        )
+    except ValueError as exc:
+        return _error_response(502, "BAD_GATEWAY", str(exc))
+
+    runtime_status = str(ping_payload.get("status", "")).strip()
+    now_iso = _utc_now_iso()
+
+    if runtime_status == "HealthyBusy":
+        _update_running(db, key, now_iso)
+        next_status = str(JobStatus.RUNNING)
+    elif runtime_status == "Healthy":
+        _update_completed(db, key, now_iso)
+        next_status = str(JobStatus.COMPLETED)
+    else:
+        _update_failed(
+            db,
+            key,
+            now_iso,
+            f"Unexpected runtime ping status: {runtime_status or 'empty'}",
+        )
+        next_status = str(JobStatus.FAILED)
+
+    return _response(
+        200,
+        {
+            "jobId": job_id,
+            "status": next_status,
+            "runtimeStatus": runtime_status or None,
+            "checkedAt": now_iso,
+        },
+    )
+
+
+def _update_running(db: TenantScopedDynamoDB, key: dict[str, str], now_iso: str) -> None:
+    db.update_item(
+        JOBS_TABLE,
+        key,
+        update_expression="SET #status = :status, started_at = if_not_exists(started_at, :now)",
+        expression_attribute_values={
+            ":status": str(JobStatus.RUNNING),
+            ":now": now_iso,
+        },
+        expression_attribute_names={"#status": "status"},
+    )
+
+
+def _update_completed(db: TenantScopedDynamoDB, key: dict[str, str], now_iso: str) -> None:
+    db.update_item(
+        JOBS_TABLE,
+        key,
+        update_expression="SET #status = :status, completed_at = :now",
+        expression_attribute_values={
+            ":status": str(JobStatus.COMPLETED),
+            ":now": now_iso,
+        },
+        expression_attribute_names={"#status": "status"},
+    )
+
+
+def _update_failed(
+    db: TenantScopedDynamoDB,
+    key: dict[str, str],
+    now_iso: str,
+    reason: str,
+) -> None:
+    db.update_item(
+        JOBS_TABLE,
+        key,
+        update_expression=(
+            "SET #status = :status, "
+            "completed_at = if_not_exists(completed_at, :now), "
+            "error_message = :reason"
+        ),
+        expression_attribute_values={
+            ":status": str(JobStatus.FAILED),
+            ":now": now_iso,
+            ":reason": reason,
+        },
+        expression_attribute_names={"#status": "status"},
+    )
+
+
+def _http_get_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    request = urllib.request.Request(url=url, headers=headers, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        raw_payload = response.read().decode("utf-8")
+
+    parsed = json.loads(raw_payload) if raw_payload else {}
+    if not isinstance(parsed, dict):
+        raise ValueError("Runtime /ping response must be a JSON object")
+    return parsed
+
+
+def _payload(event: dict[str, Any]) -> dict[str, Any]:
+    detail = event.get("detail")
+    if isinstance(detail, dict):
+        return detail
+    return event
+
+
+def _required_str(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise ValueError(f"{field} is required")
+
+
+def _tenant_tier(raw_tier: Any) -> TenantTier:
+    if raw_tier is None:
+        return TenantTier.BASIC
+    try:
+        return TenantTier(str(raw_tier))
+    except ValueError:
+        logger.warning("Invalid tier supplied in event; defaulting to basic", tier=raw_tier)
+        return TenantTier.BASIC
+
+
+def _ping_url(event_url: Any) -> str | None:
+    base = event_url if isinstance(event_url, str) and event_url.strip() else RUNTIME_PING_URL
+    if not base:
+        return None
+    if base.rstrip("/").endswith("/ping"):
+        return base
+    return f"{base.rstrip('/')}/ping"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _error_response(status_code: int, code: str, message: str) -> dict[str, Any]:
+    return _response(status_code, {"error": {"code": code, "message": message}})

--- a/tests/unit/test_async_runner_handler.py
+++ b/tests/unit/test_async_runner_handler.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+from src.async_runner import handler as async_runner_handler
+
+
+class FakeContext:
+    function_name = "async-runner"
+    memory_limit_in_mb = 256
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:111111111111:function:async-runner"
+    aws_request_id = "req-123"
+
+
+@pytest.fixture
+def aws_credentials() -> None:
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"  # pragma: allowlist secret
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # pragma: allowlist secret
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+    os.environ["AWS_REGION"] = "eu-west-2"
+    os.environ["JOBS_TABLE"] = "platform-jobs"
+    os.environ["RUNTIME_PING_URL"] = "http://runtime.local"
+
+
+@pytest.fixture
+def mock_aws_services(aws_credentials: None) -> None:
+    with mock_aws():
+        yield
+
+
+@pytest.fixture
+def jobs_table(mock_aws_services: None):
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    ddb.create_table(
+        TableName="platform-jobs",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    table = ddb.Table("platform-jobs")
+    table.put_item(
+        Item={
+            "PK": "JOB#job-001",
+            "SK": "METADATA",
+            "job_id": "job-001",
+            "tenant_id": "t-001",
+            "agent_name": "echo-agent",
+            "status": "pending",
+            "created_at": "2026-03-01T00:00:00+00:00",
+            "ttl": 1770000000,
+        }
+    )
+    return table
+
+
+def _event() -> dict[str, str]:
+    return {
+        "jobId": "job-001",
+        "tenantId": "t-001",
+        "appId": "app-001",
+        "agentName": "echo-agent",
+        "sessionId": "sess-001",
+        "runtimePingUrl": "http://runtime.local",
+    }
+
+
+def _body(response: dict[str, object]) -> dict[str, object]:
+    return json.loads(str(response["body"]))
+
+
+def test_handler_marks_job_running_on_healthybusy(jobs_table) -> None:
+    with patch.object(
+        async_runner_handler,
+        "_http_get_json",
+        return_value={"status": "HealthyBusy"},
+    ):
+        response = async_runner_handler.handler(_event(), FakeContext())
+
+    assert response["statusCode"] == 200
+    payload = _body(response)
+    assert payload["status"] == "running"
+    assert payload["runtimeStatus"] == "HealthyBusy"
+
+    item = jobs_table.get_item(Key={"PK": "JOB#job-001", "SK": "METADATA"})["Item"]
+    assert item["status"] == "running"
+    assert "started_at" in item
+
+
+def test_handler_marks_job_completed_on_healthy(jobs_table) -> None:
+    jobs_table.update_item(
+        Key={"PK": "JOB#job-001", "SK": "METADATA"},
+        UpdateExpression="SET #status = :status, started_at = :started",
+        ExpressionAttributeNames={"#status": "status"},
+        ExpressionAttributeValues={
+            ":status": "running",
+            ":started": "2026-03-01T00:01:00+00:00",
+        },
+    )
+
+    with patch.object(async_runner_handler, "_http_get_json", return_value={"status": "Healthy"}):
+        response = async_runner_handler.handler(_event(), FakeContext())
+
+    assert response["statusCode"] == 200
+    payload = _body(response)
+    assert payload["status"] == "completed"
+    assert payload["runtimeStatus"] == "Healthy"
+
+    item = jobs_table.get_item(Key={"PK": "JOB#job-001", "SK": "METADATA"})["Item"]
+    assert item["status"] == "completed"
+    assert "completed_at" in item
+
+
+def test_handler_rejects_missing_required_fields(jobs_table) -> None:
+    del jobs_table
+    response = async_runner_handler.handler({"jobId": "job-001"}, FakeContext())
+    assert response["statusCode"] == 400
+    assert _body(response)["error"]["code"] == "INVALID_REQUEST"


### PR DESCRIPTION
## Summary
- implement `src/async_runner/handler.py` with concrete async job polling logic against Runtime `/ping`
- transition JOB records via `TenantScopedDynamoDB` (`pending -> running` on `HealthyBusy`, `running -> completed` on `Healthy`, unexpected status -> `failed`)
- add unit tests covering HealthyBusy transition, completion transition, and request validation

## Validation Evidence
- `uv run ruff check src/async_runner/handler.py tests/unit/test_async_runner_handler.py` ✅
- `uv run ruff format --check src/async_runner/handler.py tests/unit/test_async_runner_handler.py` ✅
- `uv run pytest -q tests/unit/test_async_runner_handler.py` ✅ (3 passed)
- `make preflight-session` ✅
- `make pre-validate-session` ✅
- git pre-push hook (`make validate-pre-push`) ✅

Closes #53
