### PR TITLE
Issue #105: add CI-safe prod infrastructure deploy target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,7 +138,7 @@ deploy-prod:
     AWS_ROLE_ARN: ${AWS_ROLE_ARN_DEPLOY_PROD}
     ENV: prod
   script:
-    - make infra-deploy ENV=prod
+    - make infra-deploy-prod-ci
     - make spa-deploy ENV=prod
   environment:
     name: prod

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 .PHONY: dev dev-stop dev-logs dev-invoke
 .PHONY: test-unit test-int test-agent test-all
 .PHONY: worktree-create worktree-list worktree-clean
-.PHONY: infra-synth infra-diff infra-deploy infra-destroy
+.PHONY: infra-synth infra-diff infra-deploy infra-deploy-prod-ci infra-destroy
 .PHONY: infra-rollback-lambda infra-set-runtime-region
 .PHONY: failover-lock-acquire failover-lock-release
 .PHONY: bootstrap-cdk bootstrap-secrets bootstrap-gitlab-oidc
@@ -338,6 +338,17 @@ infra-diff:
 infra-deploy:
 	@test "$(ENV)" != "prod" || (echo "ERROR: Use GitLab pipeline for prod deploys" && exit 1)
 	cd infra/cdk && npx cdk deploy --all --context env=$(ENV) --require-approval never
+
+## infra-deploy-prod-ci: Deploy CDK stacks to prod from CI only
+## Usage: make infra-deploy-prod-ci
+infra-deploy-prod-ci:
+	@test "$(CI)" = "true" || (echo "ERROR: infra-deploy-prod-ci is CI-only" && exit 1)
+	@test "$$GITLAB_CI" = "true" || (echo "ERROR: infra-deploy-prod-ci requires GitLab CI context" && exit 1)
+	@test -n "$$AWS_REGION" || (echo "ERROR: AWS_REGION must be set" && exit 1)
+	@test -n "$$AWS_ROLE_ARN_DEPLOY_PROD" || (echo "ERROR: AWS_ROLE_ARN_DEPLOY_PROD must be set" && exit 1)
+	@test -n "$$AWS_ROLE_ARN" || (echo "ERROR: AWS_ROLE_ARN must be set" && exit 1)
+	@test "$$AWS_ROLE_ARN" = "$$AWS_ROLE_ARN_DEPLOY_PROD" || (echo "ERROR: AWS_ROLE_ARN must match AWS_ROLE_ARN_DEPLOY_PROD for prod deploy" && exit 1)
+	cd infra/cdk && npx cdk deploy --all --context env=prod --require-approval never
 
 ## infra-destroy: Destroy all CDK stacks (dev only)
 infra-destroy:

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ make worktree-push-issue      # push branch with preflight + pre-validate enforc
 make issues-audit             # validate issue lifecycle/queue invariants
 make docs-sync-audit          # docs/code semver + drift heuristics audit
 make docs-sync-stamp          # refresh docs/DOCS_SYNC.json (release checkpoint)
+# CI-only prod infrastructure deploy target: make infra-deploy-prod-ci
 
 # Agent developer inner loop
 make agent-push AGENT=my-agent ENV=dev    # Push agent, fast path <30s if deps cached


### PR DESCRIPTION
## Summary
- add dedicated `infra-deploy-prod-ci` Make target for production CDK deploys
- enforce CI-only and GitLab-only guardrails with required prod role/env checks
- keep local `infra-deploy ENV=prod` blocked
- update `deploy-prod` pipeline job to call the CI-safe target
- document the target in README command list

## Validation Evidence
- `make preflight-session` -> PASS (run multiple times during session, including pre-commit and pre-push)
- `make pre-validate-session` -> PASS (pre-push gate)
- `make validate-local` -> PASS
- `make infra-deploy ENV=prod` -> fails with `ERROR: Use GitLab pipeline for prod deploys`
- `make infra-deploy-prod-ci` -> fails locally with `ERROR: infra-deploy-prod-ci is CI-only`
- `CI=true make infra-deploy-prod-ci` -> fails with `ERROR: infra-deploy-prod-ci requires GitLab CI context`
- CI-mode command-path smoke with stubbed `npx` and required vars -> executes `cdk deploy --context env=prod`

Closes #105.
