### PR TITLE
feat: align invoke/jobs contract across CDK bridge and OpenAPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # =============================================================================
 
 .PHONY: help bootstrap ensure-tools validate-local validate-local-full
-.PHONY: validate-local-prereqs validate-python validate-cdk validate-cdk-ts validate-cdk-ts-push validate-cdk-synth
+.PHONY: validate-local-prereqs validate-python validate-openapi validate-cdk validate-cdk-ts validate-cdk-ts-push validate-cdk-synth
 .PHONY: validate-pre-push validate-secrets-diff validate-secrets-push validate-secrets-full
 .PHONY: docs-sync-audit docs-sync-stamp
 .PHONY: dev dev-stop dev-logs dev-invoke
@@ -146,6 +146,11 @@ validate-python:
 	uv run ruff check .
 	uv run ruff format --check .
 	cd infra/cdk && npx --no-install pyright --project ../../pyrightconfig.json
+	@$(MAKE) --no-print-directory validate-openapi
+
+## validate-openapi: Validate canonical OpenAPI route contract
+validate-openapi:
+	uv run pytest tests/unit/test_openapi_contract_routes.py
 
 ## validate-agent-manifest: Validate agent pyproject.toml [tool.agentcore] section
 validate-agent-manifest:

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -75,7 +75,7 @@ describe('PlatformStack (TASK-023)', () => {
     });
   });
 
-  test('wires invoke route to /v1/agents/{agentName}/invoke and removes legacy /v1/invoke', () => {
+  test('wires canonical invoke and jobs routes and removes legacy /v1/invoke', () => {
     const resources = template.findResources('AWS::ApiGateway::Resource');
     const pathParts = Object.values(resources).map((resource) => {
       const properties = (resource as { Properties?: { PathPart?: string } }).Properties;
@@ -85,6 +85,8 @@ describe('PlatformStack (TASK-023)', () => {
     expect(pathParts).toContain('agents');
     expect(pathParts).toContain('{agentName}');
     expect(pathParts).toContain('invoke');
+    expect(pathParts).toContain('jobs');
+    expect(pathParts).toContain('{jobId}');
 
     const stages = template.findResources('AWS::ApiGateway::Stage');
     const methodSettings = Object.values(stages).flatMap((stage) => {
@@ -97,6 +99,10 @@ describe('PlatformStack (TASK-023)', () => {
         expect.objectContaining({
           HttpMethod: 'POST',
           ResourcePath: '/~1v1~1agents~1{agentName}~1invoke',
+        }),
+        expect.objectContaining({
+          HttpMethod: 'GET',
+          ResourcePath: '/~1v1~1jobs~1{jobId}',
         }),
       ]),
     );

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -364,7 +364,10 @@ def handler(event: dict[str, Any], context: LambdaContext, response_stream: Any 
         path_params = {}
 
     # 2. Route non-invocation APIs implemented in TASK-048.
-    if method == "GET" and _coerce_optional_string(path_params.get("jobId")):
+    job_id = _coerce_optional_string(path_params.get("jobId"))
+    if method == "GET" and job_id:
+        if path and not _is_jobs_contract_path(path, job_id):
+            return error_response(404, "NOT_FOUND", "Route not found", request_id)
         return get_job_status(tenant_context, path_params, request_id)
     if method == "GET" and path.endswith("/v1/agents"):
         return list_agents(tenant_context)
@@ -460,6 +463,20 @@ def _is_invoke_contract_path(path: str, agent_name: str | None) -> bool:
     if not route_agent_name:
         return False
     return agent_name is None or route_agent_name == agent_name
+
+
+def _is_jobs_contract_path(path: str, job_id: str | None) -> bool:
+    normalized = str(path).rstrip("/")
+    segments = [segment for segment in normalized.split("/") if segment]
+    if len(segments) < 3:
+        return False
+    if segments[-3] != "v1" or segments[-2] != "jobs":
+        return False
+
+    route_job_id = segments[-1].strip()
+    if not route_job_id:
+        return False
+    return job_id is None or route_job_id == job_id
 
 
 def _parse_body(event: dict[str, Any]) -> dict[str, Any]:

--- a/tests/integration/test_bridge_invoke_route_contract.py
+++ b/tests/integration/test_bridge_invoke_route_contract.py
@@ -37,6 +37,22 @@ def _invoke_event(path: str, path_parameters: dict[str, str] | None, body: dict[
     }
 
 
+def _job_status_event(path: str, path_parameters: dict[str, str] | None) -> dict:
+    return {
+        "httpMethod": "GET",
+        "path": path,
+        "pathParameters": path_parameters,
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+    }
+
+
 def _agent(agent_name: str) -> AgentRecord:
     return AgentRecord(
         agent_name=agent_name,
@@ -81,6 +97,33 @@ def test_contract_invoke_route_uses_agent_name_path_parameter():
 
 def test_legacy_invoke_route_is_not_accepted():
     event = _invoke_event("/v1/invoke", None, {"agentName": "echo-agent", "input": "hello"})
+
+    response = handler(event, FakeLambdaContext())
+
+    assert response["statusCode"] == 404
+    body = json.loads(response["body"])
+    assert body["error"]["code"] == "NOT_FOUND"
+
+
+def test_contract_jobs_route_uses_path_parameter():
+    event = _job_status_event("/v1/jobs/job-123", {"jobId": "job-123"})
+
+    with patch(
+        "src.bridge.handler.get_job_status",
+        return_value={
+            "statusCode": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"jobId": "job-123", "status": "running"}),
+        },
+    ) as mock_get_job_status:
+        response = handler(event, FakeLambdaContext())
+
+    assert response["statusCode"] == 200
+    mock_get_job_status.assert_called_once()
+
+
+def test_non_contract_jobs_route_is_not_accepted():
+    event = _job_status_event("/v1/platform/ops/jobs/job-123", {"jobId": "job-123"})
 
     response = handler(event, FakeLambdaContext())
 

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -554,6 +554,76 @@ def test_get_job_status_returns_job_payload(setup_data):
     assert body["resultUrl"] is None
 
 
+def test_get_job_status_rejects_non_contract_route_with_job_id_path_param(setup_data):
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    jobs_table = ddb.Table("platform-jobs")
+    jobs_table.put_item(
+        Item={
+            "PK": "TENANT#t-001",
+            "SK": "JOB#job-123",
+            "job_id": "job-123",
+            "tenant_id": "t-001",
+            "agent_name": "echo-agent",
+            "status": "running",
+            "created_at": "2026-03-01T10:00:00Z",
+        }
+    )
+
+    event = {
+        "httpMethod": "GET",
+        "path": "/v1/platform/ops/jobs/job-123",
+        "pathParameters": {"jobId": "job-123"},
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+    }
+
+    response = handler(event, FakeLambdaContext())
+    assert response["statusCode"] == 404
+    body = json.loads(response["body"])
+    assert body["error"]["code"] == "NOT_FOUND"
+
+
+def test_get_job_status_accepts_stage_prefixed_contract_route(setup_data):
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    jobs_table = ddb.Table("platform-jobs")
+    jobs_table.put_item(
+        Item={
+            "PK": "TENANT#t-001",
+            "SK": "JOB#job-123",
+            "job_id": "job-123",
+            "tenant_id": "t-001",
+            "agent_name": "echo-agent",
+            "status": "running",
+            "created_at": "2026-03-01T10:00:00Z",
+        }
+    )
+
+    event = {
+        "httpMethod": "GET",
+        "path": "/prod/v1/jobs/job-123",
+        "pathParameters": {"jobId": "job-123"},
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+    }
+
+    response = handler(event, FakeLambdaContext())
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["jobId"] == "job-123"
+
+
 def test_get_job_status_generates_presigned_result_url_with_expected_expiry(setup_data):
     ddb = boto3.resource("dynamodb", region_name="eu-west-2")
     jobs_table = ddb.Table("platform-jobs")

--- a/tests/unit/test_openapi_contract_routes.py
+++ b/tests/unit/test_openapi_contract_routes.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def _load_openapi() -> dict:
+    spec_path = Path(__file__).resolve().parents[2] / "docs" / "openapi.yaml"
+    with spec_path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def test_openapi_declares_canonical_invoke_and_jobs_routes() -> None:
+    spec = _load_openapi()
+    paths = spec.get("paths", {})
+
+    assert "/v1/agents/{agentName}/invoke" in paths
+    assert "/v1/jobs/{jobId}" in paths
+    assert "/v1/invoke" not in paths
+
+    invoke_operation = paths["/v1/agents/{agentName}/invoke"].get("post", {})
+    assert invoke_operation.get("operationId") == "invokeAgent"
+
+    jobs_operation = paths["/v1/jobs/{jobId}"].get("get", {})
+    assert jobs_operation.get("operationId") == "getJob"
+
+
+def test_openapi_async_invoke_response_contract_points_to_jobs_polling() -> None:
+    spec = _load_openapi()
+    components = spec.get("components", {})
+    schemas = components.get("schemas", {})
+    async_schema = schemas.get("AgentInvokeAsyncAccepted", {})
+    required = async_schema.get("required", [])
+    properties = async_schema.get("properties", {})
+
+    assert "jobId" in required
+    assert "pollUrl" in required
+    assert "mode" in required
+    assert properties.get("mode", {}).get("enum") == ["async"]

--- a/tests/unit/test_ops_api.py
+++ b/tests/unit/test_ops_api.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src.tenant_api import handler as tenant_api_handler
 from tests.unit.test_tenant_api_handler import (
+    FakeDynamoDbResource,
     FakeEvents,
     FakeMemoryProvisioner,
     FakeScopedDb,
@@ -33,6 +34,7 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     deps = tenant_api_handler.TenantApiDependencies(
         secretsmanager=FakeSecretsManager(),
         events=FakeEvents(),
+        dynamodb=FakeDynamoDbResource(),
         usage_client=FakeUsageClient(),
         memory_provisioner=FakeMemoryProvisioner(),
     )

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -121,6 +121,25 @@ class FakeMemoryProvisioner:
         return {"memoryStoreArn": f"arn:aws:memory:eu-west-2::store/{tenant_id}"}
 
 
+class FakeDynamoDbTable:
+    def __init__(self) -> None:
+        self.scan_calls: list[dict[str, Any]] = []
+
+    def scan(self, **kwargs: Any) -> dict[str, Any]:
+        self.scan_calls.append(dict(kwargs))
+        return {"Items": []}
+
+
+class FakeDynamoDbResource:
+    def __init__(self) -> None:
+        self.tables: dict[str, FakeDynamoDbTable] = {}
+
+    def Table(self, name: str) -> FakeDynamoDbTable:  # noqa: N802 - boto3 compatibility
+        if name not in self.tables:
+            self.tables[name] = FakeDynamoDbTable()
+        return self.tables[name]
+
+
 class FakeLambdaContext:
     function_name = "tenant-api"
     memory_limit_in_mb = 256
@@ -139,6 +158,7 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     deps = tenant_api_handler.TenantApiDependencies(
         secretsmanager=FakeSecretsManager(),
         events=FakeEvents(),
+        dynamodb=FakeDynamoDbResource(),
         usage_client=FakeUsageClient(),
         memory_provisioner=FakeMemoryProvisioner(),
     )


### PR DESCRIPTION
## Summary
- enforce canonical jobs route parsing in bridge (`GET /v1/jobs/{jobId}`) alongside existing canonical invoke route handling
- add regression contract tests for invoke/jobs route alignment across bridge integration tests, bridge unit tests, and CDK synth assertions
- add OpenAPI contract validation test and wire it into `make validate-python` via new `validate-openapi` target
- update tenant/ops unit test fixtures for `TenantApiDependencies` to include the required `dynamodb` dependency so full unit suite passes

## Contract Decision
Canonical contract remains:
- `POST /v1/agents/{agentName}/invoke`
- `GET /v1/jobs/{jobId}`
- legacy `POST /v1/invoke` remains rejected

## Validation Evidence
- `uv run pytest tests/unit/test_bridge_handler.py tests/integration/test_bridge_invoke_route_contract.py tests/unit/test_openapi_contract_routes.py` (25 passed)
- `cd infra/cdk && npx --no-install jest test/platform-stack.test.ts -t "canonical invoke and jobs routes"` (passed)
- `make test-unit` (301 passed)
- `make validate-local` (passed)
- `make preflight-session` (passed)
- `make pre-validate-session` (passed)
- `make worktree-push-issue` (passed enforced preflight + pre-validate + push)

Closes #107.
