### PR TITLE
TASK-036: complete gateway request interceptor behavior and tests

### DIFF
--- a/gateway/interceptors/request_interceptor.py
+++ b/gateway/interceptors/request_interceptor.py
@@ -175,6 +175,15 @@ def _is_tier_allowed(tenant_tier: str, minimum_tier: str) -> bool:
     return tenant_rank >= minimum_rank
 
 
+def _extract_minimum_tier(tool_record: dict[str, Any]) -> str:
+    minimum = tool_record.get("tierMinimum")
+    if minimum is None:
+        minimum = tool_record.get("tier_minimum")
+    if minimum is None:
+        return "basic"
+    return str(minimum)
+
+
 def get_tool_record(tool_name: str, tenant_id: str) -> dict[str, Any] | None:
     """Fetch tenant-specific tool first, then global."""
     table = get_dynamodb().Table(TOOLS_TABLE)
@@ -403,7 +412,7 @@ def _process_request(event: dict[str, Any]) -> dict[str, Any]:
                 message="Tool is unavailable for this tenant",
             )
 
-        minimum_tier = str(tool_record.get("tier_minimum") or "basic")
+        minimum_tier = _extract_minimum_tier(tool_record)
         if not _is_tier_allowed(tier, minimum_tier):
             return _error_response(
                 gateway_request=gateway_request,

--- a/tests/integration/fixtures/request_interceptor_gateway_event.json
+++ b/tests/integration/fixtures/request_interceptor_gateway_event.json
@@ -1,0 +1,15 @@
+{
+  "interceptorInputVersion": "1.0",
+  "mcp": {
+    "gatewayRequest": {
+      "path": "/mcp",
+      "httpMethod": "POST",
+      "headers": {
+        "Authorization": "Bearer original.user.token",
+        "Mcp-Session-Id": "mcp-session-123",
+        "Content-Type": "application/json"
+      },
+      "body": "{\"jsonrpc\":\"2.0\",\"id\":\"rpc-42\",\"method\":\"tools/call\",\"params\":{\"name\":\"echo\",\"arguments\":{\"text\":\"hello world\"}}}"
+    }
+  }
+}

--- a/tests/integration/test_request_interceptor_integration.py
+++ b/tests/integration/test_request_interceptor_integration.py
@@ -1,0 +1,74 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gateway.interceptors import request_interceptor
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent / "fixtures" / "request_interceptor_gateway_event.json"
+)
+OS_ENV = {
+    "AWS_REGION": "eu-west-2",
+    "ENTRA_JWKS_URL": "http://localhost:8766/.well-known/jwks.json",
+    "ENTRA_AUDIENCE": "api://platform-local",
+    "ENTRA_ISSUER": "http://localhost:8766",
+    "TOOLS_TABLE": "platform-tools-dev",
+    "SCOPED_TOKEN_SIGNING_KEY": "unit-test-signing-key-with-32-bytes-minimum",
+    "SCOPED_TOKEN_ISSUER": "platform-gateway",
+}
+
+
+class MockContext:
+    function_name = "request-interceptor"
+    memory_limit_in_mb = 128
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:000000000000:function:request-interceptor"
+    aws_request_id = "request-id"
+
+
+def test_request_interceptor_gateway_event_fixture_roundtrip():
+    event = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload = {
+        "tenantid": "t-basic-001",
+        "appid": "platform-local",
+        "tier": "basic",
+        "sub": "user-123",
+        "iss": OS_ENV["ENTRA_ISSUER"],
+        "aud": OS_ENV["ENTRA_AUDIENCE"],
+    }
+    mock_jwk_client = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with (
+        patch.dict(os.environ, OS_ENV, clear=False),
+        patch("gateway.interceptors.request_interceptor.ENTRA_JWKS_URL", OS_ENV["ENTRA_JWKS_URL"]),
+        patch("gateway.interceptors.request_interceptor.ENTRA_AUDIENCE", OS_ENV["ENTRA_AUDIENCE"]),
+        patch("gateway.interceptors.request_interceptor.ENTRA_ISSUER", OS_ENV["ENTRA_ISSUER"]),
+        patch(
+            "gateway.interceptors.request_interceptor.SCOPED_TOKEN_ISSUER",
+            OS_ENV["SCOPED_TOKEN_ISSUER"],
+        ),
+        patch(
+            "gateway.interceptors.request_interceptor.get_jwk_client",
+            return_value=mock_jwk_client,
+        ),
+        patch(
+            "gateway.interceptors.request_interceptor.get_tool_record",
+            return_value={"tool_name": "echo", "tierMinimum": "basic", "enabled": True},
+        ),
+        patch("jwt.decode", return_value=payload),
+    ):
+        result = request_interceptor.handler(event, MockContext())
+
+    transformed_request = result["mcp"]["transformedGatewayRequest"]
+    headers = transformed_request["headers"]
+
+    assert transformed_request["body"]["id"] == "rpc-42"
+    assert transformed_request["body"]["params"]["name"] == "echo"
+    assert headers["x-tenant-id"] == "t-basic-001"
+    assert headers["x-app-id"] == "platform-local"
+    assert headers["x-tier"] == "basic"
+    assert headers["x-acting-sub"] == "user-123"
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers["Authorization"] != "Bearer original.user.token"

--- a/tests/unit/test_request_interceptor.py
+++ b/tests/unit/test_request_interceptor.py
@@ -83,13 +83,8 @@ def _base_event() -> dict:
     }
 
 
-@patch("gateway.interceptors.request_interceptor.get_jwk_client")
-@patch("gateway.interceptors.request_interceptor.get_tool_record")
-def test_request_interceptor_enforces_tier(
-    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
-):
-    event = _base_event()
-    payload = {
+def _valid_payload() -> dict:
+    return {
         "tenantid": "t-basic-001",
         "appid": "platform-local",
         "tier": "basic",
@@ -97,6 +92,15 @@ def test_request_interceptor_enforces_tier(
         "iss": OS_ENV["ENTRA_ISSUER"],
         "aud": OS_ENV["ENTRA_AUDIENCE"],
     }
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+@patch("gateway.interceptors.request_interceptor.get_tool_record")
+def test_request_interceptor_enforces_tier(
+    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
+):
+    event = _base_event()
+    payload = _valid_payload()
     mock_get_tool_record.return_value = {
         "tool_name": "echo",
         "tier_minimum": "premium",
@@ -121,14 +125,7 @@ def test_request_interceptor_issues_scoped_token_and_headers(
     mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
 ):
     event = _base_event()
-    payload = {
-        "tenantid": "t-basic-001",
-        "appid": "platform-local",
-        "tier": "basic",
-        "sub": "user-123",
-        "iss": OS_ENV["ENTRA_ISSUER"],
-        "aud": OS_ENV["ENTRA_AUDIENCE"],
-    }
+    payload = _valid_payload()
     mock_get_tool_record.return_value = {
         "tool_name": "echo",
         "tier_minimum": "basic",
@@ -167,3 +164,74 @@ def test_request_interceptor_issues_scoped_token_and_headers(
     assert scoped_claims["aud"] == "tool:echo"
     assert scoped_claims["exp"] > scoped_claims["iat"]
     assert scoped_claims["exp"] - scoped_claims["iat"] <= 300
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+def test_request_interceptor_rejects_invalid_jwt(mock_get_jwk_client, mock_env, lambda_context):
+    event = _base_event()
+    mock_get_jwk_client.return_value = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with patch("jwt.decode", side_effect=jwt.InvalidTokenError("bad token")):
+        result = request_interceptor.handler(event, lambda_context)
+
+    response = result["mcp"]["transformedGatewayResponse"]
+    assert response["statusCode"] == 401
+    assert response["body"]["error"]["message"] == "Bearer token validation failed"
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+@patch("gateway.interceptors.request_interceptor.get_tool_record")
+def test_request_interceptor_enforces_tier_minimum_camel_case(
+    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
+):
+    event = _base_event()
+    mock_get_tool_record.return_value = {
+        "tool_name": "echo",
+        "tierMinimum": "premium",
+        "enabled": True,
+    }
+    mock_get_jwk_client.return_value = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with patch("jwt.decode", return_value=_valid_payload()):
+        result = request_interceptor.handler(event, lambda_context)
+
+    response = result["mcp"]["transformedGatewayResponse"]
+    assert response["statusCode"] == 403
+    assert response["body"]["error"]["message"] == "Tenant tier is insufficient for this tool"
+
+
+def test_request_interceptor_uses_idempotency_key_for_duplicates(lambda_context):
+    event = _base_event()
+    seen_keys: list[str] = []
+    cache: dict[str, dict] = {}
+
+    def fake_idempotency_handler(
+        *, idempotency_data: dict[str, str], interceptor_event: dict
+    ) -> dict:
+        key = idempotency_data["idempotency_key"]
+        seen_keys.append(key)
+        if key not in cache:
+            cache[key] = request_interceptor._process_request(interceptor_event)
+        return cache[key]
+
+    with (
+        patch(
+            "gateway.interceptors.request_interceptor._get_idempotency_handler",
+            return_value=fake_idempotency_handler,
+        ),
+        patch(
+            "gateway.interceptors.request_interceptor._process_request",
+            return_value={"result": "ok"},
+        ) as mock_process,
+    ):
+        first = request_interceptor.handler(event, lambda_context)
+        second = request_interceptor.handler(event, lambda_context)
+
+    assert first == {"result": "ok"}
+    assert second == {"result": "ok"}
+    assert seen_keys == ["mcp-session-123:rpc-1", "mcp-session-123:rpc-1"]
+    mock_process.assert_called_once_with(event)


### PR DESCRIPTION
## Summary
- support both `tierMinimum` and `tier_minimum` when enforcing tool tier access in the request interceptor
- add unit coverage for invalid JWT handling, camelCase tier policy enforcement, and duplicate idempotency key behavior (`Mcp-Session-Id + body.id`)
- add integration test using a gateway event fixture to verify end-to-end request transformation and required header/token injection

## Validation Evidence
- `make preflight-session` (PASS)
- `PYTHONPATH=. uv run pytest -q tests/unit/test_request_interceptor.py tests/integration/test_request_interceptor_integration.py` (PASS: `6 passed`)
- `make test-int` (PASS: `1 passed`)
- `PYTEST_ADDOPTS=--import-mode=importlib make test-unit` (PASS: `224 passed`)
- `make validate-local` (PASS)
- `make pre-validate-session` (PASS)

## Notes
- plain `make test-unit` in this workspace currently hits a pytest package import-mode collision (`tests.test_client`) unless `--import-mode=importlib` is set; suite itself passes with importlib mode.

Closes #43
