### PR TITLE
Align invoke route with OpenAPI contract

### DIFF
--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -494,7 +494,7 @@ export class PlatformStack extends cdk.Stack {
         tracingEnabled: true,
         metricsEnabled: true,
         methodOptions: {
-          '/v1/invoke/POST': {
+          '/v1/agents/{agentName}/invoke/POST': {
             throttlingRateLimit: 50,
             throttlingBurstLimit: 100,
             metricsEnabled: true,
@@ -519,7 +519,9 @@ export class PlatformStack extends cdk.Stack {
     });
 
     const v1 = this.api.root.addResource('v1');
-    const invoke = v1.addResource('invoke');
+    const agents = v1.addResource('agents');
+    const agentByName = agents.addResource('{agentName}');
+    const invoke = agentByName.addResource('invoke');
     const jobs = v1.addResource('jobs');
     const jobById = jobs.addResource('{jobId}');
     const webhooks = v1.addResource('webhooks');

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -75,6 +75,41 @@ describe('PlatformStack (TASK-023)', () => {
     });
   });
 
+  test('wires invoke route to /v1/agents/{agentName}/invoke and removes legacy /v1/invoke', () => {
+    const resources = template.findResources('AWS::ApiGateway::Resource');
+    const pathParts = Object.values(resources).map((resource) => {
+      const properties = (resource as { Properties?: { PathPart?: string } }).Properties;
+      return properties?.PathPart;
+    });
+
+    expect(pathParts).toContain('agents');
+    expect(pathParts).toContain('{agentName}');
+    expect(pathParts).toContain('invoke');
+
+    const stages = template.findResources('AWS::ApiGateway::Stage');
+    const methodSettings = Object.values(stages).flatMap((stage) => {
+      const properties = (stage as { Properties?: { MethodSettings?: Array<unknown> } }).Properties;
+      return properties?.MethodSettings ?? [];
+    });
+
+    expect(methodSettings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          HttpMethod: 'POST',
+          ResourcePath: '/~1v1~1agents~1{agentName}~1invoke',
+        }),
+      ]),
+    );
+    expect(methodSettings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          HttpMethod: 'POST',
+          ResourcePath: '/~1v1~1invoke',
+        }),
+      ]),
+    );
+  });
+
   test('creates bridge canary deployment group with error-rate auto-rollback alarm', () => {
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmName: 'platform-core-dev-error_rate_high',

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -371,21 +371,21 @@ def handler(event: dict[str, Any], context: LambdaContext, response_stream: Any 
     if method == "DELETE" and _coerce_optional_string(path_params.get("webhookId")):
         return delete_webhook(tenant_context, path_params, request_id)
 
-    # 3. Default to invoke route for backward compatibility.
+    # 3. Contracted invoke route: POST /v1/agents/{agentName}/invoke.
     if method != "POST":
         return error_response(404, "NOT_FOUND", "Route not found", request_id)
+
+    agent_name = _coerce_optional_string(path_params.get("agentName"))
+    if path and not _is_invoke_contract_path(path, agent_name):
+        return error_response(404, "NOT_FOUND", "Route not found", request_id)
+    if not agent_name:
+        return error_response(400, "INVALID_REQUEST", "Missing agentName in path", request_id)
 
     # 4. Parse Request Body
     try:
         body = _parse_body(event)
     except ValueError:
         return error_response(400, "INVALID_REQUEST", "Invalid JSON in request body", request_id)
-
-    agent_name = _coerce_optional_string(path_params.get("agentName")) or _coerce_optional_string(
-        body.get("agentName")
-    )
-    if not agent_name:
-        return error_response(400, "INVALID_REQUEST", "Missing agentName in path", request_id)
 
     prompt = _coerce_optional_string(body.get("input"))
     if not prompt:
@@ -434,6 +434,24 @@ def _request_path(event: dict[str, Any]) -> str:
     if not path:
         return ""
     return str(path)
+
+
+def _is_invoke_contract_path(path: str, agent_name: str | None) -> bool:
+    normalized = str(path).rstrip("/")
+    if not normalized.endswith("/invoke"):
+        return False
+
+    # Accept optional stage prefixes and validate the right-most contract path.
+    segments = [segment for segment in normalized.split("/") if segment]
+    if len(segments) < 4:
+        return False
+    if segments[-4] != "v1" or segments[-3] != "agents" or segments[-1] != "invoke":
+        return False
+
+    route_agent_name = segments[-2].strip()
+    if not route_agent_name:
+        return False
+    return agent_name is None or route_agent_name == agent_name
 
 
 def _parse_body(event: dict[str, Any]) -> dict[str, Any]:

--- a/tests/integration/test_bridge_invoke_route_contract.py
+++ b/tests/integration/test_bridge_invoke_route_contract.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+from data_access.models import AgentRecord, InvocationMode, TenantTier
+
+from src.bridge.handler import handler
+
+
+class FakeLambdaContext:
+    function_name = "bridge"
+    memory_limit_in_mb = 256
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:111111111111:function:bridge"
+    aws_request_id = "req-integration"
+
+
+def _invoke_event(path: str, path_parameters: dict[str, str] | None, body: dict[str, str]) -> dict:
+    return {
+        "httpMethod": "POST",
+        "path": path,
+        "pathParameters": path_parameters,
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+        "body": json.dumps(body),
+    }
+
+
+def _agent(agent_name: str) -> AgentRecord:
+    return AgentRecord(
+        agent_name=agent_name,
+        version="1.0.0",
+        owner_team="platform-test",
+        tier_minimum=TenantTier.BASIC,
+        layer_hash="0000",
+        layer_s3_key="layer.zip",
+        script_s3_key="script.zip",
+        deployed_at="2026-01-01T00:00:00Z",
+        invocation_mode=InvocationMode.SYNC,
+        streaming_enabled=False,
+    )
+
+
+def test_contract_invoke_route_uses_agent_name_path_parameter():
+    event = _invoke_event(
+        "/v1/agents/echo-agent/invoke",
+        {"agentName": "echo-agent"},
+        {"agentName": "wrong-agent", "input": "hello"},
+    )
+
+    with (
+        patch(
+            "src.bridge.handler.get_agent_record",
+            return_value=_agent("echo-agent"),
+        ) as mock_get_agent,
+        patch(
+            "src.bridge.handler.invoke_agent",
+            return_value={
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"status": "success"}),
+            },
+        ),
+    ):
+        response = handler(event, FakeLambdaContext())
+
+    assert response["statusCode"] == 200
+    mock_get_agent.assert_called_once_with("echo-agent")
+
+
+def test_legacy_invoke_route_is_not_accepted():
+    event = _invoke_event("/v1/invoke", None, {"agentName": "echo-agent", "input": "hello"})
+
+    response = handler(event, FakeLambdaContext())
+
+    assert response["statusCode"] == 404
+    body = json.loads(response["body"])
+    assert body["error"]["code"] == "NOT_FOUND"

--- a/tests/unit/test_authoriser.py
+++ b/tests/unit/test_authoriser.py
@@ -74,7 +74,9 @@ def _sigv4_authorization(
 
 def _sigv4_event(
     *,
-    method_arn: str = "arn:aws:execute-api:eu-west-2:123456789012:api/dev/POST/v1/invoke",
+    method_arn: str = (
+        "arn:aws:execute-api:eu-west-2:123456789012:api/dev/POST/v1/agents/echo-agent/invoke"
+    ),
     tenant_id: str = "t-test-001",
     authorization: str | None = None,
     include_identity: bool = True,

--- a/tests/unit/test_bridge_failover.py
+++ b/tests/unit/test_bridge_failover.py
@@ -115,6 +115,7 @@ def setup_data(mock_aws_services):
 
 def test_handler_failover_on_503(setup_data):
     event = {
+        "path": "/v1/agents/echo-agent/invoke",
         "pathParameters": {"agentName": "echo-agent"},
         "requestContext": {
             "authorizer": {
@@ -171,6 +172,7 @@ def test_handler_failover_already_in_progress(setup_data):
     )
 
     event = {
+        "path": "/v1/agents/echo-agent/invoke",
         "pathParameters": {"agentName": "echo-agent"},
         "requestContext": {
             "authorizer": {

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -114,6 +114,7 @@ def setup_data(mock_aws_services):
 
 def test_handler_sync_success(setup_data):
     event = {
+        "path": "/v1/agents/echo-agent/invoke",
         "pathParameters": {"agentName": "echo-agent"},
         "requestContext": {
             "authorizer": {
@@ -145,6 +146,26 @@ def test_handler_sync_success(setup_data):
         assert "invocationId" in body
 
 
+def test_handler_rejects_legacy_invoke_route(setup_data):
+    event = {
+        "path": "/v1/invoke",
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+        "body": json.dumps({"agentName": "echo-agent", "input": "Hello"}),
+    }
+
+    response = handler(event, FakeLambdaContext())
+    assert response["statusCode"] == 404
+    body = json.loads(response["body"])
+    assert body["error"]["code"] == "NOT_FOUND"
+
+
 def test_handler_tier_insufficient(setup_data):
     # Seed agent requiring premium
     ddb = boto3.resource("dynamodb", region_name="eu-west-2")
@@ -167,6 +188,7 @@ def test_handler_tier_insufficient(setup_data):
     )
 
     event = {
+        "path": "/v1/agents/premium-agent/invoke",
         "pathParameters": {"agentName": "premium-agent"},
         "requestContext": {
             "authorizer": {
@@ -187,6 +209,7 @@ def test_handler_tier_insufficient(setup_data):
 
 def test_handler_agent_not_found(setup_data):
     event = {
+        "path": "/v1/agents/missing-agent/invoke",
         "pathParameters": {"agentName": "missing-agent"},
         "requestContext": {
             "authorizer": {
@@ -227,6 +250,7 @@ def test_handler_async_accepted(setup_data):
     )
 
     event = {
+        "path": "/v1/agents/async-agent/invoke",
         "pathParameters": {"agentName": "async-agent"},
         "requestContext": {
             "authorizer": {
@@ -276,6 +300,7 @@ def test_handler_streaming(setup_data):
     )
 
     event = {
+        "path": "/v1/agents/stream-agent/invoke",
         "pathParameters": {"agentName": "stream-agent"},
         "requestContext": {
             "authorizer": {
@@ -306,6 +331,7 @@ def test_handler_streaming(setup_data):
 
 def test_handler_session_id_propagation(setup_data):
     event = {
+        "path": "/v1/agents/echo-agent/invoke",
         "pathParameters": {"agentName": "echo-agent"},
         "requestContext": {
             "authorizer": {
@@ -344,6 +370,7 @@ def test_handler_session_id_propagation(setup_data):
 
 def test_handler_session_id_from_runtime(setup_data):
     event = {
+        "path": "/v1/agents/echo-agent/invoke",
         "pathParameters": {"agentName": "echo-agent"},
         "requestContext": {
             "authorizer": {
@@ -607,6 +634,7 @@ def test_handler_async_uses_registered_webhook_callback(setup_data):
     )
 
     event = {
+        "path": "/v1/agents/async-webhook-agent/invoke",
         "pathParameters": {"agentName": "async-webhook-agent"},
         "requestContext": {
             "authorizer": {
@@ -651,6 +679,7 @@ def test_handler_async_rejects_unknown_webhook_id(setup_data):
     )
 
     event = {
+        "path": "/v1/agents/async-agent-missing-webhook/invoke",
         "pathParameters": {"agentName": "async-agent-missing-webhook"},
         "requestContext": {
             "authorizer": {


### PR DESCRIPTION
## Summary
- align API Gateway invoke route wiring with OpenAPI contract at `/v1/agents/{agentName}/invoke`
- enforce contract handling in bridge invoke path (path parameter required; legacy `/v1/invoke` rejected)
- add CDK/unit/integration regression coverage for contract route and legacy route absence

## Validation Evidence
- `make preflight-session` (PASS)
- `make test-unit` (PASS, 279 passed)
- `make test-int` (PASS, 4 passed)
- `cd infra/cdk && npx --no-install jest test/platform-stack.test.ts --runInBand` (PASS, includes new route assertion)
- `make validate-local` (PASS)
- `make pre-validate-session` (PASS)
- `make worktree-push-issue` (PASS; enforced preflight + pre-validate)

Closes #91
