### PR TITLE
Issue #106: Harden CI OIDC bootstrap for deterministic AWS CLI availability

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,10 +30,27 @@ default:
 
 .aws_oidc_base:
   before_script:
-    - apt-get update && apt-get install -y curl nodejs npm unzip jq
+    - |
+      if command -v apt-get >/dev/null 2>&1 && [ "$(id -u)" -eq 0 ]; then
+        apt-get update && apt-get install -y curl nodejs npm unzip jq
+      else
+        echo "Skipping apt bootstrap (non-privileged runner or apt-get unavailable); using existing/user-space tools."
+      fi
     - curl -Ls https://astral.sh/uv/install.sh | sh
     - export PATH="$HOME/.local/bin:$PATH"
     - make ensure-tools
+    - |
+      export PATH="$HOME/.local/bin:$PATH"
+      if ! command -v aws >/dev/null 2>&1; then
+        echo "AWS CLI not found; installing user-scoped awscli with uv."
+        uv tool install --force awscli
+      fi
+      if ! command -v aws >/dev/null 2>&1; then
+        echo "ERROR: AWS CLI required for OIDC bootstrap is unavailable."
+        echo "Install aws in the runner image or allow uv package downloads."
+        exit 1
+      fi
+      aws --version
     - |
       KST=($(aws sts assume-role-with-web-identity \
         --role-arn ${AWS_ROLE_ARN} \


### PR DESCRIPTION
## Summary
- make CI apt bootstrap conditional on privileged runners to avoid hard failure on non-privileged profiles
- add deterministic AWS CLI bootstrap before OIDC STS assume-role (`uv tool install --force awscli` when `aws` is absent)
- add explicit `aws` preflight gate with actionable failure text before `assume-role-with-web-identity`

## Validation Evidence
- `make preflight-session` (PASS)
- `make pre-validate-session` (PASS)
- local fallback simulation (no preinstalled `aws`):
  - `uv tool uninstall awscli`
  - run CI-equivalent fallback block
  - `aws --version` resolved successfully from `~/.local/bin/aws`
- push hook pre-validation on force-push (PASS)

Closes #106
