### PR TITLE
feat(spa): enforce component coverage for core pages and async polling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,6 +127,17 @@ test-cdk:
   script:
     - cd infra/cdk && npm test -- --runInBand
 
+test-spa:
+  extends: .test_job_base
+  script:
+    - cd spa
+    - npm ci
+    - npm test
+  artifacts:
+    when: always
+    paths:
+      - spa/coverage/
+
 # --- PLAN STAGE ---
 
 plan-infra:

--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -28,6 +28,7 @@
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "^2.1.9",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.39.3",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -68,6 +69,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -453,6 +468,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -1327,6 +1349,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1406,6 +1456,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1901,6 +1962,39 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -2043,7 +2137,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2619,12 +2712,26 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -3477,6 +3584,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3524,6 +3648,28 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3534,6 +3680,39 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3600,6 +3779,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3712,6 +3898,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3746,6 +3942,76 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -3978,6 +4244,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -4031,6 +4338,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -4160,6 +4477,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4211,6 +4535,30 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -4828,6 +5176,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4850,6 +5211,103 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4985,6 +5443,21 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -5832,6 +6305,91 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/xml-name-validator": {

--- a/spa/package.json
+++ b/spa/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "test": "VITE_ENTRA_CLIENT_ID=test-client-id VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/test-tenant-id VITE_ENTRA_SCOPES=api://platform-dev/Agent.Invoke VITE_ENTRA_REDIRECT_URI=http://localhost:3000 VITE_ENTRA_POST_LOGOUT_REDIRECT_URI=http://localhost:3000 VITE_API_BASE_URL=https://api.example.test vitest run",
+    "test": "VITE_ENTRA_CLIENT_ID=test-client-id VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/test-tenant-id VITE_ENTRA_SCOPES=api://platform-dev/Agent.Invoke VITE_ENTRA_REDIRECT_URI=http://localhost:3000 VITE_ENTRA_POST_LOGOUT_REDIRECT_URI=http://localhost:3000 VITE_API_BASE_URL=https://api.example.test vitest run --coverage",
+    "test:quick": "VITE_ENTRA_CLIENT_ID=test-client-id VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/test-tenant-id VITE_ENTRA_SCOPES=api://platform-dev/Agent.Invoke VITE_ENTRA_REDIRECT_URI=http://localhost:3000 VITE_ENTRA_POST_LOGOUT_REDIRECT_URI=http://localhost:3000 VITE_API_BASE_URL=https://api.example.test vitest run",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
@@ -31,6 +32,7 @@
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^2.1.9",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.39.3",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/spa/src/api/openapiContract.test.ts
+++ b/spa/src/api/openapiContract.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
@@ -14,7 +15,8 @@ type OpenApiDoc = {
 };
 
 function loadOpenApiDoc(): OpenApiDoc {
-  const specPath = fileURLToPath(new URL("../../../docs/openapi.yaml", import.meta.url));
+  const currentFile = fileURLToPath(import.meta.url);
+  const specPath = path.resolve(path.dirname(currentFile), "../../../docs/openapi.yaml");
   const yaml = fs.readFileSync(specPath, "utf8");
   return YAML.parse(yaml) as OpenApiDoc;
 }

--- a/spa/src/hooks/useJobPolling.test.tsx
+++ b/spa/src/hooks/useJobPolling.test.tsx
@@ -119,4 +119,114 @@ describe("useJobPolling", () => {
         expect(latest?.loading).toBe(false);
         expect(latest?.error).toBe("Request failed with HTTP 500");
     });
+
+    it("keeps polling disabled when no job id is provided", async () => {
+        const states: PollingState[] = [];
+
+        await act(async () => {
+            TestRenderer.create(<PollingHarness jobId={null} onState={(state) => states.push(state)} />);
+        });
+
+        await flushMicrotasks();
+
+        const latest = states.at(-1);
+        expect(requestMock).not.toHaveBeenCalled();
+        expect(latest?.status).toBeNull();
+        expect(latest?.loading).toBe(false);
+        expect(latest?.error).toBeNull();
+    });
+
+    it("stops polling after terminal failed status", async () => {
+        const states: PollingState[] = [];
+        requestMock.mockResolvedValueOnce({
+            jobId: "job-3",
+            tenantId: "tenant-1",
+            agentName: "echo-agent",
+            status: "failed",
+            createdAt: "2026-03-08T00:00:00Z",
+            completedAt: "2026-03-08T00:00:03Z",
+            errorMessage: "upstream timeout",
+        });
+
+        await act(async () => {
+            TestRenderer.create(<PollingHarness jobId="job-3" onState={(state) => states.push(state)} />);
+        });
+
+        await flushMicrotasks();
+
+        await act(async () => {
+            vi.advanceTimersByTime(100);
+            await Promise.resolve();
+        });
+
+        const latest = states.at(-1);
+        expect(requestMock).toHaveBeenCalledTimes(1);
+        expect(latest?.status?.status).toBe("failed");
+        expect(latest?.loading).toBe(false);
+        expect(latest?.error).toBeNull();
+    });
+
+    it("ignores in-flight success results after unmount", async () => {
+        const states: PollingState[] = [];
+        let resolveRequest: ((value: unknown) => void) | null = null;
+        requestMock.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveRequest = resolve;
+                }),
+        );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<PollingHarness jobId="job-4" onState={(state) => states.push(state)} />);
+        });
+
+        expect(requestMock).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            renderer!.unmount();
+        });
+
+        await act(async () => {
+            resolveRequest?.({
+                jobId: "job-4",
+                tenantId: "tenant-1",
+                agentName: "echo-agent",
+                status: "running",
+                createdAt: "2026-03-08T00:00:00Z",
+            });
+            await Promise.resolve();
+        });
+
+        expect(states.some((state) => state.status?.jobId === "job-4")).toBe(false);
+    });
+
+    it("ignores in-flight errors after unmount", async () => {
+        const states: PollingState[] = [];
+        let rejectRequest: ((reason?: unknown) => void) | null = null;
+        requestMock.mockImplementationOnce(
+            () =>
+                new Promise((_, reject) => {
+                    rejectRequest = reject;
+                }),
+        );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<PollingHarness jobId="job-5" onState={(state) => states.push(state)} />);
+        });
+
+        expect(requestMock).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            renderer!.unmount();
+        });
+
+        await act(async () => {
+            rejectRequest?.(new Error("late failure"));
+            await Promise.resolve();
+        });
+
+        expect(states.some((state) => state.error === "late failure")).toBe(false);
+    });
 });

--- a/spa/src/pages/AdminPage.test.tsx
+++ b/spa/src/pages/AdminPage.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
+import { createApiClientMock, createAuthContextValue } from "../test/mockFactories";
+import { healthFail, healthOk, quotaRows, tenantRows } from "../test/testData";
 import { AdminPage } from "./AdminPage";
 
 vi.mock("../api/client", () => ({
@@ -18,88 +20,84 @@ vi.mock("../auth/useAuth", () => ({
 describe("AdminPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useAuth).mockReturnValue({
-      getAccessToken: vi.fn(),
+    vi.mocked(useAuth).mockReturnValue(createAuthContextValue({
       isAuthenticated: true,
       account: {
         idTokenClaims: { roles: ["Platform.Admin"] },
-      },
-    } as never);
+      } as never,
+    }) as never);
   });
 
   it("renders health, tenant, and quota data", async () => {
     const request = vi
       .fn()
-      .mockResolvedValueOnce({
-        status: "ok",
-        version: "0.1.0",
-        timestamp: "2026-03-01T09:00:00Z",
-      })
-      .mockResolvedValueOnce({
-        items: [
-          {
-            tenantId: "t-001",
-            appId: "app-001",
-            displayName: "Acme",
-            tier: "premium",
-            status: "active",
-            runtimeRegion: "eu-west-1",
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        utilisation: [
-          {
-            region: "eu-west-1",
-            quotaName: "ConcurrentSessions",
-            currentValue: 5,
-            limit: 25,
-            utilisationPercentage: 20,
-          },
-        ],
-      });
-    vi.mocked(getApiClient).mockReturnValue({ request } as never);
+      .mockResolvedValueOnce(healthOk)
+      .mockResolvedValueOnce(tenantRows)
+      .mockResolvedValueOnce(quotaRows);
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({ request }) as never);
 
     render(<AdminPage />);
 
     await waitFor(() => {
       expect(screen.getByText("Platform Health")).toBeInTheDocument();
       expect(screen.getByText("Acme")).toBeInTheDocument();
+      expect(screen.getByText("Beta")).toBeInTheDocument();
       expect(
-        screen.getByText((value) => value.includes("ConcurrentSessions")),
-      ).toBeInTheDocument();
+        screen.getAllByText((value) => value.includes("ConcurrentSessions")),
+      ).toHaveLength(2);
+      expect(screen.getByText("92%")).toBeInTheDocument();
     });
+    expect(request).toHaveBeenNthCalledWith(1, "/v1/health");
+    expect(request).toHaveBeenNthCalledWith(2, "/v1/tenants");
+    expect(request).toHaveBeenNthCalledWith(3, "/v1/platform/quota");
   });
 
   it("renders empty admin sections when API returns empty arrays", async () => {
     const request = vi
       .fn()
-      .mockResolvedValueOnce({
-        status: "ok",
-        version: "0.1.0",
-        timestamp: "2026-03-01T09:00:00Z",
-      })
+      .mockResolvedValueOnce(healthFail)
       .mockResolvedValueOnce({ items: [] })
       .mockResolvedValueOnce({ utilisation: [] });
-    vi.mocked(getApiClient).mockReturnValue({ request } as never);
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({ request }) as never);
 
     render(<AdminPage />);
 
     await waitFor(() => {
       expect(screen.getByText("No quota data available.")).toBeInTheDocument();
       expect(screen.getByText("0 Total")).toBeInTheDocument();
+      expect(screen.getByText("fail")).toBeInTheDocument();
     });
   });
 
   it("renders error state when admin fetch fails", async () => {
-    vi.mocked(getApiClient).mockReturnValue({
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
       request: vi.fn().mockRejectedValue(new Error("admin data failed")),
-    } as never);
+    }) as never);
 
     render(<AdminPage />);
 
     await waitFor(() => {
       expect(screen.getByText("admin data failed")).toBeInTheDocument();
     });
+  });
+
+  it("renders access denied for non-admin roles and skips requests", async () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthContextValue({
+      isAuthenticated: true,
+      account: {
+        idTokenClaims: { roles: ["Agent.Developer"] },
+      } as never,
+    }) as never);
+    const request = vi.fn();
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({ request }) as never);
+
+    render(<AdminPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Access Denied: Platform.Operator role required."),
+      ).toBeInTheDocument();
+    });
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/spa/src/pages/AgentCataloguePage.test.tsx
+++ b/spa/src/pages/AgentCataloguePage.test.tsx
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
+import { createApiClientMock, createAuthContextValue } from "../test/mockFactories";
+import { catalogueMixedAgents } from "../test/testData";
 import { AgentCataloguePage } from "./AgentCataloguePage";
 
 vi.mock("../api/client", () => ({
@@ -19,27 +21,16 @@ vi.mock("../auth/useAuth", () => ({
 describe("AgentCataloguePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useAuth).mockReturnValue({
-      getAccessToken: vi.fn(),
+    vi.mocked(useAuth).mockReturnValue(createAuthContextValue({
       isAuthenticated: true,
-    } as never);
+    }) as never);
   });
 
   it("renders agents on success", async () => {
-    vi.mocked(getApiClient).mockReturnValue({
-      request: vi.fn().mockResolvedValue({
-        items: [
-          {
-            agentName: "echo-agent",
-            latestVersion: "1.0.0",
-            tierMinimum: "basic",
-            invocationMode: "sync",
-            streamingEnabled: true,
-            ownerTeam: "platform-team",
-          },
-        ],
-      }),
-    } as never);
+    const request = vi.fn().mockResolvedValue(catalogueMixedAgents);
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
+      request,
+    }) as never);
 
     render(
       <MemoryRouter>
@@ -50,13 +41,19 @@ describe("AgentCataloguePage", () => {
     await waitFor(() => {
       expect(screen.getByText("echo-agent")).toBeInTheDocument();
       expect(screen.getByText("Version 1.0.0 • sync")).toBeInTheDocument();
+      expect(screen.getByText("research-agent")).toBeInTheDocument();
+      expect(screen.getByText("Version 2.1.0 • async")).toBeInTheDocument();
+      expect(screen.getByText("ops-agent")).toBeInTheDocument();
+      expect(screen.getByText("Version 3.0.0 • streaming")).toBeInTheDocument();
+      expect(screen.getAllByText("Streaming")).toHaveLength(2);
     });
+    expect(request).toHaveBeenCalledWith("/v1/agents");
   });
 
   it("renders empty state when no agents are returned", async () => {
-    vi.mocked(getApiClient).mockReturnValue({
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
       request: vi.fn().mockResolvedValue({ items: [] }),
-    } as never);
+    }) as never);
 
     render(
       <MemoryRouter>
@@ -71,9 +68,9 @@ describe("AgentCataloguePage", () => {
 
   it("renders error state when request fails", async () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.mocked(getApiClient).mockReturnValue({
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
       request: vi.fn().mockRejectedValue(new Error("catalogue failed")),
-    } as never);
+    }) as never);
 
     render(
       <MemoryRouter>
@@ -85,5 +82,26 @@ describe("AgentCataloguePage", () => {
       expect(screen.getByText("catalogue failed")).toBeInTheDocument();
     });
     spy.mockRestore();
+  });
+
+  it("does not fetch catalogue when user is unauthenticated", async () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthContextValue({
+      isAuthenticated: false,
+    }) as never);
+    const request = vi.fn();
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
+      request,
+    }) as never);
+
+    const { container } = render(
+      <MemoryRouter>
+        <AgentCataloguePage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/spa/src/pages/InvokePage.test.tsx
+++ b/spa/src/pages/InvokePage.test.tsx
@@ -2,18 +2,22 @@ import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createAuthContextValue } from "../test/mockFactories";
+import { asyncAccepted, buildAgent } from "../test/testData";
 import { InvokePage } from "./InvokePage";
 
-const { getApiClientMock, getAccessTokenMock, navigateMock, requestMock, streamMock, useJobPollingMock } =
+const { getApiClientMock, getAccessTokenMock, navigateMock, requestMock, streamMock, useAuthMock, useJobPollingMock } =
     vi.hoisted(() => {
         const request = vi.fn();
         const stream = vi.fn();
+        const useAuth = vi.fn();
         return {
             getApiClientMock: vi.fn(() => ({ request, stream })),
             getAccessTokenMock: vi.fn(async () => "token"),
             navigateMock: vi.fn(),
             requestMock: request,
             streamMock: stream,
+            useAuthMock: useAuth,
             useJobPollingMock: vi.fn(() => ({ status: null, loading: false, error: null })),
         };
     });
@@ -27,10 +31,7 @@ vi.mock("../api/client", async () => {
 });
 
 vi.mock("../auth/useAuth", () => ({
-    useAuth: () => ({
-        getAccessToken: getAccessTokenMock,
-        isAuthenticated: true,
-    }),
+    useAuth: useAuthMock,
 }));
 
 vi.mock("../hooks/useJobPolling", () => ({
@@ -46,21 +47,6 @@ vi.mock("react-router-dom", async () => {
         useParams: () => ({ agentName: "echo-agent" }),
     };
 });
-
-type AgentMode = "sync" | "streaming" | "async";
-
-function buildAgent(invocationMode: AgentMode) {
-    return {
-        agent_name: "echo-agent",
-        version: "1.0.0",
-        owner_team: "platform",
-        tier_minimum: "basic" as const,
-        deployed_at: "2026-03-08T00:00:00Z",
-        invocation_mode: invocationMode,
-        streaming_enabled: invocationMode === "streaming",
-        estimated_duration_seconds: 5,
-    };
-}
 
 async function flushMicrotasks(): Promise<void> {
     await act(async () => {
@@ -80,6 +66,10 @@ function getInvokeBody(): Record<string, unknown> {
 describe("InvokePage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        useAuthMock.mockReturnValue(createAuthContextValue({
+            isAuthenticated: true,
+            getAccessToken: getAccessTokenMock,
+        }));
     });
 
     it("sends sync invoke requests with contract-compatible input payload", async () => {
@@ -149,12 +139,7 @@ describe("InvokePage", () => {
     });
 
     it("handles async accepted responses and starts polling with jobId", async () => {
-        requestMock.mockResolvedValueOnce(buildAgent("async")).mockResolvedValueOnce({
-            jobId: "job-777",
-            status: "accepted",
-            mode: "async",
-            pollUrl: "/v1/jobs/job-777",
-        });
+        requestMock.mockResolvedValueOnce(buildAgent("async")).mockResolvedValueOnce(asyncAccepted);
 
         let renderer: TestRenderer.ReactTestRenderer;
         await act(async () => {
@@ -175,5 +160,135 @@ describe("InvokePage", () => {
 
         expect(getInvokeBody()).toEqual({ input: "run async" });
         expect(useJobPollingMock).toHaveBeenLastCalledWith("job-777", getAccessTokenMock);
+    });
+
+    it("surfaces async contract error when accepted response has no job id", async () => {
+        requestMock.mockResolvedValueOnce(buildAgent("async")).mockResolvedValueOnce({
+            jobId: "",
+            status: "accepted",
+            mode: "async",
+            pollUrl: "",
+        });
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<InvokePage />);
+        });
+
+        await flushMicrotasks();
+
+        const textarea = renderer!.root.findByType("textarea");
+        act(() => {
+            textarea.props.onChange({ target: { value: "run async without id" } });
+        });
+
+        const form = renderer!.root.findByType("form");
+        await act(async () => {
+            await form.props.onSubmit({ preventDefault: () => undefined });
+        });
+
+        const pageText = JSON.stringify(renderer!.toJSON());
+        expect(pageText).toContain("Async invoke response missing jobId");
+    });
+
+    it("does not fetch agent details when unauthenticated", async () => {
+        useAuthMock.mockReturnValue(createAuthContextValue({
+            isAuthenticated: false,
+            getAccessToken: getAccessTokenMock,
+        }));
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<InvokePage />);
+        });
+
+        await flushMicrotasks();
+
+        expect(requestMock).not.toHaveBeenCalled();
+        expect(JSON.stringify(renderer!.toJSON())).toContain("Loading...");
+    });
+
+    it("shows fetch error when initial agent lookup fails", async () => {
+        requestMock.mockRejectedValueOnce(new Error("agent lookup failed"));
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<InvokePage />);
+        });
+
+        await flushMicrotasks();
+
+        expect(JSON.stringify(renderer!.toJSON())).toContain("agent lookup failed");
+    });
+
+    it("renders async completion link and polling error details", async () => {
+        useJobPollingMock.mockReturnValue({
+            status: {
+                jobId: "job-777",
+                tenantId: "tenant-1",
+                agentName: "echo-agent",
+                status: "completed",
+                createdAt: "2026-03-08T00:00:00Z",
+                completedAt: "2026-03-08T00:00:10Z",
+                resultUrl: "https://example.test/result",
+            },
+            loading: false,
+            error: "polling warning",
+        });
+        requestMock.mockResolvedValueOnce(buildAgent("async")).mockResolvedValueOnce(asyncAccepted);
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<InvokePage />);
+        });
+
+        await flushMicrotasks();
+
+        const textarea = renderer!.root.findByType("textarea");
+        act(() => {
+            textarea.props.onChange({ target: { value: "complete async" } });
+        });
+
+        const form = renderer!.root.findByType("form");
+        await act(async () => {
+            await form.props.onSubmit({ preventDefault: () => undefined });
+        });
+
+        const pageText = JSON.stringify(renderer!.toJSON());
+        expect(pageText).toContain("View Results");
+        expect(pageText).toContain("polling warning");
+    });
+
+    it("navigates back to catalogue when back button is clicked", async () => {
+        requestMock.mockResolvedValueOnce(buildAgent("sync"));
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<InvokePage />);
+        });
+
+        await flushMicrotasks();
+
+        const backButton = renderer!
+            .root
+            .findAllByType("button")
+            .find((node) => {
+                const children = node.props.children;
+                if (typeof children === "string") {
+                    return children.includes("Back to Catalogue");
+                }
+                if (Array.isArray(children)) {
+                    return children.join("").includes("Back to Catalogue");
+                }
+                return false;
+            });
+        if (!backButton) {
+            throw new Error("Back button not found");
+        }
+        act(() => {
+            backButton.props.onClick();
+        });
+
+        expect(navigateMock).toHaveBeenCalledWith("/");
     });
 });

--- a/spa/src/pages/SessionsPage.test.tsx
+++ b/spa/src/pages/SessionsPage.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
+import { createApiClientMock, createAuthContextValue } from "../test/mockFactories";
+import { sessionsList } from "../test/testData";
 import { SessionsPage } from "./SessionsPage";
 
 vi.mock("../api/client", () => ({
@@ -18,39 +20,32 @@ vi.mock("../auth/useAuth", () => ({
 describe("SessionsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useAuth).mockReturnValue({
-      getAccessToken: vi.fn(),
+    vi.mocked(useAuth).mockReturnValue(createAuthContextValue({
       isAuthenticated: true,
-    } as never);
+    }) as never);
   });
 
   it("renders sessions when API returns items", async () => {
-    vi.mocked(getApiClient).mockReturnValue({
-      request: vi.fn().mockResolvedValue({
-        items: [
-          {
-            sessionId: "sess-12345678",
-            agentName: "echo-agent",
-            startedAt: "2026-03-01T09:00:00Z",
-            lastActivityAt: "2026-03-01T09:05:00Z",
-            status: "active",
-          },
-        ],
-      }),
-    } as never);
+    const request = vi.fn().mockResolvedValue(sessionsList);
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
+      request,
+    }) as never);
 
     render(<SessionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText("echo-agent")).toBeInTheDocument();
       expect(screen.getByText("active")).toBeInTheDocument();
+      expect(screen.getByText("research-agent")).toBeInTheDocument();
+      expect(screen.getByText("completed")).toBeInTheDocument();
     });
+    expect(request).toHaveBeenCalledWith("/v1/sessions");
   });
 
   it("renders empty state when no sessions are returned", async () => {
-    vi.mocked(getApiClient).mockReturnValue({
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
       request: vi.fn().mockResolvedValue({ items: [] }),
-    } as never);
+    }) as never);
 
     render(<SessionsPage />);
 
@@ -60,14 +55,31 @@ describe("SessionsPage", () => {
   });
 
   it("renders error state when sessions request fails", async () => {
-    vi.mocked(getApiClient).mockReturnValue({
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
       request: vi.fn().mockRejectedValue(new Error("sessions failed")),
-    } as never);
+    }) as never);
 
     render(<SessionsPage />);
 
     await waitFor(() => {
       expect(screen.getByText("sessions failed")).toBeInTheDocument();
     });
+  });
+
+  it("does not fetch sessions when user is unauthenticated", async () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthContextValue({
+      isAuthenticated: false,
+    }) as never);
+    const request = vi.fn();
+    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
+      request,
+    }) as never);
+
+    render(<SessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Loading sessions...")).toBeInTheDocument();
+    });
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/spa/src/test/mockFactories.ts
+++ b/spa/src/test/mockFactories.ts
@@ -1,0 +1,31 @@
+import type { AuthContextValue } from "../auth/AuthProvider";
+import { vi } from "vitest";
+
+type ApiClientMock = {
+  request: ReturnType<typeof vi.fn>;
+  stream: ReturnType<typeof vi.fn>;
+};
+
+export function createAuthContextValue(
+  overrides: Partial<AuthContextValue> = {},
+): AuthContextValue {
+  return {
+    account: null,
+    isAuthenticated: false,
+    isLoading: false,
+    login: async () => undefined,
+    logout: async () => undefined,
+    getAccessToken: async () => "token",
+    ...overrides,
+  };
+}
+
+export function createApiClientMock(
+  overrides: Partial<ApiClientMock> = {},
+): ApiClientMock {
+  return {
+    request: vi.fn(),
+    stream: vi.fn(),
+    ...overrides,
+  };
+}

--- a/spa/src/test/testData.ts
+++ b/spa/src/test/testData.ts
@@ -1,0 +1,141 @@
+import type {
+  AgentsListResponseDto,
+  HealthResponseDto,
+  PlatformQuotaResponseDto,
+  SessionsListResponseDto,
+  TenantsListResponseDto,
+} from "../api/contracts";
+import type { AgentInvokeResponse, Agent } from "../types";
+
+export const catalogueSingleAgent: AgentsListResponseDto = {
+  items: [
+    {
+      agentName: "echo-agent",
+      latestVersion: "1.0.0",
+      tierMinimum: "basic",
+      invocationMode: "sync",
+      streamingEnabled: true,
+      ownerTeam: "platform-team",
+    },
+  ],
+};
+
+export const catalogueMixedAgents: AgentsListResponseDto = {
+  items: [
+    {
+      agentName: "echo-agent",
+      latestVersion: "1.0.0",
+      tierMinimum: "basic",
+      invocationMode: "sync",
+      streamingEnabled: true,
+      ownerTeam: "platform-team",
+    },
+    {
+      agentName: "research-agent",
+      latestVersion: "2.1.0",
+      tierMinimum: "premium",
+      invocationMode: "async",
+      streamingEnabled: false,
+      ownerTeam: "ai-research",
+    },
+    {
+      agentName: "ops-agent",
+      latestVersion: "3.0.0",
+      tierMinimum: "standard",
+      invocationMode: "streaming",
+      streamingEnabled: true,
+      ownerTeam: "ops-team",
+    },
+  ],
+};
+
+export const sessionsList: SessionsListResponseDto = {
+  items: [
+    {
+      sessionId: "sess-12345678",
+      agentName: "echo-agent",
+      startedAt: "2026-03-01T09:00:00Z",
+      lastActivityAt: "2026-03-01T09:05:00Z",
+      status: "active",
+    },
+    {
+      sessionId: "sess-abcdef12",
+      agentName: "research-agent",
+      startedAt: "2026-03-01T10:00:00Z",
+      lastActivityAt: "2026-03-01T10:15:00Z",
+      status: "completed",
+    },
+  ],
+};
+
+export const healthOk: HealthResponseDto = {
+  status: "ok",
+  version: "0.1.0",
+  timestamp: "2026-03-01T09:00:00Z",
+};
+
+export const healthFail: HealthResponseDto = {
+  status: "fail",
+  version: "0.1.0",
+  timestamp: "2026-03-01T09:00:00Z",
+};
+
+export const tenantRows: TenantsListResponseDto = {
+  items: [
+    {
+      tenantId: "t-001",
+      appId: "app-001",
+      displayName: "Acme",
+      tier: "premium",
+      status: "active",
+      runtimeRegion: "eu-west-1",
+    },
+    {
+      tenantId: "t-002",
+      appId: "app-002",
+      displayName: "Beta",
+      tier: "basic",
+      status: "suspended",
+      runtimeRegion: "eu-west-1",
+    },
+  ],
+};
+
+export const quotaRows: PlatformQuotaResponseDto = {
+  utilisation: [
+    {
+      region: "eu-west-1",
+      quotaName: "ConcurrentSessions",
+      currentValue: 5,
+      limit: 25,
+      utilisationPercentage: 20,
+    },
+    {
+      region: "eu-central-1",
+      quotaName: "ConcurrentSessions",
+      currentValue: 23,
+      limit: 25,
+      utilisationPercentage: 92,
+    },
+  ],
+};
+
+export function buildAgent(invocationMode: Agent["invocation_mode"]): Agent {
+  return {
+    agent_name: "echo-agent",
+    version: "1.0.0",
+    owner_team: "platform",
+    tier_minimum: "basic",
+    deployed_at: "2026-03-08T00:00:00Z",
+    invocation_mode: invocationMode,
+    streaming_enabled: invocationMode === "streaming",
+    estimated_duration_seconds: 5,
+  };
+}
+
+export const asyncAccepted: AgentInvokeResponse = {
+  jobId: "job-777",
+  status: "accepted",
+  mode: "async",
+  pollUrl: "/v1/jobs/job-777",
+};

--- a/spa/vite.config.ts
+++ b/spa/vite.config.ts
@@ -5,6 +5,27 @@ import path from 'path'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "json-summary"],
+      include: [
+        "src/pages/AgentCataloguePage.tsx",
+        "src/pages/InvokePage.tsx",
+        "src/pages/SessionsPage.tsx",
+        "src/pages/AdminPage.tsx",
+        "src/hooks/useJobPolling.ts",
+      ],
+      thresholds: {
+        statements: 85,
+        branches: 75,
+        functions: 85,
+        lines: 85,
+        perFile: true,
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
Implements #121 by strengthening SPA component-level test coverage for core pages and async polling, adding reusable test fixtures/mocks, and enforcing per-file coverage gates in CI.

## Changes
- Added shared SPA test helpers and fixture data:
  - spa/src/test/mockFactories.ts
  - spa/src/test/testData.ts
- Expanded page/hook coverage for required success/empty/error/auth-role paths:
  - spa/src/pages/AgentCataloguePage.test.tsx
  - spa/src/pages/InvokePage.test.tsx
  - spa/src/pages/SessionsPage.test.tsx
  - spa/src/pages/AdminPage.test.tsx
  - spa/src/hooks/useJobPolling.test.tsx
- Hardened OpenAPI contract test path resolution under coverage instrumentation:
  - spa/src/api/openapiContract.test.ts
- Added Vitest coverage provider + per-file thresholds for target files:
  - spa/package.json
  - spa/vite.config.ts
- Added CI SPA test job to run coverage-gated test script and publish coverage artifacts:
  - .gitlab-ci.yml

## Validation Evidence
- cd spa && npm test
  - Result: 10 test files passed, 42 tests passed
  - Coverage (gated target files):
    - useJobPolling.ts: 92.75% statements, 87.5% branches, 100% funcs, 92.75% lines
    - AgentCataloguePage.tsx: 100% statements/lines/functions, 90.47% branches
    - InvokePage.tsx: 100% statements/lines/functions, 97.61% branches
    - SessionsPage.tsx: 100% statements/lines/functions, 94.11% branches
    - AdminPage.tsx: 100% statements/lines/functions, 85.29% branches
- make validate-local
  - Result: PASS
- make preflight-session
  - Result: PASS
- make pre-validate-session
  - Result: PASS
- make worktree-push-issue
  - Result: PASS (preflight + pre-validate + push)

Closes #121
