### PR TITLE
TASK-093: Harden tenant isolation for job access paths

### DIFF
--- a/infra/cdk/lib/tenant-stack.ts
+++ b/infra/cdk/lib/tenant-stack.ts
@@ -87,8 +87,6 @@ export class TenantStack extends cdk.Stack {
           'ForAllValues:StringLike': {
             'dynamodb:LeadingKeys': [
               `TENANT#${tenantId}*`,
-              `JOB#*`, // Fallback for JOB table where PK is JOB#uuid (see models.py)
-              `SESSION#*`, // Fallback for SESSION table if needed
             ],
           },
         },

--- a/src/async_runner/handler.py
+++ b/src/async_runner/handler.py
@@ -63,7 +63,7 @@ def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
         sub="async-runner",
     )
     db = TenantScopedDynamoDB(tenant_context)
-    key = {"PK": f"JOB#{job_id}", "SK": "METADATA"}
+    key = {"PK": f"TENANT#{tenant_id}", "SK": f"JOB#{job_id}"}
     job = db.get_item(JOBS_TABLE, key)
     if job is None:
         return _error_response(404, "NOT_FOUND", f"Job '{job_id}' not found")

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -458,8 +458,8 @@ def _coerce_optional_string(value: Any) -> str | None:
     return text
 
 
-def _job_key(job_id: str) -> dict[str, str]:
-    return {"PK": f"JOB#{job_id}", "SK": "METADATA"}
+def _job_key(tenant_id: str, job_id: str) -> dict[str, str]:
+    return {"PK": f"TENANT#{tenant_id}", "SK": f"JOB#{job_id}"}
 
 
 def _webhook_key(webhook_id: str) -> dict[str, str]:
@@ -474,9 +474,9 @@ def get_job_status(
         return error_response(400, "INVALID_REQUEST", "Missing jobId in path", request_id)
 
     db = TenantScopedDynamoDB(tenant_context)
-    record = db.get_item(JOBS_TABLE, _job_key(job_id))
+    record = db.get_item(JOBS_TABLE, _job_key(tenant_context.tenant_id, job_id))
 
-    if record is None or str(record.get("tenant_id", "")) != tenant_context.tenant_id:
+    if record is None:
         return error_response(404, "NOT_FOUND", f"Job '{job_id}' not found", request_id)
 
     result_url: str | None = None

--- a/src/data-access-lib/src/data_access/client.py
+++ b/src/data-access-lib/src/data_access/client.py
@@ -112,7 +112,7 @@ class TenantScopedDynamoDB:
 
         Convention: all platform DynamoDB tables use "PK" as the partition key
         attribute name (single-table design standard).  Non-TENANT# prefixed PKs
-        (AGENT#, JOB#, LOCK#, TOOL#) bypass this check; IAM governs those tables.
+        (AGENT#, LOCK#, TOOL#) bypass this check; IAM governs those tables.
         """
         pk = key.get("PK", "")
         if isinstance(pk, str) and pk.startswith(_TENANT_PK_PREFIX):

--- a/src/data-access-lib/src/data_access/models.py
+++ b/src/data-access-lib/src/data_access/models.py
@@ -210,7 +210,7 @@ class InvocationRecord:
 
 # ---------------------------------------------------------------------------
 # Table: platform-jobs
-# PK: JOB#{jobId}  SK: METADATA
+# PK: TENANT#{tenantId}  SK: JOB#{jobId}
 # Capacity: on-demand. TTL: 7 days.
 # ---------------------------------------------------------------------------
 
@@ -239,11 +239,11 @@ class JobRecord:
 
     @property
     def pk(self) -> str:
-        return f"JOB#{self.job_id}"
+        return f"TENANT#{self.tenant_id}"
 
     @property
     def sk(self) -> str:
-        return "METADATA"
+        return f"JOB#{self.job_id}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_async_runner_handler.py
+++ b/tests/unit/test_async_runner_handler.py
@@ -60,8 +60,8 @@ def jobs_table(mock_aws_services: None):
     table = ddb.Table("platform-jobs")
     table.put_item(
         Item={
-            "PK": "JOB#job-001",
-            "SK": "METADATA",
+            "PK": "TENANT#t-001",
+            "SK": "JOB#job-001",
             "job_id": "job-001",
             "tenant_id": "t-001",
             "agent_name": "echo-agent",
@@ -101,14 +101,14 @@ def test_handler_marks_job_running_on_healthybusy(jobs_table) -> None:
     assert payload["status"] == "running"
     assert payload["runtimeStatus"] == "HealthyBusy"
 
-    item = jobs_table.get_item(Key={"PK": "JOB#job-001", "SK": "METADATA"})["Item"]
+    item = jobs_table.get_item(Key={"PK": "TENANT#t-001", "SK": "JOB#job-001"})["Item"]
     assert item["status"] == "running"
     assert "started_at" in item
 
 
 def test_handler_marks_job_completed_on_healthy(jobs_table) -> None:
     jobs_table.update_item(
-        Key={"PK": "JOB#job-001", "SK": "METADATA"},
+        Key={"PK": "TENANT#t-001", "SK": "JOB#job-001"},
         UpdateExpression="SET #status = :status, started_at = :started",
         ExpressionAttributeNames={"#status": "status"},
         ExpressionAttributeValues={
@@ -125,7 +125,7 @@ def test_handler_marks_job_completed_on_healthy(jobs_table) -> None:
     assert payload["status"] == "completed"
     assert payload["runtimeStatus"] == "Healthy"
 
-    item = jobs_table.get_item(Key={"PK": "JOB#job-001", "SK": "METADATA"})["Item"]
+    item = jobs_table.get_item(Key={"PK": "TENANT#t-001", "SK": "JOB#job-001"})["Item"]
     assert item["status"] == "completed"
     assert "completed_at" in item
 

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -249,7 +249,7 @@ def test_handler_async_accepted(setup_data):
 
         # Verify job was written to DynamoDB
         jobs_table = ddb.Table("platform-jobs")
-        job_item = jobs_table.get_item(Key={"PK": f"JOB#{body['jobId']}", "SK": "METADATA"})
+        job_item = jobs_table.get_item(Key={"PK": "TENANT#t-001", "SK": f"JOB#{body['jobId']}"})
         assert "Item" in job_item
         assert job_item["Item"]["status"] == "pending"
 
@@ -385,8 +385,8 @@ def test_get_job_status_returns_job_payload(setup_data):
     jobs_table = ddb.Table("platform-jobs")
     jobs_table.put_item(
         Item={
-            "PK": "JOB#job-123",
-            "SK": "METADATA",
+            "PK": "TENANT#t-001",
+            "SK": "JOB#job-123",
             "job_id": "job-123",
             "tenant_id": "t-001",
             "agent_name": "echo-agent",
@@ -434,8 +434,8 @@ def test_get_job_status_generates_presigned_result_url_with_expected_expiry(setu
 
     jobs_table.put_item(
         Item={
-            "PK": "JOB#job-456",
-            "SK": "METADATA",
+            "PK": "TENANT#t-001",
+            "SK": "JOB#job-456",
             "job_id": "job-456",
             "tenant_id": "t-001",
             "agent_name": "echo-agent",
@@ -482,8 +482,8 @@ def test_get_job_status_hides_other_tenants_job(setup_data):
     jobs_table = ddb.Table("platform-jobs")
     jobs_table.put_item(
         Item={
-            "PK": "JOB#job-foreign",
-            "SK": "METADATA",
+            "PK": "TENANT#t-999",
+            "SK": "JOB#job-foreign",
             "job_id": "job-foreign",
             "tenant_id": "t-999",
             "agent_name": "echo-agent",
@@ -626,7 +626,8 @@ def test_handler_async_uses_registered_webhook_callback(setup_data):
     response_body = json.loads(response["body"])
     assert response_body["webhookDelivery"] == "registered"
 
-    job = jobs_table.get_item(Key={"PK": f"JOB#{response_body['jobId']}", "SK": "METADATA"})["Item"]
+    job_id = response_body["jobId"]
+    job = jobs_table.get_item(Key={"PK": "TENANT#t-001", "SK": f"JOB#{job_id}"})["Item"]
     assert job["webhook_url"] == "https://example.com/hooks/job"
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -289,14 +289,15 @@ def _make_job(**overrides) -> JobRecord:
 
 class TestJobRecord:
     def test_pk_format(self):
-        job = _make_job(job_id="job-xyz")
-        assert job.pk == "JOB#job-xyz"
+        job = _make_job(tenant_id="t-xyz")
+        assert job.pk == "TENANT#t-xyz"
 
-    def test_sk_is_metadata(self):
-        assert _make_job().sk == "METADATA"
+    def test_sk_format(self):
+        job = _make_job(job_id="job-123")
+        assert job.sk == "JOB#job-123"
 
-    def test_pk_starts_with_job_prefix(self):
-        assert _make_job().pk.startswith("JOB#")
+    def test_pk_starts_with_tenant_prefix(self):
+        assert _make_job().pk.startswith("TENANT#")
 
     def test_optional_fields_default(self):
         job = _make_job()


### PR DESCRIPTION
Closes #93. Re-partitions the platform-jobs table to use tenantId in the partition key and hardens the IAM policy in TenantStack.