### PR TITLE
TASK-050: implement A2A cross-agent orchestration

### DIFF
--- a/agents/echo-agent/handler.py
+++ b/agents/echo-agent/handler.py
@@ -18,15 +18,22 @@ Invocation modes (declared in pyproject.toml [tool.agentcore.invocation_mode]):
 
 Request payload schema:
   {
-    "prompt":   str   — text to echo (required)
-    "mode":     str   — "sync" | "streaming" | "async" (default: "sync")
-    "appid":    str   — caller app ID for logging (optional)
-    "tenantId": str   — caller tenant ID for logging (optional)
+    "prompt":      str        — text to echo (required)
+    "mode":        str        — "sync" | "streaming" | "async" (default: "sync")
+    "appid":       str        — caller app ID for logging (optional)
+    "tenantId":    str        — caller tenant ID for logging (optional)
+    "a2aTargets":  list[str]  — optional downstream A2A targets for sync orchestration
   }
 """
 
+import json
+import os
 import threading
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
 from collections.abc import Generator
 from typing import Any
 
@@ -38,6 +45,9 @@ logger = Logger(service="echo-agent")
 # ASGI application — referenced by pyproject.toml handler = "handler:invoke"
 invoke = BedrockAgentCoreApp()
 
+A2A_ENDPOINTS_ENV = "A2A_AGENT_ENDPOINTS_JSON"
+A2A_HTTP_TIMEOUT_SECONDS = float(os.environ.get("A2A_HTTP_TIMEOUT_SECONDS", "8.0"))
+
 
 @invoke.entrypoint
 def handler(payload: dict[str, Any], context: RequestContext) -> Any:
@@ -48,19 +58,32 @@ def handler(payload: dict[str, Any], context: RequestContext) -> Any:
       streaming      — echo the prompt word-by-word as SSE chunks
       async          — echo in a background task; /ping returns HealthyBusy
     """
-    mode = payload.get("mode", "sync")
+    mode = str(payload.get("mode", "sync")).strip().lower() or "sync"
     prompt = str(payload.get("prompt", ""))
     appid = str(payload.get("appid", "platform"))
     tenant_id = str(payload.get("tenantId", "unknown"))
+    a2a_targets = _parse_a2a_targets(payload.get("a2aTargets"))
 
     logger.append_keys(appid=appid, tenantid=tenant_id, mode=mode)
-    logger.info("echo-agent invoked", extra={"prompt_len": len(prompt)})
+    logger.info(
+        "echo-agent invoked",
+        extra={"prompt_len": len(prompt), "a2a_target_count": len(a2a_targets)},
+    )
+
+    if a2a_targets and mode != "sync":
+        return {
+            "error": "A2A orchestration supports sync mode only",
+            "code": "INVALID_A2A_CONFIGURATION",
+            "mode": mode,
+            "appid": appid,
+            "tenantId": tenant_id,
+        }
 
     if mode == "streaming":
         return _stream_echo(prompt, appid, tenant_id)
     if mode == "async":
         return _async_echo(prompt, appid, tenant_id)
-    return _sync_echo(prompt, appid, tenant_id)
+    return _sync_echo(prompt, appid, tenant_id, a2a_targets=a2a_targets)
 
 
 # ---------------------------------------------------------------------------
@@ -68,12 +91,31 @@ def handler(payload: dict[str, Any], context: RequestContext) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _sync_echo(prompt: str, appid: str, tenant_id: str) -> dict[str, Any]:
+def _sync_echo(
+    prompt: str,
+    appid: str,
+    tenant_id: str,
+    a2a_targets: list[str] | None = None,
+) -> dict[str, Any]:
     """Synchronous echo — returns the prompt as a JSON response immediately.
 
     Bridge Lambda invocation path: invoke and wait for response body.
     pyproject.toml: invocation_mode = "sync"
     """
+    if a2a_targets:
+        try:
+            return _sync_a2a_orchestration(prompt, appid, tenant_id, a2a_targets)
+        except Exception as exc:
+            logger.exception("a2a orchestration failed", extra={"target_count": len(a2a_targets)})
+            return {
+                "error": "A2A orchestration failed",
+                "code": "A2A_ORCHESTRATION_FAILED",
+                "details": str(exc),
+                "mode": "sync",
+                "appid": appid,
+                "tenantId": tenant_id,
+            }
+
     logger.info("sync echo complete", extra={"prompt_len": len(prompt)})
     return {
         "echo": prompt,
@@ -81,6 +123,189 @@ def _sync_echo(prompt: str, appid: str, tenant_id: str) -> dict[str, Any]:
         "appid": appid,
         "tenantId": tenant_id,
     }
+
+
+def _parse_a2a_targets(value: Any) -> list[str]:
+    """Parse and normalize optional A2A target list from payload."""
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if item is None:
+            continue
+        target = str(item).strip()
+        if not target or target in seen:
+            continue
+        seen.add(target)
+        normalized.append(target)
+    return normalized
+
+
+def _sync_a2a_orchestration(
+    prompt: str,
+    appid: str,
+    tenant_id: str,
+    a2a_targets: list[str],
+) -> dict[str, Any]:
+    """Execute sync cross-agent orchestration using A2A task calls."""
+    endpoint_map = _load_a2a_endpoint_map()
+    delegate_results: list[dict[str, str]] = []
+
+    for target in a2a_targets:
+        endpoint = endpoint_map.get(target)
+        if endpoint is None:
+            raise ValueError(f"Missing A2A endpoint for target '{target}'")
+
+        agent_card = _fetch_agent_card(endpoint)
+        card_name = str(agent_card.get("name", target))
+        output = _invoke_a2a_target(endpoint, prompt)
+        delegate_results.append(
+            {
+                "target": target,
+                "agentCardName": card_name,
+                "output": output,
+            }
+        )
+
+    # Deterministic aggregate output for contract-style tests and simple clients.
+    aggregate_output = " | ".join(f"{item['target']}={item['output']}" for item in delegate_results)
+    logger.info(
+        "sync a2a orchestration complete",
+        extra={"target_count": len(delegate_results)},
+    )
+    return {
+        "echo": prompt,
+        "mode": "sync",
+        "appid": appid,
+        "tenantId": tenant_id,
+        "orchestration": "a2a",
+        "delegates": delegate_results,
+        "output": aggregate_output,
+    }
+
+
+def _load_a2a_endpoint_map() -> dict[str, str]:
+    """Load A2A endpoint mapping from environment.
+
+    Expected env var:
+      A2A_AGENT_ENDPOINTS_JSON='{"planner":"https://planner.example","retriever":"https://..."}'
+    """
+    raw_value = os.environ.get(A2A_ENDPOINTS_ENV, "").strip()
+    if not raw_value:
+        return {}
+
+    try:
+        decoded = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{A2A_ENDPOINTS_ENV} must be valid JSON") from exc
+
+    if not isinstance(decoded, dict):
+        raise ValueError(f"{A2A_ENDPOINTS_ENV} must be a JSON object")
+
+    endpoint_map: dict[str, str] = {}
+    for key, value in decoded.items():
+        target = str(key).strip()
+        endpoint = str(value).strip().rstrip("/")
+        if not target or not endpoint:
+            continue
+        endpoint_map[target] = endpoint
+    return endpoint_map
+
+
+def _fetch_agent_card(endpoint: str) -> dict[str, Any]:
+    card_url = f"{endpoint}/.well-known/agent-card.json"
+    return _http_json_request(card_url, method="GET")
+
+
+def _invoke_a2a_target(endpoint: str, prompt: str) -> str:
+    rpc_payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": "tasks/send",
+        "params": {
+            "id": str(uuid.uuid4()),
+            "message": {
+                "role": "user",
+                "parts": [{"type": "text", "text": prompt}],
+            },
+        },
+    }
+    rpc_response = _http_json_request(f"{endpoint}/", method="POST", payload=rpc_payload)
+    return _extract_a2a_output_text(rpc_response)
+
+
+def _http_json_request(
+    url: str, method: str, payload: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    data: bytes | None = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    request = urllib.request.Request(url=url, data=data, method=method.upper())
+    request.add_header("Accept", "application/json")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+
+    try:
+        with urllib.request.urlopen(request, timeout=A2A_HTTP_TIMEOUT_SECONDS) as response:
+            body_bytes = response.read()
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+    body_text = body_bytes.decode("utf-8") if body_bytes else "{}"
+    try:
+        decoded = json.loads(body_text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Response from {url} is not valid JSON") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError(f"Response from {url} must be a JSON object")
+    return decoded
+
+
+def _extract_a2a_output_text(response: dict[str, Any]) -> str:
+    if isinstance(response.get("error"), dict):
+        message = str(response["error"].get("message", "Unknown A2A error"))
+        raise RuntimeError(message)
+
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return json.dumps(response, sort_keys=True)
+
+    artifacts = result.get("artifacts")
+    if isinstance(artifacts, list):
+        text_parts: list[str] = []
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            parts = artifact.get("parts")
+            if not isinstance(parts, list):
+                continue
+            for part in parts:
+                if not isinstance(part, dict):
+                    continue
+                text = part.get("text")
+                if text is not None:
+                    text_parts.append(str(text))
+        if text_parts:
+            return " ".join(text_parts)
+
+    message = result.get("message")
+    if isinstance(message, dict):
+        parts = message.get("parts")
+        if isinstance(parts, list):
+            text_parts = [
+                str(part.get("text"))
+                for part in parts
+                if isinstance(part, dict) and part.get("text") is not None
+            ]
+            if text_parts:
+                return " ".join(text_parts)
+
+    output = result.get("output")
+    if output is not None:
+        return str(output)
+    return json.dumps(result, sort_keys=True)
 
 
 # ---------------------------------------------------------------------------

--- a/agents/echo-agent/tests/test_handler.py
+++ b/agents/echo-agent/tests/test_handler.py
@@ -28,7 +28,7 @@ if str(_AGENT_ROOT) not in sys.path:
     sys.path.insert(0, str(_AGENT_ROOT))
 
 import handler as agent_handler  # noqa: E402  (must be after sys.path modification)
-from handler import _async_echo, _stream_echo, _sync_echo, invoke  # noqa: E402
+from handler import _async_echo, _parse_a2a_targets, _stream_echo, _sync_echo, invoke  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -75,6 +75,55 @@ class TestSyncEcho:
         inp = case["input"]
         result = _sync_echo(inp["prompt"], inp["appid"], inp["tenantId"])
         assert result == case["expected"]
+
+    def test_sync_a2a_orchestration_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A2A orchestration returns deterministic aggregated output."""
+        monkeypatch.setenv(
+            "A2A_AGENT_ENDPOINTS_JSON",
+            json.dumps(
+                {
+                    "retriever": "https://retriever.example",
+                    "planner": "https://planner.example",
+                }
+            ),
+        )
+
+        with (
+            patch("handler._fetch_agent_card") as mock_card,
+            patch("handler._invoke_a2a_target") as mock_invoke,
+        ):
+            mock_card.side_effect = [
+                {"name": "retriever"},
+                {"name": "planner"},
+            ]
+            mock_invoke.side_effect = ["docs found", "plan ready"]
+
+            result = _sync_echo(
+                "hello",
+                "app-a2a",
+                "tenant-a2a",
+                a2a_targets=["retriever", "planner"],
+            )
+
+        assert result["mode"] == "sync"
+        assert result["orchestration"] == "a2a"
+        assert result["output"] == "retriever=docs found | planner=plan ready"
+        assert len(result["delegates"]) == 2
+        assert result["delegates"][0]["agentCardName"] == "retriever"
+
+    def test_sync_a2a_missing_target_mapping_returns_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing target mapping returns a structured orchestration failure."""
+        monkeypatch.setenv(
+            "A2A_AGENT_ENDPOINTS_JSON", json.dumps({"known": "https://known.example"})
+        )
+
+        result = _sync_echo("hello", "app-a2a", "tenant-a2a", a2a_targets=["unknown"])
+
+        assert result["code"] == "A2A_ORCHESTRATION_FAILED"
+        assert result["mode"] == "sync"
+        assert result["tenantId"] == "tenant-a2a"
 
 
 # ---------------------------------------------------------------------------
@@ -268,3 +317,21 @@ class TestHandlerDispatch:
         assert isinstance(result, dict)
         assert result["accepted"] is True
         mock_add.assert_called_once()
+
+    def test_dispatch_rejects_a2a_for_streaming_mode(self) -> None:
+        """A2A orchestration is only valid for sync mode."""
+        payload: dict[str, Any] = {
+            "prompt": "stream me",
+            "mode": "streaming",
+            "a2aTargets": ["planner"],
+        }
+        result = agent_handler.handler(payload, self._make_context())
+        assert isinstance(result, dict)
+        assert result["code"] == "INVALID_A2A_CONFIGURATION"
+
+
+def test_parse_a2a_targets_normalizes_and_dedupes() -> None:
+    assert _parse_a2a_targets([" retriever ", "", "retriever", None, "planner"]) == [
+        "retriever",
+        "planner",
+    ]

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -205,7 +205,7 @@ Results delivered via webhook or poll endpoint.
 ## Backlog (Not in MVP scope)
 
 - Account vending Terraform (Option B/C topology) — triggers at 70% quota utilisation
-- A2A cross-agent orchestration — blocked on AWS GA in eu-west-1
+- A2A cross-agent orchestration — delivered in TASK-050 (2026-03-10)
 - AgentCore Policy CEDAR enforcement — blocked on GA in eu-west-1
 - Agent marketplace and catalogue portal
 - Tenant self-service portal (currently operator-provisioned)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,7 +53,7 @@ result delivered via webhook and poll endpoint.
 | Option B account topology       | ConcurrentSessions > 70% of account quota      |
 | Billing metering pipeline       | After V1.0 — token cost attribution per tenant |
 | Tenant self-service portal      | After V1.0 — tenant manages own API keys/users |
-| A2A cross-agent orchestration   | AWS GA of A2A in eu-west-1                     |
+| A2A cross-agent orchestration   | Delivered (TASK-050, 2026-03-10)               |
 | AgentCore Policy CEDAR          | AWS GA of Policy in eu-west-1                  |
 | Agent marketplace               | After V1.0 — discovery and composition portal  |
 | eu-west-2 Runtime               | AWS extends AgentCore to London                |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -471,8 +471,10 @@ task. Result delivered via webhook and available via poll endpoint.
               BLOCKED: Trigger is ConcurrentSessions > 70% quota. Not yet reached.
               ADRs: ADR-009
 
-[!] TASK-050  A2A cross-agent orchestration
-              BLOCKED: Awaiting AWS GA of A2A protocol in eu-west-1
+[x] TASK-050  A2A cross-agent orchestration
+              Implemented: reference-agent sync A2A delegate orchestration pattern
+              using AgentCore Runtime A2A protocol (target map + task fan-out).
+              Done: 2026-03-10
 
 [!] TASK-051  AgentCore Policy CEDAR enforcement
               BLOCKED: Policy GA not available in eu-west-1 or eu-west-2


### PR DESCRIPTION
## Summary
- add optional sync-path A2A orchestration support to `agents/echo-agent` via `a2aTargets`
- add A2A endpoint-map/env parsing, agent-card fetch, JSON-RPC `tasks/send` invocation, and deterministic aggregate output
- add unit tests for A2A orchestration success, invalid config path, and mode guard
- update backlog snapshots to mark TASK-050 delivered

## Issue
Closes #57

## Validation Evidence
- `make test-agent AGENT=echo-agent` (16 passed)
- `make validate-local` (PASS)
- `make preflight-session` (PASS)
- `make pre-validate-session` (PASS)
- `make worktree-push-issue` (push path PASS with enforced preflight + pre-validate)
