### PR TITLE
TASK-098: make TenantStack id tenant-aware when tenantId is set

### DIFF
--- a/infra/cdk/bin/app.ts
+++ b/infra/cdk/bin/app.ts
@@ -62,13 +62,17 @@ const platformStack = new PlatformStack(app, `platform-core-${env}`, {
   platformConfigKey: identityStack.platformConfigKey,
 });
 
-// 4. TenantStack (stub — real deployments triggered by EventBridge)
-const tenantIdStub = app.node.tryGetContext('tenantId') || 'stub';
-const tierStub = app.node.tryGetContext('tier') || 'basic';
+// 4. TenantStack (real deployments triggered by EventBridge per-tenant)
+const tenantId = app.node.tryGetContext('tenantId');
+const stackId = tenantId
+  ? `platform-tenant-${tenantId}-${env}`
+  : `platform-tenant-stub-${env}`;
 
-new TenantStack(app, `platform-tenant-stub-${env}`, {
+new TenantStack(app, stackId, {
   env: awsEnv,
-  description: `Platform per-tenant resources stub — ${env}`,
+  description: tenantId
+    ? `Platform resources for tenant ${tenantId} — ${env}`
+    : `Platform per-tenant resources stub — ${env}`,
 });
 
 // 5. ObservabilityStack


### PR DESCRIPTION
## Summary
- update CDK app entrypoint to use a tenant-aware TenantStack id when `tenantId` context is present
- keep existing stub stack id behavior when `tenantId` is absent
- update stack description to reflect tenant-specific vs stub deployment

## Validation
- npx --no-install tsc --noEmit (infra/cdk)
- npx --no-install cdk synth --context env=dev --quiet (infra/cdk)

Closes #98
