### PR TITLE
Issue #109: decouple tenant role resolution from hardcoded ARN naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 .PHONY: ops-reinstate-tenant ops-quota-report ops-invocation-report
 .PHONY: ops-security-events ops-dlq-inspect ops-dlq-redrive ops-error-rate
 .PHONY: ops-notify-tenant ops-service-health ops-billing-status
-.PHONY: ops-update-tenant-budget ops-fail-job ops-audit-export ops-page-security
+.PHONY: ops-update-tenant-budget ops-fail-job ops-audit-export ops-page-security ops-backfill-tenant-role-arn
 .PHONY: logs-bridge logs-authoriser logs-tenant-api logs-async-runner logs-bff
 .PHONY: plan-dev
 .PHONY: task-next task-list task-start task-resume task-finish task-prompt
@@ -569,6 +569,13 @@ ops-audit-export:
 ops-page-security:
 	@test -n "$(INCIDENT)" || (echo "ERROR: INCIDENT required" && exit 1)
 	uv run python scripts/ops.py page-security --incident "$(INCIDENT)" --tenant "$(or $(TENANT),unknown)" --env $(ENV)
+
+## ops-backfill-tenant-role-arn: Backfill/verify executionRoleArn from SSM for tenant records
+## Usage: make ops-backfill-tenant-role-arn [TENANT=t-abc123] [APPLY=1]
+ops-backfill-tenant-role-arn:
+	uv run python scripts/backfill_tenant_execution_role_arn.py \
+		$(if $(TENANT),--tenant-id $(TENANT),) \
+		$(if $(APPLY),--apply,)
 
 # =============================================================================
 # LOG STREAMING

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ make agent-test AGENT=my-agent
 # Operations
 make ops-top-tenants ENV=prod
 make ops-quota-report ENV=prod
+make ops-backfill-tenant-role-arn APPLY=1   # backfill/verify tenant executionRoleArn from SSM
 make failover-lock-acquire && make infra-set-runtime-region REGION=eu-central-1 ENV=prod
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,7 +57,8 @@ Client
       Returns usageIdentifierKey for usage plan enforcement
   → Bridge Lambda eu-west-2
       Reads invocation_mode from DynamoDB agent registry
-      Assumes tenant execution role via STS
+      Resolves executionRoleArn from tenant metadata (fallback: SSM /platform/tenants/{tenantId}/execution-role-arn)
+      Validates IAM role ARN/account match, then assumes tenant execution role via STS
       Reads active runtime region from SSM (cached 60s)
       Invokes AgentCore Runtime eu-west-1 via bedrock-agentcore SDK
       Writes INVOCATION record to DynamoDB on completion
@@ -263,6 +264,7 @@ tenant-premium      → Agent.Invoke tier:premium
 
 TenantStack deploys per-tenant on EventBridge platform.tenant.created event.
 It is NOT deployed by the platform pipeline — only triggered by tenant provisioning.
+Existing tenants are migrated/verified with `make ops-backfill-tenant-role-arn [APPLY=1]`.
 
 ## Known Constraints
 

--- a/scripts/backfill_tenant_execution_role_arn.py
+++ b/scripts/backfill_tenant_execution_role_arn.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Backfill/verify tenant execution role ARNs from authoritative SSM parameters."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+from botocore.exceptions import ClientError
+
+ROLE_ARN_PATTERN = re.compile(
+    r"^arn:(?:aws|aws-us-gov|aws-cn):iam::(?P<account_id>\d{12}):role/(?P<role_name>[\w+=,.@\-_/]+)$"
+)
+DEFAULT_TABLE_NAME = "platform-tenants"
+DEFAULT_PARAM_TEMPLATE = "/platform/tenants/{tenant_id}/execution-role-arn"
+
+
+@dataclass(frozen=True)
+class TenantRow:
+    pk: str
+    sk: str
+    tenant_id: str
+    account_id: str
+    execution_role_arn: str | None
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _validate_role_arn(role_arn: str, account_id: str) -> str | None:
+    match = ROLE_ARN_PATTERN.fullmatch(role_arn)
+    if not match:
+        return "malformed"
+    if match.group("account_id") != account_id:
+        return "account-mismatch"
+    return None
+
+
+def _read_execution_role_from_ssm(ssm: Any, *, tenant_id: str, param_template: str) -> str | None:
+    parameter_name = param_template.format(tenant_id=tenant_id)
+    try:
+        response = ssm.get_parameter(Name=parameter_name)
+    except ClientError as exc:
+        code = str(exc.response.get("Error", {}).get("Code", ""))
+        if code == "ParameterNotFound":
+            return None
+        raise
+    parameter = response.get("Parameter", {})
+    return _str_or_none(parameter.get("Value"))
+
+
+def _tenant_row(item: dict[str, Any]) -> TenantRow | None:
+    pk = _str_or_none(item.get("PK"))
+    sk = _str_or_none(item.get("SK"))
+    tenant_id = _str_or_none(item.get("tenant_id") or item.get("tenantId"))
+    account_id = _str_or_none(item.get("account_id") or item.get("accountId"))
+    execution_role_arn = _str_or_none(
+        item.get("execution_role_arn") or item.get("executionRoleArn")
+    )
+    if not pk or not sk or not tenant_id or not account_id:
+        return None
+    return TenantRow(
+        pk=pk,
+        sk=sk,
+        tenant_id=tenant_id,
+        account_id=account_id,
+        execution_role_arn=execution_role_arn,
+    )
+
+
+def _scan_tenant_rows(table: Any, *, tenant_id: str | None) -> list[TenantRow]:
+    if tenant_id:
+        item = table.get_item(Key={"PK": f"TENANT#{tenant_id}", "SK": "METADATA"}).get("Item")
+        row = _tenant_row(item) if isinstance(item, dict) else None
+        return [row] if row else []
+
+    rows: list[TenantRow] = []
+    scan_kwargs: dict[str, Any] = {"FilterExpression": Attr("SK").eq("METADATA")}
+    while True:
+        response = table.scan(**scan_kwargs)
+        for item in response.get("Items", []):
+            if not isinstance(item, dict):
+                continue
+            row = _tenant_row(item)
+            if row is not None:
+                rows.append(row)
+        if "LastEvaluatedKey" not in response:
+            break
+        scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+    return rows
+
+
+def _apply_backfill(table: Any, *, row: TenantRow, execution_role_arn: str) -> None:
+    table.update_item(
+        Key={"PK": row.pk, "SK": row.sk},
+        UpdateExpression=(
+            "SET executionRoleArn = :executionRoleArn, "
+            "execution_role_arn = :executionRoleArn, "
+            "updatedAt = :updatedAt"
+        ),
+        ExpressionAttributeValues={
+            ":executionRoleArn": execution_role_arn,
+            ":updatedAt": _utc_now(),
+        },
+        ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    if not args.region:
+        print("AWS region is required. Set AWS_REGION or pass --region.")
+        return 2
+
+    session = boto3.session.Session(region_name=args.region)
+    ddb = session.resource("dynamodb")
+    ssm = session.client("ssm")
+    table = ddb.Table(args.table_name)
+
+    rows = _scan_tenant_rows(table, tenant_id=args.tenant_id)
+    if not rows:
+        print("No tenant rows found")
+        return 1
+
+    verified = 0
+    backfilled = 0
+    unresolved = 0
+    malformed = 0
+
+    for row in rows:
+        current = row.execution_role_arn
+        if current:
+            validation_error = _validate_role_arn(current, row.account_id)
+            if validation_error is None:
+                verified += 1
+                print(f"[verified] tenant={row.tenant_id} source=record roleArn={current}")
+                continue
+            malformed += 1
+            print(
+                "[invalid] "
+                f"tenant={row.tenant_id} "
+                "source=record "
+                f"error={validation_error} "
+                f"roleArn={current}"
+            )
+            continue
+
+        resolved = _read_execution_role_from_ssm(
+            ssm,
+            tenant_id=row.tenant_id,
+            param_template=args.param_template,
+        )
+        if not resolved:
+            unresolved += 1
+            print(f"[missing] tenant={row.tenant_id} source=ssm")
+            continue
+
+        validation_error = _validate_role_arn(resolved, row.account_id)
+        if validation_error is not None:
+            malformed += 1
+            print(
+                "[invalid] "
+                f"tenant={row.tenant_id} "
+                "source=ssm "
+                f"error={validation_error} "
+                f"roleArn={resolved}"
+            )
+            continue
+
+        verified += 1
+        if args.apply:
+            _apply_backfill(table, row=row, execution_role_arn=resolved)
+            backfilled += 1
+            print(f"[backfilled] tenant={row.tenant_id} roleArn={resolved}")
+        else:
+            print(f"[ready] tenant={row.tenant_id} roleArn={resolved}")
+
+    print(
+        "Summary:",
+        f"scanned={len(rows)}",
+        f"verified={verified}",
+        f"backfilled={backfilled}",
+        f"unresolved={unresolved}",
+        f"invalid={malformed}",
+    )
+    if unresolved > 0 or malformed > 0:
+        return 1
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Backfill and verify executionRoleArn for tenant records."
+    )
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION"), help="AWS region")
+    parser.add_argument("--table-name", default=DEFAULT_TABLE_NAME, help="Tenant table name")
+    parser.add_argument(
+        "--param-template",
+        default=DEFAULT_PARAM_TEMPLATE,
+        help="SSM parameter template (must include {tenant_id})",
+    )
+    parser.add_argument("--tenant-id", default=None, help="Only process one tenant ID")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write back resolved ARN to tenant records. Default is verify-only mode.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -9,6 +9,7 @@ ADRs: ADR-003, ADR-005, ADR-009, ADR-010
 
 import json
 import os
+import re
 import secrets
 import time
 import urllib.parse
@@ -22,6 +23,7 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
 from data_access import TenantScopedDynamoDB, TenantScopedS3
 from data_access.models import (
     AgentRecord,
@@ -51,7 +53,13 @@ RUNTIME_REGION_PARAM = os.environ.get("RUNTIME_REGION_PARAM", "/platform/config/
 MOCK_RUNTIME_URL_PARAM = os.environ.get(
     "MOCK_RUNTIME_URL_PARAM", "/platform/config/mock-runtime-url"
 )
+TENANT_EXECUTION_ROLE_PARAM_TEMPLATE = os.environ.get(
+    "TENANT_EXECUTION_ROLE_PARAM_TEMPLATE", "/platform/tenants/{tenant_id}/execution-role-arn"
+)
 JOB_RESULT_URL_EXPIRY_SECONDS = int(os.environ.get("JOB_RESULT_URL_EXPIRY_SECONDS", "3600"))
+IAM_ROLE_ARN_PATTERN = re.compile(
+    r"^arn:(?:aws|aws-us-gov|aws-cn):iam::(?P<account_id>\d{12}):role/(?P<role_name>[\w+=,.@\-_/]+)$"
+)
 
 # TTL constants from models
 INVOCATION_TTL_SECONDS = 90 * 24 * 60 * 60
@@ -298,19 +306,78 @@ def error_response(status_code: int, code: str, message: str, request_id: str) -
     }
 
 
-def assume_tenant_role(
-    tenant_id: str, account_id: str, role_arn: str | None = None
-) -> dict[str, Any] | None:
+def _tenant_execution_role_param_name(tenant_id: str) -> str:
+    return TENANT_EXECUTION_ROLE_PARAM_TEMPLATE.format(tenant_id=tenant_id)
+
+
+def _get_execution_role_arn_from_ssm(tenant_id: str) -> str | None:
+    parameter_name = _tenant_execution_role_param_name(tenant_id)
+    try:
+        ssm = get_ssm()
+        response = ssm.get_parameter(Name=parameter_name)
+    except ClientError as exc:
+        code = str(exc.response.get("Error", {}).get("Code", ""))
+        if code == "ParameterNotFound":
+            logger.warning(
+                "Tenant execution role ARN parameter not found",
+                extra={"tenant_id": tenant_id, "parameter_name": parameter_name},
+            )
+            return None
+        logger.exception(
+            "Failed to fetch tenant execution role ARN from SSM",
+            extra={"tenant_id": tenant_id, "parameter_name": parameter_name},
+        )
+        raise
+
+    parameter = response.get("Parameter", {})
+    role_arn = _coerce_optional_string(parameter.get("Value"))
+    if role_arn is None:
+        logger.warning(
+            "Tenant execution role ARN parameter is empty",
+            extra={"tenant_id": tenant_id, "parameter_name": parameter_name},
+        )
+    return role_arn
+
+
+def _validate_execution_role_arn(role_arn: str, expected_account_id: str) -> str:
+    match = IAM_ROLE_ARN_PATTERN.fullmatch(role_arn)
+    if not match:
+        raise ValueError("Tenant execution role ARN is malformed")
+
+    if match.group("account_id") != expected_account_id:
+        raise ValueError("Tenant execution role ARN account mismatch")
+
+    return role_arn
+
+
+def resolve_tenant_execution_role_arn(
+    tenant: dict[str, Any], *, tenant_id: str, account_id: str
+) -> str | None:
+    role_arn = _coerce_optional_string(
+        tenant.get("execution_role_arn") or tenant.get("executionRoleArn")
+    )
+    source = "tenant-record"
+    if role_arn is None:
+        role_arn = _get_execution_role_arn_from_ssm(tenant_id)
+        source = "ssm"
+    if role_arn is None:
+        return None
+
+    validated = _validate_execution_role_arn(role_arn, expected_account_id=account_id)
+    logger.info(
+        "Resolved tenant execution role ARN",
+        extra={"tenant_id": tenant_id, "account_id": account_id, "source": source},
+    )
+    return validated
+
+
+def assume_tenant_role(tenant_id: str, role_arn: str) -> dict[str, Any] | None:
     """Assume the tenant's execution role via STS.
 
     Returns temporary credentials, or None if in local/mock mode.
     """
     if os.environ.get("MOCK_RUNTIME") == "true":
         return None
-
-    if not role_arn:
-        # Fallback to standard naming convention (fixed suffix mismatch: TASK-092)
-        role_arn = f"arn:aws:iam::{account_id}:role/platform-tenant-{tenant_id}-execution-role"
 
     try:
         sts = get_sts()
@@ -893,19 +960,39 @@ def invoke_real_runtime(
     if not account_id:
         return error_response(500, "INTERNAL_ERROR", "Tenant account_id not configured", request_id)
 
-    # Lookup execution role ARN (Phase 3 contract fix: TASK-092)
-    execution_role_arn = tenant.get("execution_role_arn") or tenant.get("executionRoleArn")
+    account_id_str = str(account_id)
+    try:
+        execution_role_arn = resolve_tenant_execution_role_arn(
+            tenant,
+            tenant_id=tenant_context.tenant_id,
+            account_id=account_id_str,
+        )
+    except ValueError as exc:
+        logger.warning(
+            "Tenant execution role ARN validation failed",
+            extra={"tenant_id": tenant_context.tenant_id, "account_id": account_id_str},
+        )
+        return error_response(500, "INTERNAL_ERROR", str(exc), request_id)
+    except Exception:
+        return error_response(
+            500, "INTERNAL_ERROR", "Failed to resolve tenant execution role ARN", request_id
+        )
+
+    if not execution_role_arn:
+        return error_response(
+            500, "INTERNAL_ERROR", "Tenant execution role ARN not configured", request_id
+        )
 
     # 2. Assume tenant role
     try:
         # returns credentials; will be used in Phase 3 to initialize SDK client
-        assume_tenant_role(tenant_context.tenant_id, str(account_id), role_arn=execution_role_arn)
+        assume_tenant_role(tenant_context.tenant_id, execution_role_arn)
         logger.info(
             "Assumed tenant role",
             extra={
-                "account_id": account_id,
+                "account_id": account_id_str,
                 "region": region,
-                "role_arn": execution_role_arn or "constructed",
+                "role_arn": execution_role_arn,
             },
         )
     except Exception:

--- a/tests/integration/test_bridge_role_resolution_contract.py
+++ b/tests/integration/test_bridge_role_resolution_contract.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+from src.bridge.handler import handler
+
+
+class FakeLambdaContext:
+    function_name = "bridge"
+    memory_limit_in_mb = 256
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:111111111111:function:bridge"
+    aws_request_id = "req-integration-role-resolution"
+
+
+@pytest.fixture
+def aws_credentials():
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"  # pragma: allowlist secret
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # pragma: allowlist secret
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+    os.environ["AWS_REGION"] = "eu-west-2"
+    os.environ["MOCK_RUNTIME"] = "false"
+
+
+@pytest.fixture
+def mock_aws_services(aws_credentials):
+    with mock_aws():
+        yield
+
+
+def _create_table(ddb: Any, table_name: str) -> None:
+    ddb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _seed_agent(ddb: Any) -> None:
+    ddb.Table("platform-agents").put_item(
+        Item={
+            "PK": "AGENT#echo-agent",
+            "SK": "VERSION#1.0.0",
+            "agent_name": "echo-agent",
+            "version": "1.0.0",
+            "owner_team": "platform-test",
+            "tier_minimum": "basic",
+            "layer_hash": "hash",
+            "layer_s3_key": "layer.zip",
+            "script_s3_key": "script.zip",
+            "deployed_at": "2026-01-01T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+        }
+    )
+
+
+def _invoke_event() -> dict[str, Any]:
+    return {
+        "httpMethod": "POST",
+        "path": "/v1/agents/echo-agent/invoke",
+        "pathParameters": {"agentName": "echo-agent"},
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+        "body": json.dumps({"input": "hello"}),
+    }
+
+
+def test_handler_assume_role_uses_tenant_record_arn(mock_aws_services):
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    _create_table(ddb, "platform-agents")
+    _create_table(ddb, "platform-tenants")
+    _seed_agent(ddb)
+
+    ddb.Table("platform-tenants").put_item(
+        Item={
+            "PK": "TENANT#t-001",
+            "SK": "METADATA",
+            "tenantId": "t-001",
+            "accountId": "123456789012",
+            "executionRoleArn": "arn:aws:iam::123456789012:role/custom-record-role",
+        }
+    )
+
+    with (
+        patch(
+            "src.bridge.handler.get_config",
+            return_value={"runtime_region": "eu-west-1", "mock_runtime_url": None},
+        ),
+        patch("src.bridge.handler.get_sts") as mock_get_sts,
+    ):
+        mock_sts = MagicMock()
+        mock_get_sts.return_value = mock_sts
+        mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
+
+        response = handler(_invoke_event(), FakeLambdaContext())
+
+    assert response["statusCode"] == 501
+    _, kwargs = mock_sts.assume_role.call_args
+    assert kwargs["RoleArn"] == "arn:aws:iam::123456789012:role/custom-record-role"
+
+
+def test_handler_assume_role_uses_ssm_arn_when_tenant_record_missing_field(mock_aws_services):
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    ssm = boto3.client("ssm", region_name="eu-west-2")
+    _create_table(ddb, "platform-agents")
+    _create_table(ddb, "platform-tenants")
+    _seed_agent(ddb)
+
+    ddb.Table("platform-tenants").put_item(
+        Item={
+            "PK": "TENANT#t-001",
+            "SK": "METADATA",
+            "tenantId": "t-001",
+            "accountId": "123456789012",
+        }
+    )
+    ssm.put_parameter(
+        Name="/platform/tenants/t-001/execution-role-arn",
+        Value="arn:aws:iam::123456789012:role/custom-ssm-role",
+        Type="String",
+    )
+
+    with (
+        patch(
+            "src.bridge.handler.get_config",
+            return_value={"runtime_region": "eu-west-1", "mock_runtime_url": None},
+        ),
+        patch("src.bridge.handler.get_sts") as mock_get_sts,
+    ):
+        mock_sts = MagicMock()
+        mock_get_sts.return_value = mock_sts
+        mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
+
+        response = handler(_invoke_event(), FakeLambdaContext())
+
+    assert response["statusCode"] == 501
+    _, kwargs = mock_sts.assume_role.call_args
+    assert kwargs["RoleArn"] == "arn:aws:iam::123456789012:role/custom-ssm-role"

--- a/tests/unit/test_backfill_tenant_execution_role_arn.py
+++ b/tests/unit/test_backfill_tenant_execution_role_arn.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts import backfill_tenant_execution_role_arn as script
+
+
+@pytest.fixture
+def aws_credentials(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")  # pragma: allowlist secret
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")  # pragma: allowlist secret
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-2")
+    monkeypatch.setenv("AWS_REGION", "eu-west-2")
+
+
+@pytest.fixture
+def mock_aws_services(aws_credentials):
+    with mock_aws():
+        yield
+
+
+def _create_tenants_table() -> None:
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    ddb.create_table(
+        TableName="platform-tenants",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def test_backfill_apply_sets_execution_role_fields(mock_aws_services):
+    _create_tenants_table()
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    ssm = boto3.client("ssm", region_name="eu-west-2")
+    table = ddb.Table("platform-tenants")
+
+    table.put_item(
+        Item={
+            "PK": "TENANT#t-001",
+            "SK": "METADATA",
+            "tenantId": "t-001",
+            "accountId": "123456789012",
+        }
+    )
+    ssm.put_parameter(
+        Name="/platform/tenants/t-001/execution-role-arn",
+        Value="arn:aws:iam::123456789012:role/tenant-custom-role",
+        Type="String",
+    )
+
+    rc = script.run(
+        argparse.Namespace(
+            region="eu-west-2",
+            table_name="platform-tenants",
+            param_template="/platform/tenants/{tenant_id}/execution-role-arn",
+            tenant_id=None,
+            apply=True,
+        )
+    )
+
+    assert rc == 0
+    item = table.get_item(Key={"PK": "TENANT#t-001", "SK": "METADATA"})["Item"]
+    assert item["executionRoleArn"] == "arn:aws:iam::123456789012:role/tenant-custom-role"
+    assert item["execution_role_arn"] == "arn:aws:iam::123456789012:role/tenant-custom-role"
+
+
+def test_backfill_fails_on_account_mismatch(mock_aws_services):
+    _create_tenants_table()
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    table = ddb.Table("platform-tenants")
+
+    table.put_item(
+        Item={
+            "PK": "TENANT#t-002",
+            "SK": "METADATA",
+            "tenantId": "t-002",
+            "accountId": "123456789012",
+            "executionRoleArn": "arn:aws:iam::999999999999:role/wrong-account-role",
+        }
+    )
+
+    rc = script.run(
+        argparse.Namespace(
+            region="eu-west-2",
+            table_name="platform-tenants",
+            param_template="/platform/tenants/{tenant_id}/execution-role-arn",
+            tenant_id=None,
+            apply=False,
+        )
+    )
+
+    assert rc == 1

--- a/tests/unit/test_bridge_role_arn.py
+++ b/tests/unit/test_bridge_role_arn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -33,33 +34,21 @@ def mock_aws_services(aws_credentials):
         yield
 
 
-def test_assume_tenant_role_uses_correct_suffix(mock_aws_services):
-    tenant_id = "t-123"
-    account_id = "123456789012"
-    with patch("src.bridge.handler.get_sts") as mock_get_sts:
-        mock_sts = MagicMock()
-        mock_get_sts.return_value = mock_sts
-        mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
-        assume_tenant_role(tenant_id, account_id)
-        expected_role_arn = (
-            f"arn:aws:iam::{account_id}:role/platform-tenant-{tenant_id}-execution-role"
-        )
-        mock_sts.assume_role.assert_called_once()
-        args, kwargs = mock_sts.assume_role.call_args
-        assert kwargs["RoleArn"] == expected_role_arn
+def _error_message(response: dict[str, str]) -> str:
+    body = json.loads(response["body"])
+    return str(body["error"]["message"])
 
 
 def test_assume_tenant_role_uses_provided_arn(mock_aws_services):
     tenant_id = "t-123"
-    account_id = "123456789012"
     provided_arn = "arn:aws:iam::123456789012:role/custom-role"
     with patch("src.bridge.handler.get_sts") as mock_get_sts:
         mock_sts = MagicMock()
         mock_get_sts.return_value = mock_sts
         mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
-        assume_tenant_role(tenant_id, account_id, role_arn=provided_arn)
+        assume_tenant_role(tenant_id, provided_arn)
         mock_sts.assume_role.assert_called_once()
-        args, kwargs = mock_sts.assume_role.call_args
+        _, kwargs = mock_sts.assume_role.call_args
         assert kwargs["RoleArn"] == provided_arn
 
 
@@ -77,23 +66,84 @@ def test_invoke_real_runtime_uses_arn_from_record(mock_assume, mock_get_record, 
     from src.bridge.handler import invoke_real_runtime
 
     invoke_real_runtime("eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None)
-    mock_assume.assert_called_once_with(
-        "t-123", "123456789012", role_arn="arn:aws:iam::123456789012:role/record-role"
+    mock_assume.assert_called_once_with("t-123", "arn:aws:iam::123456789012:role/record-role")
+
+
+@patch("src.bridge.handler.get_tenant_record")
+@patch("src.bridge.handler._get_execution_role_arn_from_ssm")
+@patch("src.bridge.handler.assume_tenant_role")
+def test_invoke_real_runtime_uses_ssm_arn_when_record_missing(
+    mock_assume, mock_get_role_from_ssm, mock_get_record, mock_aws_services
+):
+    tenant_context = MagicMock()
+    tenant_context.tenant_id = "t-123"
+    mock_get_record.return_value = {"account_id": "123456789012"}
+    mock_get_role_from_ssm.return_value = "arn:aws:iam::123456789012:role/ssm-role"
+    agent = MagicMock()
+    invoke_real_runtime("eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None)
+    mock_assume.assert_called_once_with("t-123", "arn:aws:iam::123456789012:role/ssm-role")
+    mock_get_role_from_ssm.assert_called_once_with("t-123")
+
+
+@patch("src.bridge.handler.get_tenant_record")
+@patch("src.bridge.handler._get_execution_role_arn_from_ssm")
+@patch("src.bridge.handler.assume_tenant_role")
+def test_invoke_real_runtime_errors_when_execution_role_arn_missing(
+    mock_assume, mock_get_role_from_ssm, mock_get_record, mock_aws_services
+):
+    tenant_context = MagicMock()
+    tenant_context.tenant_id = "t-123"
+    mock_get_record.return_value = {"account_id": "123456789012"}
+    mock_get_role_from_ssm.return_value = None
+    agent = MagicMock()
+
+    response = invoke_real_runtime(
+        "eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None
     )
+
+    assert response["statusCode"] == 500
+    assert _error_message(response) == "Tenant execution role ARN not configured"
+    mock_assume.assert_not_called()
+
+
+@patch("src.bridge.handler.get_tenant_record")
+@patch("src.bridge.handler._get_execution_role_arn_from_ssm")
+@patch("src.bridge.handler.assume_tenant_role")
+def test_invoke_real_runtime_errors_when_execution_role_arn_malformed(
+    mock_assume, mock_get_role_from_ssm, mock_get_record, mock_aws_services
+):
+    tenant_context = MagicMock()
+    tenant_context.tenant_id = "t-123"
+    mock_get_record.return_value = {"account_id": "123456789012"}
+    mock_get_role_from_ssm.return_value = "not-an-arn"
+    agent = MagicMock()
+
+    response = invoke_real_runtime(
+        "eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None
+    )
+
+    assert response["statusCode"] == 500
+    assert _error_message(response) == "Tenant execution role ARN is malformed"
+    mock_assume.assert_not_called()
 
 
 @patch("src.bridge.handler.get_tenant_record")
 @patch("src.bridge.handler.assume_tenant_role")
-def test_invoke_real_runtime_falls_back_to_constructed_arn(
+def test_invoke_real_runtime_errors_when_execution_role_arn_account_mismatch(
     mock_assume, mock_get_record, mock_aws_services
 ):
     tenant_context = MagicMock()
     tenant_context.tenant_id = "t-123"
     mock_get_record.return_value = {
-        "account_id": "123456789012"
-        # no executionRoleArn
+        "account_id": "123456789012",
+        "executionRoleArn": "arn:aws:iam::999999999999:role/record-role",
     }
     agent = MagicMock()
-    invoke_real_runtime("eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None)
-    # Passing None to role_arn which will trigger fallback in assume_tenant_role
-    mock_assume.assert_called_once_with("t-123", "123456789012", role_arn=None)
+
+    response = invoke_real_runtime(
+        "eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None
+    )
+
+    assert response["statusCode"] == 500
+    assert _error_message(response) == "Tenant execution role ARN account mismatch"
+    mock_assume.assert_not_called()


### PR DESCRIPTION
## Summary
- remove Bridge fallback ARN-name construction and resolve execution role ARN from authoritative sources (tenant metadata first, SSM parameter fallback)
- validate resolved IAM role ARN format and account-id match before STS assume-role
- add migration/verification utility (`scripts/backfill_tenant_execution_role_arn.py`) and Make target (`make ops-backfill-tenant-role-arn`)
- add unit and integration coverage for resolution success/failure and assume-role contract paths
- document authoritative source and migration command in architecture/readme

## Validation Evidence
- `make preflight-session` -> PASS
- `uv run pytest tests/unit/test_bridge_role_arn.py tests/unit/test_backfill_tenant_execution_role_arn.py tests/integration/test_bridge_role_resolution_contract.py tests/unit/test_bridge_handler.py tests/integration/test_bridge_invoke_route_contract.py -q` -> `29 passed`
- `make pre-validate-session` -> PASS
- `make worktree-push-issue` -> PASS (includes enforced preflight + pre-validate + pre-push hook)

Closes #109
