### PR TITLE
TASK-053: tenant self-service portal MVP

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -389,6 +389,72 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /v1/tenants/{tenantId}/api-key/rotate:
+    post:
+      tags: [Tenants]
+      operationId: rotateTenantApiKey
+      summary: Rotate tenant API key
+      description: >
+        Rotates the tenant API key secret value for the specified tenant.
+        Allowed for own-tenant callers and platform admin/operator roles.
+      parameters:
+        - $ref: "#/components/parameters/TenantId"
+      responses:
+        "200":
+          description: API key rotated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantApiKeyRotateResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/tenants/{tenantId}/users/invite:
+    post:
+      tags: [Tenants]
+      operationId: inviteTenantUser
+      summary: Invite tenant user
+      description: >
+        Creates a tenant user invitation request. Allowed for own-tenant callers
+        and platform admin/operator roles.
+      parameters:
+        - $ref: "#/components/parameters/TenantId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantUserInviteRequest"
+      responses:
+        "202":
+          description: Invite accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantUserInviteAccepted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /v1/jobs/{jobId}:
     get:
       tags: [Jobs]
@@ -1151,6 +1217,58 @@ components:
           format: uri
         expiresAt:
           $ref: "#/components/schemas/UtcTimestamp"
+
+    TenantApiKeyRotateResponse:
+      type: object
+      required: [tenantId, apiKeySecretArn, rotatedAt]
+      properties:
+        tenantId:
+          type: string
+        apiKeySecretArn:
+          type: string
+        rotatedAt:
+          $ref: "#/components/schemas/UtcTimestamp"
+        versionId:
+          type: [string, "null"]
+
+    TenantUserInviteRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          default: Agent.Invoke
+        displayName:
+          type: string
+      additionalProperties: false
+
+    TenantUserInviteAccepted:
+      type: object
+      required: [invite]
+      properties:
+        invite:
+          type: object
+          required: [inviteId, tenantId, email, role, status, expiresAt]
+          properties:
+            inviteId:
+              type: string
+            tenantId:
+              type: string
+            email:
+              type: string
+              format: email
+            role:
+              type: string
+            displayName:
+              type: [string, "null"]
+            status:
+              type: string
+              enum: [pending]
+            expiresAt:
+              $ref: "#/components/schemas/UtcTimestamp"
 
     JobStatusResponse:
       type: object

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -200,7 +200,11 @@ export class PlatformStack extends cdk.Stack {
     this.tenantsTable.grantReadWriteData(this.tenantApiFn);
     this.tenantApiFn.addToRolePolicy(
       new iam.PolicyStatement({
-        actions: ['secretsmanager:CreateSecret', 'secretsmanager:TagResource'],
+        actions: [
+          'secretsmanager:CreateSecret',
+          'secretsmanager:TagResource',
+          'secretsmanager:PutSecretValue',
+        ],
         resources: [
           `arn:aws:secretsmanager:${this.region}:${this.account}:secret:platform/tenants/*`,
         ],
@@ -531,6 +535,10 @@ export class PlatformStack extends cdk.Stack {
     const tenants = v1.addResource('tenants');
     const tenantById = tenants.addResource('{tenantId}');
     const auditExport = tenantById.addResource('audit-export');
+    const tenantApiKey = tenantById.addResource('api-key');
+    const tenantApiKeyRotate = tenantApiKey.addResource('rotate');
+    const tenantUsers = tenantById.addResource('users');
+    const tenantUsersInvite = tenantUsers.addResource('invite');
     const platform = v1.addResource('platform');
     const failover = platform.addResource('failover');
     const quota = platform.addResource('quota');
@@ -572,6 +580,8 @@ export class PlatformStack extends cdk.Stack {
     tenantById.addMethod('DELETE', tenantApiIntegration, securedMethodOptions);
 
     auditExport.addMethod('GET', tenantApiIntegration, securedMethodOptions);
+    tenantApiKeyRotate.addMethod('POST', tenantApiIntegration, securedMethodOptions);
+    tenantUsersInvite.addMethod('POST', tenantApiIntegration, securedMethodOptions);
 
     failover.addMethod('POST', tenantApiIntegration, securedMethodOptions);
     quota.addMethod('GET', tenantApiIntegration, securedMethodOptions);

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -4,6 +4,7 @@ import { AgentCataloguePage } from "./pages/AgentCataloguePage";
 import { InvokePage } from "./pages/InvokePage";
 import { SessionsPage } from "./pages/SessionsPage";
 import { AdminPage } from "./pages/AdminPage";
+import { TenantPortalPage } from "./pages/TenantPortalPage";
 import { useAuth } from "./auth/useAuth";
 
 function App() {
@@ -40,6 +41,7 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<AgentCataloguePage />} />
+          <Route path="/tenant" element={<TenantPortalPage />} />
           <Route path="/invoke/:agentName" element={<InvokePage />} />
           <Route path="/sessions" element={<SessionsPage />} />
           <Route path="/admin" element={<AdminPage />} />

--- a/spa/src/components/Layout.tsx
+++ b/spa/src/components/Layout.tsx
@@ -8,6 +8,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
 
     const navItems = [
         { name: "Catalogue", path: "/" },
+        { name: "Tenant Portal", path: "/tenant" },
         { name: "Sessions", path: "/sessions" },
         { name: "Admin", path: "/admin", adminOnly: true },
     ];

--- a/spa/src/pages/TenantPortalPage.tsx
+++ b/spa/src/pages/TenantPortalPage.tsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { getApiClient } from "../api/client";
+import { useAuth } from "../auth/useAuth";
+
+type TenantUsage = {
+    requestsToday?: number;
+    budgetRemainingUsd?: number;
+    usageIdentifierKey?: string;
+};
+
+type TenantRecord = {
+    tenantId: string;
+    appId: string;
+    displayName: string;
+    tier: string;
+    status: string;
+    updatedAt: string;
+    apiKeySecretArn?: string;
+    usage?: TenantUsage;
+};
+
+type RotateResponse = {
+    tenantId: string;
+    apiKeySecretArn: string;
+    rotatedAt: string;
+    versionId?: string | null;
+};
+
+type InviteResponse = {
+    invite: {
+        inviteId: string;
+        tenantId: string;
+        email: string;
+        role: string;
+        status: string;
+        expiresAt: string;
+    };
+};
+
+function resolveTenantId(claims: unknown): string | null {
+    if (!claims || typeof claims !== "object") {
+        return null;
+    }
+    const map = claims as Record<string, unknown>;
+    const tenantId = map.tenantid ?? map.tenantId;
+    if (typeof tenantId !== "string") {
+        return null;
+    }
+    const trimmed = tenantId.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+export const TenantPortalPage: React.FC = () => {
+    const { getAccessToken, account, isAuthenticated } = useAuth();
+    const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
+
+    const [tenant, setTenant] = useState<TenantRecord | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [rotating, setRotating] = useState(false);
+    const [rotateMessage, setRotateMessage] = useState<string | null>(null);
+    const [inviteEmail, setInviteEmail] = useState("");
+    const [inviteRole, setInviteRole] = useState("Agent.Invoke");
+    const [invitePending, setInvitePending] = useState(false);
+    const [inviteMessage, setInviteMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!isAuthenticated) {
+            setLoading(false);
+            return;
+        }
+        if (!tenantId) {
+            setLoading(false);
+            setError("Token is missing tenantid claim.");
+            return;
+        }
+
+        const run = async () => {
+            try {
+                const client = getApiClient(getAccessToken);
+                const data = await client.request<{ tenant: TenantRecord }>(`/v1/tenants/${tenantId}`);
+                setTenant(data.tenant);
+                setError(null);
+            } catch (err) {
+                const message = err instanceof Error ? err.message : "Failed to load tenant portal data.";
+                setError(message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        void run();
+    }, [getAccessToken, isAuthenticated, tenantId]);
+
+    const onRotateApiKey = async () => {
+        if (!tenantId) {
+            return;
+        }
+        setRotating(true);
+        setRotateMessage(null);
+        try {
+            const client = getApiClient(getAccessToken);
+            const result = await client.request<RotateResponse>(`/v1/tenants/${tenantId}/api-key/rotate`, {
+                method: "POST",
+            });
+            setRotateMessage(
+                `API key rotated at ${new Date(result.rotatedAt).toLocaleString()} (version ${result.versionId ?? "n/a"}).`,
+            );
+            setTenant((prev) =>
+                prev
+                    ? {
+                        ...prev,
+                        apiKeySecretArn: result.apiKeySecretArn,
+                        updatedAt: result.rotatedAt,
+                    }
+                    : prev,
+            );
+        } catch (err) {
+            const message = err instanceof Error ? err.message : "API key rotation failed.";
+            setRotateMessage(message);
+        } finally {
+            setRotating(false);
+        }
+    };
+
+    const onInviteSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!tenantId || !inviteEmail.trim()) {
+            return;
+        }
+        setInvitePending(true);
+        setInviteMessage(null);
+        try {
+            const client = getApiClient(getAccessToken);
+            const payload = {
+                email: inviteEmail.trim(),
+                role: inviteRole.trim() || "Agent.Invoke",
+            };
+            const response = await client.request<InviteResponse>(`/v1/tenants/${tenantId}/users/invite`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+            setInviteMessage(
+                `Invite ${response.invite.inviteId} accepted for ${response.invite.email}; expires ${new Date(
+                    response.invite.expiresAt,
+                ).toLocaleString()}.`,
+            );
+            setInviteEmail("");
+        } catch (err) {
+            const message = err instanceof Error ? err.message : "Failed to submit invite.";
+            setInviteMessage(message);
+        } finally {
+            setInvitePending(false);
+        }
+    };
+
+    if (loading) {
+        return <div>Loading tenant portal...</div>;
+    }
+
+    if (error) {
+        return (
+            <div className="bg-red-50 border-l-4 border-red-400 p-4">
+                <p className="text-sm text-red-700">{error}</p>
+            </div>
+        );
+    }
+
+    if (!tenant) {
+        return <div>No tenant data available.</div>;
+    }
+
+    return (
+        <div className="space-y-8">
+            <div>
+                <h1 className="text-3xl font-bold text-gray-900">Tenant Portal</h1>
+                <p className="mt-2 text-gray-600">
+                    Self-service controls for tenant <span className="font-medium">{tenant.tenantId}</span>.
+                </p>
+            </div>
+
+            <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
+                <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
+                    <h2 className="text-lg font-medium text-gray-900">Usage Snapshot</h2>
+                </div>
+                <div className="px-4 py-5 sm:p-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    <div className="rounded border border-gray-200 p-4">
+                        <p className="text-sm text-gray-500">Requests Today</p>
+                        <p className="text-2xl font-semibold text-gray-900">{tenant.usage?.requestsToday ?? 0}</p>
+                    </div>
+                    <div className="rounded border border-gray-200 p-4">
+                        <p className="text-sm text-gray-500">Budget Remaining (USD)</p>
+                        <p className="text-2xl font-semibold text-gray-900">
+                            {tenant.usage?.budgetRemainingUsd ?? "n/a"}
+                        </p>
+                    </div>
+                    <div className="rounded border border-gray-200 p-4">
+                        <p className="text-sm text-gray-500">Tier / Status</p>
+                        <p className="text-2xl font-semibold text-gray-900">
+                            {tenant.tier} / {tenant.status}
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
+                <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
+                    <h2 className="text-lg font-medium text-gray-900">API Key Rotation</h2>
+                </div>
+                <div className="px-4 py-5 sm:p-6 space-y-4">
+                    <p className="text-sm text-gray-600">Secret ARN: {tenant.apiKeySecretArn ?? "Not configured"}</p>
+                    <button
+                        onClick={onRotateApiKey}
+                        disabled={rotating}
+                        className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400"
+                    >
+                        {rotating ? "Rotating..." : "Rotate API Key"}
+                    </button>
+                    {rotateMessage && <p className="text-sm text-gray-700">{rotateMessage}</p>}
+                </div>
+            </section>
+
+            <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
+                <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
+                    <h2 className="text-lg font-medium text-gray-900">Invite User</h2>
+                </div>
+                <form className="px-4 py-5 sm:p-6 space-y-4" onSubmit={onInviteSubmit}>
+                    <div>
+                        <label htmlFor="invite-email" className="block text-sm font-medium text-gray-700">
+                            Email
+                        </label>
+                        <input
+                            id="invite-email"
+                            type="email"
+                            required
+                            value={inviteEmail}
+                            onChange={(e) => setInviteEmail(e.target.value)}
+                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                            placeholder="new.user@example.com"
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="invite-role" className="block text-sm font-medium text-gray-700">
+                            Role
+                        </label>
+                        <input
+                            id="invite-role"
+                            type="text"
+                            value={inviteRole}
+                            onChange={(e) => setInviteRole(e.target.value)}
+                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={invitePending}
+                        className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400"
+                    >
+                        {invitePending ? "Sending..." : "Send Invite"}
+                    </button>
+                    {inviteMessage && <p className="text-sm text-gray-700">{inviteMessage}</p>}
+                </form>
+            </section>
+        </div>
+    );
+};

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -31,6 +31,8 @@ _EVENT_BUS_ENV = "EVENT_BUS_NAME"
 _API_KEY_SECRET_PREFIX_ENV = "TENANT_API_KEY_SECRET_PREFIX"  # pragma: allowlist secret
 _DELETE_RETENTION_DAYS = 30
 _ADMIN_ROLES = {"Platform.Admin"}
+_SELF_SERVICE_ADMIN_ROLES = {"Platform.Admin", "Platform.Operator"}
+_INVITE_EXPIRY_DAYS = 7
 
 
 @dataclass(frozen=True)
@@ -271,6 +273,14 @@ def _require_admin(caller: CallerIdentity) -> None:
 
 def _can_read_tenant(caller: CallerIdentity, tenant_id: str) -> bool:
     return caller.is_admin or caller.tenant_id == tenant_id
+
+
+def _is_self_service_admin(caller: CallerIdentity) -> bool:
+    return bool(caller.roles & _SELF_SERVICE_ADMIN_ROLES)
+
+
+def _can_manage_tenant_self_service(caller: CallerIdentity, tenant_id: str) -> bool:
+    return _is_self_service_admin(caller) or caller.tenant_id == tenant_id
 
 
 def _ddb_value(value: Any) -> Any:
@@ -655,6 +665,124 @@ def _handle_delete(
         },
     )
     return _response(200, {"tenant": _serialize_tenant(item)})
+
+
+def _handle_rotate_api_key(
+    caller: CallerIdentity,
+    deps: TenantApiDependencies,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    if not _can_manage_tenant_self_service(caller, tenant_id):
+        raise PermissionError(
+            "Caller may only manage own tenant unless Platform.Admin/Platform.Operator"
+        )
+
+    existing = _read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if existing is None:
+        return _error(404, "NOT_FOUND", "Tenant not found")
+
+    app_id = _str_or_none(existing.get("appId"))
+    secret_arn = _str_or_none(existing.get("apiKeySecretArn"))
+    if app_id is None or secret_arn is None:
+        return _error(
+            409,
+            "CONFLICT",
+            "Tenant is missing API key secret metadata",
+        )
+
+    rotated_at = _now_utc()
+    secret_value = {
+        "tenantId": tenant_id,
+        "appId": app_id,
+        "apiKey": secrets.token_urlsafe(32),
+        "rotatedAt": _iso(rotated_at),
+    }
+    put_response = deps.secretsmanager.put_secret_value(
+        SecretId=secret_arn,
+        SecretString=json.dumps(secret_value),
+    )
+
+    db = _db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+    update_expression, expr_names, expr_values = _build_update_expression(
+        {"updatedAt": _iso(rotated_at)}
+    )
+    db.update_item(
+        _tenants_table_name(),
+        key=_tenant_key(tenant_id),
+        update_expression=update_expression,
+        expression_attribute_values=expr_values,
+        expression_attribute_names=expr_names,
+        condition_expression="attribute_exists(PK) AND attribute_exists(SK)",
+    )
+
+    _put_event(
+        deps,
+        detail_type="tenant.api_key_rotated",
+        detail={
+            "tenantId": tenant_id,
+            "appId": app_id,
+            "actorSub": caller.sub,
+            "secretArn": secret_arn,
+        },
+    )
+    return _response(
+        200,
+        {
+            "tenantId": tenant_id,
+            "apiKeySecretArn": secret_arn,
+            "rotatedAt": _iso(rotated_at),
+            "versionId": _str_or_none(put_response.get("VersionId")),
+        },
+    )
+
+
+def _handle_invite_user(
+    event: dict[str, Any],
+    caller: CallerIdentity,
+    deps: TenantApiDependencies,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    if not _can_manage_tenant_self_service(caller, tenant_id):
+        raise PermissionError(
+            "Caller may only manage own tenant unless Platform.Admin/Platform.Operator"
+        )
+
+    existing = _read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if existing is None:
+        return _error(404, "NOT_FOUND", "Tenant not found")
+
+    body = _require_json_body(event)
+    email = _str_or_none(body.get("email"))
+    if email is None or "@" not in email:
+        raise ValueError("email is required and must be a valid email address")
+
+    role = _str_or_none(body.get("role")) or "Agent.Invoke"
+    display_name = _str_or_none(body.get("displayName"))
+    app_id = _str_or_none(existing.get("appId"))
+
+    invite_id = f"invite-{secrets.token_hex(8)}"
+    expires_at = _now_utc() + timedelta(days=_INVITE_EXPIRY_DAYS)
+    invite = {
+        "inviteId": invite_id,
+        "tenantId": tenant_id,
+        "email": email.lower(),
+        "role": role,
+        "displayName": display_name,
+        "status": "pending",
+        "expiresAt": _iso(expires_at),
+    }
+    _put_event(
+        deps,
+        detail_type="tenant.user_invited",
+        detail={
+            **invite,
+            "actorSub": caller.sub,
+            "appId": app_id,
+        },
+    )
+    return _response(202, {"invite": invite})
 
 
 def _handle_audit_export(
@@ -1072,6 +1200,10 @@ def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
                 return _handle_list(event, caller, deps)
 
         if tenant_id is not None:
+            if path.endswith("/api-key/rotate") and method == "POST":
+                return _handle_rotate_api_key(caller, deps, tenant_id=tenant_id)
+            if path.endswith("/users/invite") and method == "POST":
+                return _handle_invite_user(event, caller, deps, tenant_id=tenant_id)
             if path.endswith("/audit-export") and method == "GET":
                 return _handle_audit_export(caller, deps, tenant_id=tenant_id)
 

--- a/tests/unit/test_authoriser.py
+++ b/tests/unit/test_authoriser.py
@@ -120,6 +120,10 @@ def test_generate_policy():
         ("arn:aws:execute-api:eu-west-2:123456789012:api/dev/PATCH/v1/tenants/t-001", True),
         ("arn:aws:execute-api:eu-west-2:123456789012:api/dev/DELETE/v1/tenants/t-001", True),
         (
+            "arn:aws:execute-api:eu-west-2:123456789012:api/dev/POST/v1/tenants/t-001/api-key/rotate",
+            False,
+        ),
+        (
             "arn:aws:execute-api:eu-west-2:123456789012:api/dev/GET/v1/tenants/t-001/audit-export",
             True,
         ),

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -83,10 +83,15 @@ class FakeScopedDb:
 class FakeSecretsManager:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.rotate_calls: list[dict[str, Any]] = []
 
     def create_secret(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append(kwargs)
         return {"ARN": f"arn:aws:secretsmanager:eu-west-2:111111111111:secret:{kwargs['Name']}"}
+
+    def put_secret_value(self, **kwargs: Any) -> dict[str, Any]:
+        self.rotate_calls.append(kwargs)
+        return {"ARN": str(kwargs.get("SecretId", "")), "VersionId": "ver-rotated-001"}
 
 
 class FakeEvents:
@@ -478,3 +483,124 @@ def test_create_tenant_allows_json_encoded_admin_roles(fake_state: dict[str, Any
     )
 
     assert response["statusCode"] == 201
+
+
+def test_rotate_api_key_for_own_tenant_succeeds_and_emits_event(fake_state: dict[str, Any]) -> None:
+    fake_state["db"].items[("TENANT#t-rotate", "METADATA")] = {
+        "PK": "TENANT#t-rotate",
+        "SK": "METADATA",
+        "tenantId": "t-rotate",
+        "appId": "app-rotate",
+        "displayName": "Rotate",
+        "tier": "standard",
+        "status": "active",
+        "createdAt": "2026-02-25T12:00:00Z",
+        "updatedAt": "2026-02-25T12:00:00Z",
+        "ownerEmail": "r@example.com",
+        "ownerTeam": "team-r",
+        "accountId": "123456789012",
+        "apiKeySecretArn": (
+            "arn:aws:secretsmanager:eu-west-2:111111111111:secret:platform/tenants/t-rotate/api-key"
+        ),
+    }
+    event = _event(
+        method="POST",
+        tenant_id="t-rotate",
+        caller_tenant_id="t-rotate",
+        roles=[],
+        app_id="app-rotate",
+    )
+    event["path"] = "/v1/tenants/t-rotate/api-key/rotate"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 200
+    body = _body(response)
+    assert body["tenantId"] == "t-rotate"
+    assert body["versionId"] == "ver-rotated-001"
+    rotate_calls = fake_state["deps"].secretsmanager.rotate_calls
+    assert len(rotate_calls) == 1
+    assert rotate_calls[0]["SecretId"].endswith("/t-rotate/api-key")
+    detail_type, detail = _last_event_detail(fake_state)
+    assert detail_type == "tenant.api_key_rotated"
+    assert detail["tenantId"] == "t-rotate"
+
+
+def test_rotate_api_key_cross_tenant_forbidden(fake_state: dict[str, Any]) -> None:
+    fake_state["db"].items[("TENANT#t-owner", "METADATA")] = {
+        "PK": "TENANT#t-owner",
+        "SK": "METADATA",
+        "tenantId": "t-owner",
+        "appId": "app-owner",
+        "status": "active",
+        "apiKeySecretArn": (
+            "arn:aws:secretsmanager:eu-west-2:111111111111:secret:platform/tenants/t-owner/api-key"
+        ),
+    }
+    event = _event(
+        method="POST",
+        tenant_id="t-owner",
+        caller_tenant_id="t-attacker",
+        roles=[],
+        app_id="app-attacker",
+    )
+    event["path"] = "/v1/tenants/t-owner/api-key/rotate"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 403
+    assert _body(response)["error"]["code"] == "FORBIDDEN"
+
+
+def test_invite_user_for_own_tenant_succeeds(fake_state: dict[str, Any]) -> None:
+    fake_state["db"].items[("TENANT#t-invite", "METADATA")] = {
+        "PK": "TENANT#t-invite",
+        "SK": "METADATA",
+        "tenantId": "t-invite",
+        "appId": "app-invite",
+        "status": "active",
+    }
+    event = _event(
+        method="POST",
+        tenant_id="t-invite",
+        caller_tenant_id="t-invite",
+        roles=[],
+        app_id="app-invite",
+        body={"email": "new.user@example.com", "role": "Agent.Invoke"},
+    )
+    event["path"] = "/v1/tenants/t-invite/users/invite"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 202
+    invite = _body(response)["invite"]
+    assert invite["tenantId"] == "t-invite"
+    assert invite["email"] == "new.user@example.com"
+    assert invite["status"] == "pending"
+    detail_type, detail = _last_event_detail(fake_state)
+    assert detail_type == "tenant.user_invited"
+    assert detail["tenantId"] == "t-invite"
+
+
+def test_invite_user_requires_valid_email(fake_state: dict[str, Any]) -> None:
+    fake_state["db"].items[("TENANT#t-invite-2", "METADATA")] = {
+        "PK": "TENANT#t-invite-2",
+        "SK": "METADATA",
+        "tenantId": "t-invite-2",
+        "appId": "app-invite-2",
+        "status": "active",
+    }
+    event = _event(
+        method="POST",
+        tenant_id="t-invite-2",
+        caller_tenant_id="t-invite-2",
+        roles=[],
+        app_id="app-invite-2",
+        body={"email": "not-an-email"},
+    )
+    event["path"] = "/v1/tenants/t-invite-2/users/invite"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+    assert _body(response)["error"]["code"] == "BAD_REQUEST"


### PR DESCRIPTION
## Summary
- add tenant self-service endpoints in `tenant_api` for API key rotation and user invite requests
- wire API Gateway/CDK routes and IAM permission for `secretsmanager:PutSecretValue`
- add tenant portal SPA page (`/tenant`) with usage snapshot, API key rotation, and invite form
- extend unit tests and OpenAPI contract for the new endpoints

## Validation Evidence
- `uv run pytest tests/unit/test_tenant_api_handler.py tests/unit/test_authoriser.py` -> **47 passed**
- `npm test -- --runTestsByPath test/platform-stack.test.ts` (in `infra/cdk`) -> **7 passed**
- `npm run test` (in `spa`) -> **7 passed**
- `npm run build` (in `infra/cdk`) -> **pass**
- `npm run build` (in `spa`) -> **pass**
- `make validate-local` -> **pass**
- `make preflight-session` -> **PASS**
- `make pre-validate-session` -> **Pre-push validation passed**
- `make worktree-push-issue` -> enforced preflight/pre-validate + push completed

## Notes
- `npm run lint` in `spa` currently fails due pre-existing repository lint errors in unchanged files (not introduced by this change set).
