### PR TITLE
Issue #110: environment-aware canary policy and CI gate matrix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,12 @@ stages:
 variables:
   AWS_REGION: "eu-west-2"
   UV_LINK_MODE: "copy"
+  CANARY_POLICY_DEV: "all-at-once"
+  CANARY_POLICY_STAGING: "canary-10%-30m"
+  CANARY_POLICY_PROD: "canary-10%-15m"
+  STAGING_ROLLOUT_WINDOW_MINUTES: "30"
+  PROD_ROLLOUT_WINDOW_MINUTES: "15"
+  PROD_APPROVAL_MODE: "protected-environment-two-reviewer"
   # Default roles (should be overridden in GitLab CI/CD variables)
   AWS_ROLE_ARN_VALIDATE: ${AWS_ROLE_ARN_VALIDATE}
   AWS_ROLE_ARN_DEPLOY_DEV: ${AWS_ROLE_ARN_DEPLOY_DEV}
@@ -65,6 +71,19 @@ default:
       export AWS_DEFAULT_REGION=${AWS_REGION}
       export AWS_REGION=${AWS_REGION}
 
+.test_job_base:
+  stage: test
+  extends: .aws_oidc_base
+  variables:
+    AWS_ROLE_ARN: ${AWS_ROLE_ARN_VALIDATE}
+  interruptible: true
+
+.deploy_job_base:
+  extends: .aws_oidc_base
+  allow_failure: false
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+
 # --- VALIDATE STAGE ---
 
 validate:
@@ -78,20 +97,35 @@ validate:
     - make validate-secrets-full
   interruptible: true
 
-# --- TEST STAGE ---
-
-test-unit:
-  stage: test
+validate-pipeline-policy:
+  stage: validate
   extends: .aws_oidc_base
   variables:
     AWS_ROLE_ARN: ${AWS_ROLE_ARN_VALIDATE}
+  script:
+    - PYTHONPATH=. uv run pytest tests/unit/test_issue_110_ci_policy.py -v --tb=short
+  interruptible: true
+
+# --- TEST STAGE ---
+
+test-unit:
+  extends: .test_job_base
   script:
     - make test-unit PYTEST_ARGS="--junitxml=junit-report.xml"
   artifacts:
     when: always
     reports:
       junit: junit-report.xml
-  interruptible: true
+
+test-integration:
+  extends: .test_job_base
+  script:
+    - make test-int
+
+test-cdk:
+  extends: .test_job_base
+  script:
+    - cd infra/cdk && npm test -- --runInBand
 
 # --- PLAN STAGE ---
 
@@ -117,48 +151,82 @@ plan-infra:
 
 deploy-dev:
   stage: deploy-dev
-  extends: .aws_oidc_base
+  extends: .deploy_job_base
   variables:
     AWS_ROLE_ARN: ${AWS_ROLE_ARN_DEPLOY_DEV}
     ENV: dev
   script:
+    - echo "Applying canary policy for ${ENV}: ${CANARY_POLICY_DEV}"
     - make infra-deploy ENV=dev
     - make spa-deploy ENV=dev
   environment:
     name: dev
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    deployment_tier: development
 
 # --- DEPLOY STAGING ---
 
 deploy-staging:
   stage: deploy-staging
-  extends: .aws_oidc_base
+  extends: .deploy_job_base
   variables:
     AWS_ROLE_ARN: ${AWS_ROLE_ARN_DEPLOY_STAGING}
     ENV: staging
   script:
+    - echo "Applying canary policy for ${ENV}: ${CANARY_POLICY_STAGING}"
+    - echo "Staging rollout observation window: ${STAGING_ROLLOUT_WINDOW_MINUTES} minutes"
     - make infra-deploy ENV=staging
     - make spa-deploy ENV=staging
   environment:
     name: staging
+    deployment_tier: staging
+  allow_failure: false
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: manual
+
+staging-rollout-window:
+  stage: deploy-staging
+  image: alpine:3.21
+  needs: ["deploy-staging"]
+  script:
+    - echo "Staging rollout window complete after ${STAGING_ROLLOUT_WINDOW_MINUTES} minutes."
+  when: delayed
+  start_in: 30 minutes
+  allow_failure: false
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
 
 # --- DEPLOY PROD ---
 
 deploy-prod:
   stage: deploy-prod
-  extends: .aws_oidc_base
+  extends: .deploy_job_base
+  needs: ["staging-rollout-window"]
   variables:
     AWS_ROLE_ARN: ${AWS_ROLE_ARN_DEPLOY_PROD}
     ENV: prod
   script:
+    - test "${PROD_APPROVAL_MODE}" = "protected-environment-two-reviewer"
+    - echo "Applying canary policy for ${ENV}: ${CANARY_POLICY_PROD}"
+    - echo "Production rollout observation window: ${PROD_ROLLOUT_WINDOW_MINUTES} minutes"
     - make infra-deploy-prod-ci
     - make spa-deploy ENV=prod
   environment:
     name: prod
+    deployment_tier: production
+  allow_failure: false
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: manual
+
+prod-rollout-window:
+  stage: deploy-prod
+  image: alpine:3.21
+  needs: ["deploy-prod"]
+  script:
+    - echo "Production rollout window complete after ${PROD_ROLLOUT_WINDOW_MINUTES} minutes."
+  when: delayed
+  start_in: 15 minutes
+  allow_failure: false
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -38,6 +38,11 @@ type PythonLambdaProps = {
   environment?: Record<string, string>;
 };
 
+type BridgeCanaryPolicy = {
+  readonly deploymentConfig: codedeploy.ILambdaDeploymentConfig;
+  readonly summary: string;
+};
+
 export interface PlatformStackProps extends cdk.StackProps {
   readonly vpc: ec2.IVpc;
   readonly tenantDataKey: kms.IKey;
@@ -73,7 +78,8 @@ export class PlatformStack extends cdk.Stack {
     super(scope, id, props);
     this.vpc = props.vpc;
 
-    const env = this.node.tryGetContext('env') as string;
+    const env = ((this.node.tryGetContext('env') as string | undefined) ?? 'dev').toLowerCase();
+    const bridgeCanaryPolicy = this.resolveBridgeCanaryPolicy(env);
 
     // --- Secrets ---
 
@@ -378,13 +384,18 @@ export class PlatformStack extends cdk.Stack {
 
     new codedeploy.LambdaDeploymentGroup(this, 'BridgeCanaryDeploymentGroup', {
       alias: bridgeAlias,
-      deploymentConfig: codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_5MINUTES,
+      deploymentConfig: bridgeCanaryPolicy.deploymentConfig,
       alarms: [bridgeErrorRateHighAlarm],
       autoRollback: {
         deploymentInAlarm: true,
         failedDeployment: true,
         stoppedDeployment: true,
       },
+    });
+
+    new cdk.CfnOutput(this, 'BridgeCanaryPolicy', {
+      description: 'Environment-specific bridge rollout policy',
+      value: bridgeCanaryPolicy.summary,
     });
 
     const authoriserAlias = new lambda.Alias(this, 'AuthoriserLiveAlias', {
@@ -912,5 +923,27 @@ export class PlatformStack extends cdk.Stack {
         ...props.environment,
       },
     });
+  }
+
+  private resolveBridgeCanaryPolicy(env: string): BridgeCanaryPolicy {
+    switch (env) {
+      case 'dev':
+        return {
+          deploymentConfig: codedeploy.LambdaDeploymentConfig.ALL_AT_ONCE,
+          summary: 'dev=all-at-once',
+        };
+      case 'staging':
+        return {
+          deploymentConfig: codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_30MINUTES,
+          summary: 'staging=canary-10%-30m',
+        };
+      case 'prod':
+        return {
+          deploymentConfig: codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_15MINUTES,
+          summary: 'prod=canary-10%-15m',
+        };
+      default:
+        throw new Error(`Unsupported env context for canary policy: ${env}`);
+    }
   }
 }

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -5,8 +5,12 @@ import * as kms from 'aws-cdk-lib/aws-kms';
 import { PlatformStack } from '../lib/platform-stack';
 
 describe('PlatformStack (TASK-023)', () => {
-  const synthTemplate = () => {
-    const app = new cdk.App();
+  const synthTemplate = (environment: 'dev' | 'staging' | 'prod' = 'dev') => {
+    const app = new cdk.App({
+      context: {
+        env: environment,
+      },
+    });
     const env = { account: '123456789012', region: 'eu-west-2' };
     const identityStack = new cdk.Stack(app, 'IdentityStack', { env });
     const mockKey = new kms.Key(identityStack, 'MockKey');
@@ -25,7 +29,7 @@ describe('PlatformStack (TASK-023)', () => {
       ],
     });
 
-    const stack = new PlatformStack(app, 'platform-core-dev', {
+    const stack = new PlatformStack(app, `platform-core-${environment}`, {
       env,
       vpc: mockVpc,
       tenantDataKey: mockKey,
@@ -33,7 +37,7 @@ describe('PlatformStack (TASK-023)', () => {
     });
     return Template.fromStack(stack);
   };
-  const template = synthTemplate();
+  const template = synthTemplate('dev');
 
   test('creates all required DynamoDB tables with PITR and encryption', () => {
     template.resourceCountIs('AWS::DynamoDB::Table', 8);
@@ -116,15 +120,34 @@ describe('PlatformStack (TASK-023)', () => {
     );
   });
 
-  test('creates bridge canary deployment group with error-rate auto-rollback alarm', () => {
-    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
-      AlarmName: 'platform-core-dev-error_rate_high',
+  test('creates environment-aware bridge rollout policy with auto-rollback alarm', () => {
+    const devTemplate = synthTemplate('dev');
+    const stagingTemplate = synthTemplate('staging');
+    const prodTemplate = synthTemplate('prod');
+
+    devTemplate.hasResourceProperties('AWS::CodeDeploy::DeploymentGroup', {
+      DeploymentConfigName: 'CodeDeployDefault.LambdaAllAtOnce',
+    });
+    stagingTemplate.hasResourceProperties('AWS::CodeDeploy::DeploymentGroup', {
+      DeploymentConfigName: 'CodeDeployDefault.LambdaCanary10Percent30Minutes',
+    });
+    prodTemplate.hasResourceProperties('AWS::CodeDeploy::DeploymentGroup', {
+      DeploymentConfigName: 'CodeDeployDefault.LambdaCanary10Percent15Minutes',
+    });
+
+    stagingTemplate.hasOutput('BridgeCanaryPolicy', {
+      Value: 'staging=canary-10%-30m',
+    });
+    prodTemplate.hasOutput('BridgeCanaryPolicy', {
+      Value: 'prod=canary-10%-15m',
+    });
+
+    prodTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'platform-core-prod-error_rate_high',
       ComparisonOperator: 'GreaterThanOrEqualToThreshold',
       Threshold: 5,
     });
-
-    template.hasResourceProperties('AWS::CodeDeploy::DeploymentGroup', {
-      DeploymentConfigName: 'CodeDeployDefault.LambdaCanary10Percent5Minutes',
+    prodTemplate.hasResourceProperties('AWS::CodeDeploy::DeploymentGroup', {
       AutoRollbackConfiguration: {
         Enabled: true,
         Events: Match.arrayWith([

--- a/tests/unit/test_issue_110_ci_policy.py
+++ b/tests/unit/test_issue_110_ci_policy.py
@@ -1,0 +1,53 @@
+import re
+from pathlib import Path
+
+CI_FILE = Path(__file__).resolve().parents[2] / ".gitlab-ci.yml"
+
+
+def _job_block(name: str, content: str) -> str:
+    pattern = rf"(?ms)^{re.escape(name)}:\n(.*?)(?=^[A-Za-z0-9_.-]+:\n|\Z)"
+    match = re.search(pattern, content)
+    assert match is not None, f"Missing job block: {name}"
+    return match.group(1)
+
+
+def test_canary_policy_variables_are_explicit_per_environment() -> None:
+    content = CI_FILE.read_text(encoding="utf-8")
+
+    assert 'CANARY_POLICY_DEV: "all-at-once"' in content
+    assert 'CANARY_POLICY_STAGING: "canary-10%-30m"' in content
+    assert 'CANARY_POLICY_PROD: "canary-10%-15m"' in content
+    assert 'STAGING_ROLLOUT_WINDOW_MINUTES: "30"' in content
+    assert 'PROD_ROLLOUT_WINDOW_MINUTES: "15"' in content
+    assert 'PROD_APPROVAL_MODE: "protected-environment-two-reviewer"' in content
+
+
+def test_ci_test_matrix_covers_unit_integration_and_cdk() -> None:
+    content = CI_FILE.read_text(encoding="utf-8")
+    for name in ("test-unit", "test-integration", "test-cdk"):
+        block = _job_block(name, content)
+        assert "extends: .test_job_base" in block
+
+
+def test_staging_and_prod_gates_have_manual_approvals_and_rollout_windows() -> None:
+    content = CI_FILE.read_text(encoding="utf-8")
+
+    staging = _job_block("deploy-staging", content)
+    assert "when: manual" in staging
+    assert "deployment_tier: staging" in staging
+
+    staging_window = _job_block("staging-rollout-window", content)
+    assert "when: delayed" in staging_window
+    assert "start_in: 30 minutes" in staging_window
+    assert 'needs: ["deploy-staging"]' in staging_window
+
+    prod = _job_block("deploy-prod", content)
+    assert 'needs: ["staging-rollout-window"]' in prod
+    assert "when: manual" in prod
+    assert "deployment_tier: production" in prod
+    assert 'test "${PROD_APPROVAL_MODE}" = "protected-environment-two-reviewer"' in prod
+
+    prod_window = _job_block("prod-rollout-window", content)
+    assert "when: delayed" in prod_window
+    assert "start_in: 15 minutes" in prod_window
+    assert 'needs: ["deploy-prod"]' in prod_window

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -66,9 +66,9 @@ class FakeScopedDb:
 
     def scan(
         self,
-        _table_name: str,
+        _table_name: str | None = None,
         **kwargs: Any,
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         results = [dict(item) for item in self.items.values()]
         # Simple filter implementation for tests
         status_filter = kwargs.get("ExpressionAttributeValues", {}).get(":s")
@@ -77,6 +77,8 @@ class FakeScopedDb:
             results = [r for r in results if r.get("status") == status_filter]
         if tier_filter:
             results = [r for r in results if r.get("tier") == tier_filter]
+        if _table_name is None:
+            return {"Items": results}
         return results
 
 


### PR DESCRIPTION
## Summary
- made bridge canary deployment policy environment-aware in CDK:
  - `dev`: all-at-once
  - `staging`: canary 10% for 30 minutes
  - `prod`: canary 10% for 15 minutes
- added explicit/auditable canary policy output in `PlatformStack` (`BridgeCanaryPolicy`)
- expanded CDK tests to assert per-environment deployment config values
- expanded `.gitlab-ci.yml` gate matrix:
  - added pipeline policy validation test job
  - added test matrix jobs for `unit`, `integration`, and `cdk`
  - encoded explicit staging/prod rollout windows and approval controls via delayed/manual gate jobs and policy variables
- added machine-checkable CI policy unit tests (`tests/unit/test_issue_110_ci_policy.py`)
- fixed broken tenant API test fixtures to satisfy updated dependency signature (`dynamodb`) so full unit suite is green

## Validation Evidence
- `make preflight-session` (PASS)
- `make validate-local` (PASS)
- `make pre-validate-session` (PASS)
- `make test-unit` (PASS, `304 passed`)
- `make test-int` (PASS, `4 passed`)
- `PYTHONPATH=. uv run pytest tests/unit/test_issue_110_ci_policy.py -v --tb=short` (PASS, `3 passed`)
- `cd infra/cdk && npm test -- --runInBand platform-stack.test.ts` (PASS, `8 passed`)

Closes #110
