### PR TITLE
fix(bridge): fix tenant-execution-role-arn contract mismatch (TASK-092)

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -598,6 +598,10 @@ def step_post_deploy(ctx: BootstrapContext) -> dict[str, Any]:
             "runtimeRegion": ctx.runtime_region,
             "fallback_region": ctx.fallback_region,
             "fallbackRegion": ctx.fallback_region,
+            "executionRoleArn": (
+                f"arn:aws:iam::{ctx.account_id}:role/"
+                f"platform-tenant-{admin_tenant_id}-execution-role"
+            ),
             "monthly_budget_usd": Decimal("10000"),
             "monthlyBudgetUsd": Decimal("10000"),
         }

--- a/scripts/dev-bootstrap.py
+++ b/scripts/dev-bootstrap.py
@@ -158,6 +158,9 @@ TENANT_FIXTURES: list[dict[str, Any]] = [
         "owner_email": "basic-test@example.local",
         "owner_team": "platform-test",
         "account_id": "000000000000",
+        "execution_role_arn": (
+            "arn:aws:iam::000000000000:role/platform-tenant-t-basic-001-execution-role"
+        ),
         "monthly_budget_usd": Decimal("100"),
     },
     {
@@ -173,6 +176,9 @@ TENANT_FIXTURES: list[dict[str, Any]] = [
         "owner_email": "premium-test@example.local",
         "owner_team": "platform-test",
         "account_id": "000000000000",
+        "execution_role_arn": (
+            "arn:aws:iam::000000000000:role/platform-tenant-t-premium-001-execution-role"
+        ),
         "monthly_budget_usd": Decimal("1000"),
     },
 ]

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -298,7 +298,9 @@ def error_response(status_code: int, code: str, message: str, request_id: str) -
     }
 
 
-def assume_tenant_role(tenant_id: str, account_id: str) -> dict[str, Any] | None:
+def assume_tenant_role(
+    tenant_id: str, account_id: str, role_arn: str | None = None
+) -> dict[str, Any] | None:
     """Assume the tenant's execution role via STS.
 
     Returns temporary credentials, or None if in local/mock mode.
@@ -306,7 +308,10 @@ def assume_tenant_role(tenant_id: str, account_id: str) -> dict[str, Any] | None
     if os.environ.get("MOCK_RUNTIME") == "true":
         return None
 
-    role_arn = f"arn:aws:iam::{account_id}:role/platform-tenant-{tenant_id}-role"
+    if not role_arn:
+        # Fallback to standard naming convention (fixed suffix mismatch: TASK-092)
+        role_arn = f"arn:aws:iam::{account_id}:role/platform-tenant-{tenant_id}-execution-role"
+
     try:
         sts = get_sts()
         response = sts.assume_role(
@@ -766,15 +771,25 @@ def invoke_real_runtime(
     if not tenant:
         return error_response(500, "INTERNAL_ERROR", "Tenant record not found", request_id)
 
-    account_id = tenant.get("account_id")
+    account_id = tenant.get("account_id") or tenant.get("accountId")
     if not account_id:
         return error_response(500, "INTERNAL_ERROR", "Tenant account_id not configured", request_id)
+
+    # Lookup execution role ARN (Phase 3 contract fix: TASK-092)
+    execution_role_arn = tenant.get("execution_role_arn") or tenant.get("executionRoleArn")
 
     # 2. Assume tenant role
     try:
         # returns credentials; will be used in Phase 3 to initialize SDK client
-        assume_tenant_role(tenant_context.tenant_id, account_id)
-        logger.info("Assumed tenant role", extra={"account_id": account_id, "region": region})
+        assume_tenant_role(tenant_context.tenant_id, str(account_id), role_arn=execution_role_arn)
+        logger.info(
+            "Assumed tenant role",
+            extra={
+                "account_id": account_id,
+                "region": region,
+                "role_arn": execution_role_arn or "constructed",
+            },
+        )
     except Exception:
         return error_response(500, "INTERNAL_ERROR", "Failed to assume tenant role", request_id)
 

--- a/src/data-access-lib/src/data_access/models.py
+++ b/src/data-access-lib/src/data_access/models.py
@@ -103,6 +103,7 @@ class TenantRecord:
     owner_email: str
     owner_team: str
     account_id: str  # AWS account ID for tenant Runtime
+    execution_role_arn: str | None = None
     memory_store_arn: str | None = None
     runtime_region: str | None = None
     fallback_region: str | None = None

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -362,6 +362,7 @@ def _serialize_tenant(item: dict[str, Any]) -> dict[str, Any]:
         "accountId": item.get("accountId"),
     }
     optional_fields = (
+        "executionRoleArn",
         "memoryStoreArn",
         "runtimeRegion",
         "fallbackRegion",
@@ -418,7 +419,7 @@ def _handle_create(
             field="monthlyBudgetUsd",
         )
 
-    for field in ("runtimeRegion", "fallbackRegion"):
+    for field in ("runtimeRegion", "fallbackRegion", "executionRoleArn"):
         text = _str_or_none(body.get(field))
         if text is not None:
             attributes[field] = text
@@ -567,7 +568,15 @@ def _handle_update(
         return _error(404, "NOT_FOUND", "Tenant not found")
 
     body = _require_json_body(event)
-    allowed = {"tier", "monthlyBudgetUsd", "status"}
+    allowed = {
+        "tier",
+        "monthlyBudgetUsd",
+        "status",
+        "executionRoleArn",
+        "memoryStoreArn",
+        "runtimeRegion",
+        "fallbackRegion",
+    }
     unknown = sorted(set(body) - allowed)
     if unknown:
         raise ValueError(f"Unsupported update field(s): {', '.join(unknown)}")
@@ -581,6 +590,16 @@ def _handle_update(
         attrs["monthlyBudgetUsd"] = _as_float(body["monthlyBudgetUsd"], field="monthlyBudgetUsd")
     if "status" in body:
         attrs["status"] = _normalize_status(body["status"])
+
+    # Infrastructure fields
+    for field in (
+        "executionRoleArn",
+        "memoryStoreArn",
+        "runtimeRegion",
+        "fallbackRegion",
+    ):
+        if field in body:
+            attrs[field] = _str_or_none(body[field])
 
     update_expression, expr_names, expr_values = _build_update_expression(attrs)
     db = _db_for_tenant(

--- a/tests/unit/test_bridge_role_arn.py
+++ b/tests/unit/test_bridge_role_arn.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from moto import mock_aws
+
+# Add project root and data-access-lib to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+from src.bridge.handler import assume_tenant_role, invoke_real_runtime
+
+
+@pytest.fixture
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"  # pragma: allowlist secret
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # pragma: allowlist secret
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+    os.environ["AWS_REGION"] = "eu-west-2"
+    os.environ["MOCK_RUNTIME"] = "false"
+
+
+@pytest.fixture
+def mock_aws_services(aws_credentials):
+    with mock_aws():
+        yield
+
+
+def test_assume_tenant_role_uses_correct_suffix(mock_aws_services):
+    tenant_id = "t-123"
+    account_id = "123456789012"
+    with patch("src.bridge.handler.get_sts") as mock_get_sts:
+        mock_sts = MagicMock()
+        mock_get_sts.return_value = mock_sts
+        mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
+        assume_tenant_role(tenant_id, account_id)
+        expected_role_arn = (
+            f"arn:aws:iam::{account_id}:role/platform-tenant-{tenant_id}-execution-role"
+        )
+        mock_sts.assume_role.assert_called_once()
+        args, kwargs = mock_sts.assume_role.call_args
+        assert kwargs["RoleArn"] == expected_role_arn
+
+
+def test_assume_tenant_role_uses_provided_arn(mock_aws_services):
+    tenant_id = "t-123"
+    account_id = "123456789012"
+    provided_arn = "arn:aws:iam::123456789012:role/custom-role"
+    with patch("src.bridge.handler.get_sts") as mock_get_sts:
+        mock_sts = MagicMock()
+        mock_get_sts.return_value = mock_sts
+        mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
+        assume_tenant_role(tenant_id, account_id, role_arn=provided_arn)
+        mock_sts.assume_role.assert_called_once()
+        args, kwargs = mock_sts.assume_role.call_args
+        assert kwargs["RoleArn"] == provided_arn
+
+
+@patch("src.bridge.handler.get_tenant_record")
+@patch("src.bridge.handler.assume_tenant_role")
+def test_invoke_real_runtime_uses_arn_from_record(mock_assume, mock_get_record, mock_aws_services):
+    tenant_context = MagicMock()
+    tenant_context.tenant_id = "t-123"
+    mock_get_record.return_value = {
+        "account_id": "123456789012",
+        "executionRoleArn": "arn:aws:iam::123456789012:role/record-role",
+    }
+    agent = MagicMock()
+    # We expect it to return 501 eventually, but we want to check assume_tenant_role call
+    from src.bridge.handler import invoke_real_runtime
+
+    invoke_real_runtime("eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None)
+    mock_assume.assert_called_once_with(
+        "t-123", "123456789012", role_arn="arn:aws:iam::123456789012:role/record-role"
+    )
+
+
+@patch("src.bridge.handler.get_tenant_record")
+@patch("src.bridge.handler.assume_tenant_role")
+def test_invoke_real_runtime_falls_back_to_constructed_arn(
+    mock_assume, mock_get_record, mock_aws_services
+):
+    tenant_context = MagicMock()
+    tenant_context.tenant_id = "t-123"
+    mock_get_record.return_value = {
+        "account_id": "123456789012"
+        # no executionRoleArn
+    }
+    agent = MagicMock()
+    invoke_real_runtime("eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None)
+    # Passing None to role_arn which will trigger fallback in assume_tenant_role
+    mock_assume.assert_called_once_with("t-123", "123456789012", role_arn=None)


### PR DESCRIPTION
Fixes the mismatch between Bridge Lambda fallback role name and TenantStack.

Changes:
- Corrected suffix to `-execution-role` in `src/bridge/handler.py`.
- Added `execution_role_arn` to `TenantRecord` and API.
- Updated bootstrap scripts.
- Added unit tests.