### PR TITLE
TASK-036: complete gateway request interceptor behavior and tests

### DIFF
--- a/gateway/interceptors/request_interceptor.py
+++ b/gateway/interceptors/request_interceptor.py
@@ -175,6 +175,15 @@ def _is_tier_allowed(tenant_tier: str, minimum_tier: str) -> bool:
     return tenant_rank >= minimum_rank
 
 
+def _extract_minimum_tier(tool_record: dict[str, Any]) -> str:
+    minimum = tool_record.get("tierMinimum")
+    if minimum is None:
+        minimum = tool_record.get("tier_minimum")
+    if minimum is None:
+        return "basic"
+    return str(minimum)
+
+
 def get_tool_record(tool_name: str, tenant_id: str) -> dict[str, Any] | None:
     """Fetch tenant-specific tool first, then global."""
     table = get_dynamodb().Table(TOOLS_TABLE)
@@ -403,7 +412,7 @@ def _process_request(event: dict[str, Any]) -> dict[str, Any]:
                 message="Tool is unavailable for this tenant",
             )
 
-        minimum_tier = str(tool_record.get("tier_minimum") or "basic")
+        minimum_tier = _extract_minimum_tier(tool_record)
         if not _is_tier_allowed(tier, minimum_tier):
             return _error_response(
                 gateway_request=gateway_request,

--- a/tests/integration/fixtures/request_interceptor_gateway_event.json
+++ b/tests/integration/fixtures/request_interceptor_gateway_event.json
@@ -1,0 +1,15 @@
+{
+  "interceptorInputVersion": "1.0",
+  "mcp": {
+    "gatewayRequest": {
+      "path": "/mcp",
+      "httpMethod": "POST",
+      "headers": {
+        "Authorization": "Bearer original.user.token",
+        "Mcp-Session-Id": "mcp-session-123",
+        "Content-Type": "application/json"
+      },
+      "body": "{\"jsonrpc\":\"2.0\",\"id\":\"rpc-42\",\"method\":\"tools/call\",\"params\":{\"name\":\"echo\",\"arguments\":{\"text\":\"hello world\"}}}"
+    }
+  }
+}

--- a/tests/integration/test_request_interceptor_integration.py
+++ b/tests/integration/test_request_interceptor_integration.py
@@ -1,0 +1,74 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gateway.interceptors import request_interceptor
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent / "fixtures" / "request_interceptor_gateway_event.json"
+)
+OS_ENV = {
+    "AWS_REGION": "eu-west-2",
+    "ENTRA_JWKS_URL": "http://localhost:8766/.well-known/jwks.json",
+    "ENTRA_AUDIENCE": "api://platform-local",
+    "ENTRA_ISSUER": "http://localhost:8766",
+    "TOOLS_TABLE": "platform-tools-dev",
+    "SCOPED_TOKEN_SIGNING_KEY": "unit-test-signing-key-with-32-bytes-minimum",
+    "SCOPED_TOKEN_ISSUER": "platform-gateway",
+}
+
+
+class MockContext:
+    function_name = "request-interceptor"
+    memory_limit_in_mb = 128
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:000000000000:function:request-interceptor"
+    aws_request_id = "request-id"
+
+
+def test_request_interceptor_gateway_event_fixture_roundtrip():
+    event = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload = {
+        "tenantid": "t-basic-001",
+        "appid": "platform-local",
+        "tier": "basic",
+        "sub": "user-123",
+        "iss": OS_ENV["ENTRA_ISSUER"],
+        "aud": OS_ENV["ENTRA_AUDIENCE"],
+    }
+    mock_jwk_client = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with (
+        patch.dict(os.environ, OS_ENV, clear=False),
+        patch("gateway.interceptors.request_interceptor.ENTRA_JWKS_URL", OS_ENV["ENTRA_JWKS_URL"]),
+        patch("gateway.interceptors.request_interceptor.ENTRA_AUDIENCE", OS_ENV["ENTRA_AUDIENCE"]),
+        patch("gateway.interceptors.request_interceptor.ENTRA_ISSUER", OS_ENV["ENTRA_ISSUER"]),
+        patch(
+            "gateway.interceptors.request_interceptor.SCOPED_TOKEN_ISSUER",
+            OS_ENV["SCOPED_TOKEN_ISSUER"],
+        ),
+        patch(
+            "gateway.interceptors.request_interceptor.get_jwk_client",
+            return_value=mock_jwk_client,
+        ),
+        patch(
+            "gateway.interceptors.request_interceptor.get_tool_record",
+            return_value={"tool_name": "echo", "tierMinimum": "basic", "enabled": True},
+        ),
+        patch("jwt.decode", return_value=payload),
+    ):
+        result = request_interceptor.handler(event, MockContext())
+
+    transformed_request = result["mcp"]["transformedGatewayRequest"]
+    headers = transformed_request["headers"]
+
+    assert transformed_request["body"]["id"] == "rpc-42"
+    assert transformed_request["body"]["params"]["name"] == "echo"
+    assert headers["x-tenant-id"] == "t-basic-001"
+    assert headers["x-app-id"] == "platform-local"
+    assert headers["x-tier"] == "basic"
+    assert headers["x-acting-sub"] == "user-123"
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers["Authorization"] != "Bearer original.user.token"

--- a/tests/unit/test_request_interceptor.py
+++ b/tests/unit/test_request_interceptor.py
@@ -83,13 +83,8 @@ def _base_event() -> dict:
     }
 
 
-@patch("gateway.interceptors.request_interceptor.get_jwk_client")
-@patch("gateway.interceptors.request_interceptor.get_tool_record")
-def test_request_interceptor_enforces_tier(
-    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
-):
-    event = _base_event()
-    payload = {
+def _valid_payload() -> dict:
+    return {
         "tenantid": "t-basic-001",
         "appid": "platform-local",
         "tier": "basic",
@@ -97,6 +92,15 @@ def test_request_interceptor_enforces_tier(
         "iss": OS_ENV["ENTRA_ISSUER"],
         "aud": OS_ENV["ENTRA_AUDIENCE"],
     }
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+@patch("gateway.interceptors.request_interceptor.get_tool_record")
+def test_request_interceptor_enforces_tier(
+    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
+):
+    event = _base_event()
+    payload = _valid_payload()
     mock_get_tool_record.return_value = {
         "tool_name": "echo",
         "tier_minimum": "premium",
@@ -121,14 +125,7 @@ def test_request_interceptor_issues_scoped_token_and_headers(
     mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
 ):
     event = _base_event()
-    payload = {
-        "tenantid": "t-basic-001",
-        "appid": "platform-local",
-        "tier": "basic",
-        "sub": "user-123",
-        "iss": OS_ENV["ENTRA_ISSUER"],
-        "aud": OS_ENV["ENTRA_AUDIENCE"],
-    }
+    payload = _valid_payload()
     mock_get_tool_record.return_value = {
         "tool_name": "echo",
         "tier_minimum": "basic",
@@ -167,3 +164,74 @@ def test_request_interceptor_issues_scoped_token_and_headers(
     assert scoped_claims["aud"] == "tool:echo"
     assert scoped_claims["exp"] > scoped_claims["iat"]
     assert scoped_claims["exp"] - scoped_claims["iat"] <= 300
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+def test_request_interceptor_rejects_invalid_jwt(mock_get_jwk_client, mock_env, lambda_context):
+    event = _base_event()
+    mock_get_jwk_client.return_value = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with patch("jwt.decode", side_effect=jwt.InvalidTokenError("bad token")):
+        result = request_interceptor.handler(event, lambda_context)
+
+    response = result["mcp"]["transformedGatewayResponse"]
+    assert response["statusCode"] == 401
+    assert response["body"]["error"]["message"] == "Bearer token validation failed"
+
+
+@patch("gateway.interceptors.request_interceptor.get_jwk_client")
+@patch("gateway.interceptors.request_interceptor.get_tool_record")
+def test_request_interceptor_enforces_tier_minimum_camel_case(
+    mock_get_tool_record, mock_get_jwk_client, mock_env, lambda_context
+):
+    event = _base_event()
+    mock_get_tool_record.return_value = {
+        "tool_name": "echo",
+        "tierMinimum": "premium",
+        "enabled": True,
+    }
+    mock_get_jwk_client.return_value = MagicMock(
+        get_signing_key_from_jwt=MagicMock(return_value=MagicMock(key="pub-key"))
+    )
+
+    with patch("jwt.decode", return_value=_valid_payload()):
+        result = request_interceptor.handler(event, lambda_context)
+
+    response = result["mcp"]["transformedGatewayResponse"]
+    assert response["statusCode"] == 403
+    assert response["body"]["error"]["message"] == "Tenant tier is insufficient for this tool"
+
+
+def test_request_interceptor_uses_idempotency_key_for_duplicates(lambda_context):
+    event = _base_event()
+    seen_keys: list[str] = []
+    cache: dict[str, dict] = {}
+
+    def fake_idempotency_handler(
+        *, idempotency_data: dict[str, str], interceptor_event: dict
+    ) -> dict:
+        key = idempotency_data["idempotency_key"]
+        seen_keys.append(key)
+        if key not in cache:
+            cache[key] = request_interceptor._process_request(interceptor_event)
+        return cache[key]
+
+    with (
+        patch(
+            "gateway.interceptors.request_interceptor._get_idempotency_handler",
+            return_value=fake_idempotency_handler,
+        ),
+        patch(
+            "gateway.interceptors.request_interceptor._process_request",
+            return_value={"result": "ok"},
+        ) as mock_process,
+    ):
+        first = request_interceptor.handler(event, lambda_context)
+        second = request_interceptor.handler(event, lambda_context)
+
+    assert first == {"result": "ok"}
+    assert second == {"result": "ok"}
+    assert seen_keys == ["mcp-session-123:rpc-1", "mcp-session-123:rpc-1"]
+    mock_process.assert_called_once_with(event)


### PR DESCRIPTION
## Summary\n- support both  and  when enforcing tool tier access in the request interceptor\n- add unit coverage for invalid JWT handling, camelCase tier policy enforcement, and duplicate idempotency key behavior ()\n- add integration test using a gateway event fixture to verify end-to-end request transformation and required header/token injection\n\n## Validation Evidence\n- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt43'
uv run python scripts/worktree_issues.py preflight
Preflight context:
  repo:     /mnt/c/Users/julia/worktrees/wt43
  path:     /mnt/c/Users/julia/worktrees/wt43
  worktree: /mnt/c/Users/julia/worktrees/wt43
  primary:  /mnt/c/Users/julia/tf-acore-aas
  branch:   wt/task/43-write-gateway-interceptors-request-interceptor-py
Preflight result: PASS
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt43' (PASS)\n- ......                                                                   [100%]
6 passed in 49.32s (PASS: )\n- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt43'
PYTHONPATH=. uv run pytest tests/integration/ -v --tb=short
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /mnt/c/Users/julia/worktrees/wt43/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/c/Users/julia/worktrees/wt43
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0
collecting ... collected 1 item

tests/integration/test_request_interceptor_integration.py::test_request_interceptor_gateway_event_fixture_roundtrip PASSED [100%]

============================== 1 passed in 46.85s ==============================
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt43' (PASS: )\n- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt43'
PYTHONPATH=. uv run pytest tests/unit/ src/ -v --tb=short
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /mnt/c/Users/julia/worktrees/wt43/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/c/Users/julia/worktrees/wt43
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0
collecting ... collected 224 items

tests/unit/test_authoriser.py::test_generate_policy PASSED               [  0%]
tests/unit/test_authoriser.py::test_handler_missing_auth PASSED          [  0%]
tests/unit/test_authoriser.py::test_handler_valid_jwt PASSED             [  1%]
tests/unit/test_authoriser.py::test_handler_suspended_tenant PASSED      [  1%]
tests/unit/test_authoriser.py::test_handler_admin_route_unauthorised PASSED [  2%]
tests/unit/test_authoriser.py::test_handler_admin_route_authorised PASSED [  2%]
tests/unit/test_authoriser.py::test_handler_jwk_client_missing PASSED    [  3%]
tests/unit/test_authoriser.py::test_handler_sigv4_stub PASSED            [  3%]
tests/unit/test_authoriser.py::test_handler_expired_token PASSED         [  4%]
tests/unit/test_authoriser.py::test_handler_invalid_token PASSED         [  4%]
tests/unit/test_authoriser.py::test_handler_tenant_not_found PASSED      [  4%]
tests/unit/test_authoriser.py::test_handler_token_authoriser_fallback PASSED [  5%]
tests/unit/test_authoriser.py::test_get_jwk_client_logic PASSED          [  5%]
tests/unit/test_authoriser.py::test_get_dynamodb_logic PASSED            [  6%]
tests/unit/test_authoriser.py::test_get_tenant_status_no_table PASSED    [  6%]
tests/unit/test_authoriser.py::test_handler_unexpected_error PASSED      [  7%]
tests/unit/test_authoriser.py::test_get_tenant_status_error PASSED       [  7%]
tests/unit/test_bootstrap.py::test_parse_args_supports_first_deploy_step PASSED [  8%]
tests/unit/test_bootstrap.py::test_upsert_secret_create_then_update PASSED [  8%]
tests/unit/test_bootstrap.py::test_report_roundtrip_s3 PASSED            [  8%]
tests/unit/test_bootstrap.py::test_execute_step_failure_is_recorded PASSED [  9%]
tests/unit/test_bridge_handler.py::test_handler_sync_success PASSED      [  9%]
tests/unit/test_bridge_handler.py::test_handler_tier_insufficient PASSED [ 10%]
tests/unit/test_bridge_handler.py::test_handler_agent_not_found PASSED   [ 10%]
tests/unit/test_bridge_handler.py::test_handler_async_accepted PASSED    [ 11%]
tests/unit/test_bridge_handler.py::test_handler_streaming PASSED         [ 11%]
tests/unit/test_dev_bootstrap.py::test_ensure_tables_creates_all_tables PASSED [ 12%]
tests/unit/test_dev_bootstrap.py::test_ensure_tables_is_idempotent PASSED [ 12%]
tests/unit/test_dev_bootstrap.py::test_seed_tenants_creates_two_records PASSED [ 12%]
tests/unit/test_dev_bootstrap.py::test_seed_tenants_correct_tiers PASSED [ 13%]
tests/unit/test_dev_bootstrap.py::test_seed_tenants_both_active PASSED   [ 13%]
tests/unit/test_dev_bootstrap.py::test_seed_tenants_idempotent_no_duplicates PASSED [ 14%]
tests/unit/test_dev_bootstrap.py::test_seed_agents_creates_echo_agent PASSED [ 14%]
tests/unit/test_dev_bootstrap.py::test_seed_agents_idempotent_no_duplicates PASSED [ 15%]
tests/unit/test_dev_bootstrap.py::test_seed_tools_creates_echo_tool PASSED [ 15%]
tests/unit/test_dev_bootstrap.py::test_seed_tools_idempotent_no_duplicates PASSED [ 16%]
tests/unit/test_dev_bootstrap.py::test_seed_ssm_runtime_region PASSED    [ 16%]
tests/unit/test_dev_bootstrap.py::test_seed_ssm_jwks_url PASSED          [ 16%]
tests/unit/test_dev_bootstrap.py::test_seed_ssm_api_audience PASSED      [ 17%]
tests/unit/test_dev_bootstrap.py::test_seed_ssm_pii_patterns_is_valid_json PASSED [ 17%]
tests/unit/test_dev_bootstrap.py::test_seed_ssm_idempotent PASSED        [ 18%]
tests/unit/test_dev_bootstrap.py::test_fetch_jwts_returns_empty_when_service_unavailable PASSED [ 18%]
tests/unit/test_dev_bootstrap.py::test_fetch_jwts_returns_three_tokens_when_service_available PASSED [ 19%]
tests/unit/test_dev_bootstrap.py::test_write_env_test_with_tokens PASSED [ 19%]
tests/unit/test_dev_bootstrap.py::test_write_env_test_without_tokens_writes_empty_values PASSED [ 20%]
tests/unit/test_dev_bootstrap.py::test_write_env_test_is_idempotent PASSED [ 20%]
tests/unit/test_dev_bootstrap.py::test_run_bootstrap_full_first_run PASSED [ 20%]
tests/unit/test_dev_bootstrap.py::test_run_bootstrap_twice_no_duplicate_records PASSED [ 21%]
tests/unit/test_failover_lock.py::test_parse_args_for_acquire_and_release PASSED [ 21%]
tests/unit/test_failover_lock.py::test_acquire_lock_writes_expected_record PASSED [ 22%]
tests/unit/test_failover_lock.py::test_concurrent_acquire_only_one_succeeds PASSED [ 22%]
tests/unit/test_failover_lock.py::test_release_requires_matching_lock_id_when_provided PASSED [ 23%]
tests/unit/test_failover_lock.py::test_cli_acquire_then_release_uses_local_token PASSED [ 23%]
tests/unit/test_hash_layer.py::test_same_deps_same_order_gives_same_hash PASSED [ 24%]
tests/unit/test_hash_layer.py::test_order_invariant PASSED               [ 24%]
tests/unit/test_hash_layer.py::test_whitespace_invariant PASSED          [ 25%]
tests/unit/test_hash_layer.py::test_different_deps_different_hash PASSED [ 25%]
tests/unit/test_hash_layer.py::test_hash_length_is_16_chars PASSED       [ 25%]
tests/unit/test_hash_layer.py::test_empty_deps_returns_hash PASSED       [ 26%]
tests/unit/test_hash_layer.py::test_read_agent_deps_echo_agent PASSED    [ 26%]
tests/unit/test_hash_layer.py::test_read_agent_deps_missing_agent PASSED [ 27%]
tests/unit/test_hash_layer.py::test_get_ssm_hash_returns_none_when_parameter_absent PASSED [ 27%]
tests/unit/test_hash_layer.py::test_get_ssm_hash_returns_stored_value PASSED [ 28%]
tests/unit/test_hash_layer.py::test_run_returns_1_when_no_ssm_parameter PASSED [ 28%]
tests/unit/test_hash_layer.py::test_run_returns_0_when_hash_matches PASSED [ 29%]
tests/unit/test_hash_layer.py::test_run_returns_1_when_hash_mismatches PASSED [ 29%]
tests/unit/test_hash_layer.py::test_run_returns_1_when_aws_region_missing PASSED [ 29%]
tests/unit/test_hash_layer.py::test_parse_args_positional_and_env PASSED [ 30%]
tests/unit/test_hash_layer.py::test_parse_args_rejects_invalid_env PASSED [ 30%]
tests/unit/test_models.py::TestTtlConstants::test_invocation_ttl_is_90_days PASSED [ 31%]
tests/unit/test_models.py::TestTtlConstants::test_job_ttl_is_7_days PASSED [ 31%]
tests/unit/test_models.py::TestTtlConstants::test_session_ttl_is_24_hours PASSED [ 32%]
tests/unit/test_models.py::TestTtlConstants::test_ops_lock_ttl_is_5_minutes PASSED [ 32%]
tests/unit/test_models.py::TestTtlConstants::test_jitter_length_is_2 PASSED [ 33%]
tests/unit/test_models.py::TestTenantRecord::test_pk_format PASSED       [ 33%]
tests/unit/test_models.py::TestTenantRecord::test_sk_is_metadata PASSED  [ 33%]
tests/unit/test_models.py::TestTenantRecord::test_pk_starts_with_tenant_prefix PASSED [ 34%]
tests/unit/test_models.py::TestTenantRecord::test_optional_fields_default_none PASSED [ 34%]
tests/unit/test_models.py::TestTenantRecord::test_optional_fields_accept_values PASSED [ 35%]
tests/unit/test_models.py::TestTenantRecord::test_frozen PASSED          [ 35%]
tests/unit/test_models.py::TestTenantRecord::test_tier_enum_rejects_invalid PASSED [ 36%]
tests/unit/test_models.py::TestTenantRecord::test_status_enum_rejects_invalid PASSED [ 36%]
tests/unit/test_models.py::TestTenantRecord::test_all_tiers_accepted PASSED [ 37%]
tests/unit/test_models.py::TestTenantRecord::test_all_statuses_accepted PASSED [ 37%]
tests/unit/test_models.py::TestAgentRecord::test_pk_format PASSED        [ 37%]
tests/unit/test_models.py::TestAgentRecord::test_sk_format PASSED        [ 38%]
tests/unit/test_models.py::TestAgentRecord::test_pk_starts_with_agent_prefix PASSED [ 38%]
tests/unit/test_models.py::TestAgentRecord::test_sk_starts_with_version_prefix PASSED [ 39%]
tests/unit/test_models.py::TestAgentRecord::test_optional_fields_default_none PASSED [ 39%]
tests/unit/test_models.py::TestAgentRecord::test_all_invocation_modes_accepted PASSED [ 40%]
tests/unit/test_models.py::TestAgentRecord::test_frozen PASSED           [ 40%]
tests/unit/test_models.py::TestInvocationRecord::test_pk_format PASSED   [ 41%]
tests/unit/test_models.py::TestInvocationRecord::test_sk_format_without_jitter PASSED [ 41%]
tests/unit/test_models.py::TestInvocationRecord::test_sk_format_with_jitter PASSED [ 41%]
tests/unit/test_models.py::TestInvocationRecord::test_sk_starts_with_inv_prefix PASSED [ 42%]
tests/unit/test_models.py::TestInvocationRecord::test_jitter_must_be_two_chars PASSED [ 42%]
tests/unit/test_models.py::TestInvocationRecord::test_jitter_exactly_two_chars_accepted PASSED [ 43%]
tests/unit/test_models.py::TestInvocationRecord::test_jitter_none_accepted PASSED [ 43%]
tests/unit/test_models.py::TestInvocationRecord::test_optional_fields_default PASSED [ 44%]
tests/unit/test_models.py::TestInvocationRecord::test_all_invocation_statuses_accepted PASSED [ 44%]
tests/unit/test_models.py::TestInvocationRecord::test_frozen PASSED      [ 45%]
tests/unit/test_models.py::TestJobRecord::test_pk_format PASSED          [ 45%]
tests/unit/test_models.py::TestJobRecord::test_sk_is_metadata PASSED     [ 45%]
tests/unit/test_models.py::TestJobRecord::test_pk_starts_with_job_prefix PASSED [ 46%]
tests/unit/test_models.py::TestJobRecord::test_optional_fields_default PASSED [ 46%]
tests/unit/test_models.py::TestJobRecord::test_all_job_statuses_accepted PASSED [ 47%]
tests/unit/test_models.py::TestJobRecord::test_frozen PASSED             [ 47%]
tests/unit/test_models.py::TestSessionRecord::test_pk_format PASSED      [ 48%]
tests/unit/test_models.py::TestSessionRecord::test_sk_format PASSED      [ 48%]
tests/unit/test_models.py::TestSessionRecord::test_pk_starts_with_tenant_prefix PASSED [ 49%]
tests/unit/test_models.py::TestSessionRecord::test_sk_starts_with_session_prefix PASSED [ 49%]
tests/unit/test_models.py::TestSessionRecord::test_all_session_statuses_accepted PASSED [ 50%]
tests/unit/test_models.py::TestSessionRecord::test_frozen PASSED         [ 50%]
tests/unit/test_models.py::TestToolRecord::test_pk_format PASSED         [ 50%]
tests/unit/test_models.py::TestToolRecord::test_sk_global_when_no_tenant PASSED [ 51%]
tests/unit/test_models.py::TestToolRecord::test_sk_tenant_scoped_when_tenant_set PASSED [ 51%]
tests/unit/test_models.py::TestToolRecord::test_pk_starts_with_tool_prefix PASSED [ 52%]
tests/unit/test_models.py::TestToolRecord::test_global_tool_tenant_id_is_none PASSED [ 52%]
tests/unit/test_models.py::TestToolRecord::test_all_tier_minimums_accepted PASSED [ 53%]
tests/unit/test_models.py::TestToolRecord::test_frozen PASSED            [ 53%]
tests/unit/test_models.py::TestOpsLockRecord::test_pk_format PASSED      [ 54%]
tests/unit/test_models.py::TestOpsLockRecord::test_sk_is_metadata PASSED [ 54%]
tests/unit/test_models.py::TestOpsLockRecord::test_pk_starts_with_lock_prefix PASSED [ 54%]
tests/unit/test_models.py::TestOpsLockRecord::test_ttl_is_approximately_5_minutes_from_now PASSED [ 55%]
tests/unit/test_models.py::TestOpsLockRecord::test_frozen PASSED         [ 55%]
tests/unit/test_models.py::TestKeyPrefixUniqueness::test_pk_prefixes_are_unique PASSED [ 56%]
tests/unit/test_models.py::TestKeyPrefixUniqueness::test_tenant_records_share_pk_prefix_by_design PASSED [ 56%]
tests/unit/test_ops_api.py::test_ops_top_tenants PASSED                  [ 57%]
tests/unit/test_ops_api.py::test_ops_security_events PASSED              [ 57%]
tests/unit/test_ops_api.py::test_ops_error_rate PASSED                   [ 58%]
tests/unit/test_ops_api.py::test_ops_dlq_management PASSED               [ 58%]
tests/unit/test_ops_api.py::test_ops_tenant_management PASSED            [ 58%]
tests/unit/test_ops_api.py::test_ops_invocation_report PASSED            [ 59%]
tests/unit/test_ops_api.py::test_ops_service_health PASSED               [ 59%]
tests/unit/test_ops_api.py::test_ops_billing_status PASSED               [ 60%]
tests/unit/test_ops_api.py::test_ops_fail_job PASSED                     [ 60%]
tests/unit/test_ops_api.py::test_ops_page_security PASSED                [ 61%]
tests/unit/test_ops_script.py::test_parse_args_top_tenants_defaults PASSED [ 61%]
tests/unit/test_ops_script.py::test_login_persists_profile PASSED        [ 62%]
tests/unit/test_ops_script.py::test_top_tenants_calls_expected_endpoint PASSED [ 62%]
tests/unit/test_ops_script.py::test_update_tenant_budget_uses_patch_and_json_body PASSED [ 62%]
tests/unit/test_ops_script.py::test_api_error_returns_nonzero_and_prints_error PASSED [ 63%]
tests/unit/test_request_interceptor.py::test_request_interceptor_enforces_tier PASSED [ 63%]
tests/unit/test_request_interceptor.py::test_request_interceptor_issues_scoped_token_and_headers PASSED [ 64%]
tests/unit/test_request_interceptor.py::test_request_interceptor_rejects_invalid_jwt PASSED [ 64%]
tests/unit/test_request_interceptor.py::test_request_interceptor_enforces_tier_minimum_camel_case PASSED [ 65%]
tests/unit/test_request_interceptor.py::test_request_interceptor_uses_idempotency_key_for_duplicates PASSED [ 65%]
tests/unit/test_task_script.py::test_wsl_version_detection PASSED        [ 66%]
tests/unit/test_task_script.py::test_detect_runtime_env_prefers_env_override PASSED [ 66%]
tests/unit/test_task_script.py::test_detect_runtime_env_auto_remote_when_not_wsl PASSED [ 66%]
tests/unit/test_task_script.py::test_generate_prompt_marks_local_wsl_context PASSED [ 67%]
tests/unit/test_task_script.py::test_generate_prompt_marks_remote_context PASSED [ 67%]
tests/unit/test_tenant_api_handler.py::test_create_tenant_writes_record_provisions_memory_secret_and_emits_event PASSED [ 68%]
tests/unit/test_tenant_api_handler.py::test_read_own_tenant_allowed_and_enriched_with_usage PASSED [ 68%]
tests/unit/test_tenant_api_handler.py::test_read_other_tenant_forbidden_for_non_admin PASSED [ 69%]
tests/unit/test_tenant_api_handler.py::test_update_tier_admin_only_emits_tier_changed_event PASSED [ 69%]
tests/unit/test_tenant_api_handler.py::test_delete_is_soft_delete_with_30_day_retention_and_event PASSED [ 70%]
tests/unit/test_tenant_api_handler.py::test_list_tenants_admin_only PASSED [ 70%]
tests/unit/test_tenant_api_handler.py::test_audit_export_returns_presigned_url_stub PASSED [ 70%]
tests/unit/test_tenant_api_handler.py::test_platform_failover_requires_lock_and_admin PASSED [ 71%]
tests/unit/test_tenant_api_handler.py::test_platform_quota_report PASSED [ 71%]
tests/unit/test_tenant_api_handler.py::test_platform_split_accounts_requires_platform_admin PASSED [ 72%]
tests/unit/test_worktree_issues.py::test_build_queue_auto_excludes_in_progress_from_candidates PASSED [ 72%]
tests/unit/test_worktree_issues.py::test_choose_next_runnable_requires_not_blocked_and_dependencies_closed PASSED [ 73%]
tests/unit/test_worktree_issues.py::test_audit_issues_flags_invalid_status_and_ready_combinations PASSED [ 73%]
tests/unit/test_worktree_issues.py::test_audit_issues_passes_clean_state_with_next_startable PASSED [ 74%]
tests/unit/test_worktree_issues.py::test_reconcile_issue_label_changes_closed_in_progress_moves_to_done PASSED [ 74%]
tests/unit/test_worktree_issues.py::test_assert_issue_startable_rejects_in_progress PASSED [ 75%]
tests/unit/test_worktree_issues.py::test_cmd_worktree_resume_open_shell_tolerates_missing_agent_namespace_attrs PASSED [ 75%]
tests/unit/test_worktree_issues.py::test_cmd_worktree_next_skips_runnable_issue_with_existing_worktree PASSED [ 75%]
src/data-access-lib/tests/test_client.py::TestTenantAccessViolation::test_attributes PASSED [ 76%]
src/data-access-lib/tests/test_client.py::TestTenantAccessViolation::test_is_exception PASSED [ 76%]
src/data-access-lib/tests/test_client.py::TestTenantAccessViolation::test_message_contains_all_parts PASSED [ 77%]
src/data-access-lib/tests/test_client.py::TestEmitTenantViolationMetric::test_calls_put_metric_data PASSED [ 77%]
src/data-access-lib/tests/test_client.py::TestEmitTenantViolationMetric::test_metric_dimensions_contain_both_tenants PASSED [ 78%]
src/data-access-lib/tests/test_client.py::TestEmitTenantViolationMetric::test_never_raises_on_cloudwatch_error PASSED [ 78%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBInit::test_init_with_injected_clients PASSED [ 79%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBInit::test_init_without_injected_clients_uses_env_region PASSED [ 79%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBGetItem::test_get_item_own_tenant_found PASSED [ 79%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBGetItem::test_get_item_own_tenant_not_found_returns_none PASSED [ 80%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBGetItem::test_get_item_non_tenant_pk_allowed PASSED [ 80%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBGetItem::test_get_item_cross_tenant_raises_violation PASSED [ 81%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBGetItem::test_get_item_cross_tenant_emits_cloudwatch_metric PASSED [ 81%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBPutItem::test_put_item_own_tenant_succeeds PASSED [ 82%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBPutItem::test_put_item_cross_tenant_raises_violation PASSED [ 82%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBPutItem::test_put_item_cross_tenant_emits_cloudwatch_metric PASSED [ 83%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBPutItem::test_put_item_non_tenant_pk_allowed PASSED [ 83%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBUpdateItem::test_update_item_own_tenant_succeeds PASSED [ 83%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBUpdateItem::test_update_item_with_condition_expression PASSED [ 84%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBUpdateItem::test_update_item_without_optional_params PASSED [ 84%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBUpdateItem::test_update_item_cross_tenant_raises_violation PASSED [ 85%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBDeleteItem::test_delete_item_own_tenant_succeeds PASSED [ 85%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBDeleteItem::test_delete_item_cross_tenant_raises_violation PASSED [ 86%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_returns_tenant_items_only PASSED [ 86%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_with_sk_condition PASSED [ 87%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_with_limit PASSED [ 87%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_with_scan_index_forward_false PASSED [ 87%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_with_exclusive_start_key PASSED [ 88%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_optional_kwargs_via_mock PASSED [ 88%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_empty_result PASSED [ 89%]
src/data-access-lib/tests/test_client.py::TestTenantScopedDynamoDBQuery::test_query_always_uses_caller_partition PASSED [ 89%]
src/data-access-lib/tests/test_client.py::TestValidatePkEdgeCases::test_missing_pk_key_is_allowed PASSED [ 90%]
src/data-access-lib/tests/test_client.py::TestValidatePkEdgeCases::test_non_string_pk_is_allowed PASSED [ 90%]
src/data-access-lib/tests/test_client.py::TestDynamoDBViolationMetricFailure::test_cw_failure_still_raises_violation PASSED [ 91%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3Init::test_init_with_injected_clients PASSED [ 91%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3Init::test_init_without_injected_clients PASSED [ 91%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3PutObject::test_put_own_prefix_succeeds PASSED [ 92%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3PutObject::test_put_with_extra_kwargs PASSED [ 92%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3PutObject::test_put_cross_tenant_raises_violation PASSED [ 93%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3PutObject::test_put_non_tenant_path_raises_violation PASSED [ 93%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3GetObject::test_get_own_prefix_succeeds PASSED [ 94%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3GetObject::test_get_cross_tenant_raises_violation PASSED [ 94%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3GetObject::test_get_cross_tenant_emits_cloudwatch_metric PASSED [ 95%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3GetObject::test_get_non_tenant_path_raises_violation_unknown_tenant PASSED [ 95%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3DeleteObject::test_delete_own_prefix_succeeds PASSED [ 95%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3DeleteObject::test_delete_cross_tenant_raises_violation PASSED [ 96%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3ListObjects::test_list_objects_own_prefix PASSED [ 96%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3ListObjects::test_list_objects_with_sub_prefix PASSED [ 97%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3ListObjects::test_list_objects_empty PASSED [ 97%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3PresignedUrl::test_presigned_url_own_prefix PASSED [ 98%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3PresignedUrl::test_presigned_url_custom_method PASSED [ 98%]
src/data-access-lib/tests/test_client.py::TestTenantScopedS3PresignedUrl::test_presigned_url_cross_tenant_raises_violation PASSED [ 99%]
src/data-access-lib/tests/test_client.py::TestS3ValidateKeyEdgeCases::test_tenants_prefix_but_no_tenant_segment PASSED [ 99%]
src/data-access-lib/tests/test_client.py::TestS3ValidateKeyEdgeCases::test_metric_emission_failure_still_raises_violation PASSED [100%]

======================= 224 passed in 1786.10s (0:29:46) =======================
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt43' (PASS: )\n- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt43'
==> Running local validation (fast)
uv run ruff check .
All checks passed!
uv run ruff format --check .
61 files already formatted
cd infra/cdk && npx --no-install pyright --project ../../pyrightconfig.json
0 errors, 0 warnings, 0 informations
cd infra/cdk && npx --no-install tsc --noEmit
cd infra/cdk && npx --no-install cdk synth --context env=dev --quiet > /dev/null
==> detect-secrets (changed files only)
==> detect-secrets: no changed files to scan
==> Validation passed
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt43' (PASS)\n- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt43'
uv run python scripts/worktree_issues.py pre-validate \
	
make[2]: Entering directory '/mnt/c/Users/julia/worktrees/wt43'
==> Running pre-push validation (no cdk synth)
uv run ruff check .
All checks passed!
uv run ruff format --check .
61 files already formatted
cd infra/cdk && npx --no-install pyright --project ../../pyrightconfig.json
0 errors, 0 warnings, 0 informations
==> validate-cdk-ts: skipped (no CDK/TS files in commits-to-push)
==> detect-secrets (files in commits-to-push)
==> detect-secrets: no commits-to-push files detected; falling back to changed-files scan
==> detect-secrets (changed files only)
==> detect-secrets: no changed files to scan
==> Pre-push validation passed
make[2]: Leaving directory '/mnt/c/Users/julia/worktrees/wt43'
Running pre-push validation in /mnt/c/Users/julia/worktrees/wt43 (make validate-pre-push)
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt43' (PASS)\n\n## Notes\n- plain make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt43'
PYTHONPATH=. uv run pytest tests/unit/ src/ -v --tb=short
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /mnt/c/Users/julia/worktrees/wt43/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/c/Users/julia/worktrees/wt43
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0
collecting ... collected 170 items / 1 error

==================================== ERRORS ====================================
__________ ERROR collecting src/data-access-lib/tests/test_client.py ___________
ImportError while importing test module '/mnt/c/Users/julia/worktrees/wt43/src/data-access-lib/tests/test_client.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named 'tests.test_client'
=========================== short test summary info ============================
ERROR src/data-access-lib/tests/test_client.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
============================== 1 error in 39.74s ===============================
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt43' in this workspace currently hits a pytest package import-mode collision () unless  is set; suite itself passes with importlib mode.\n\nCloses #43