### PR TITLE
Issue #143: disallow weak env var override for scoped token signing in non-local environments

### DIFF
--- a/gateway/interceptors/request_interceptor.py
+++ b/gateway/interceptors/request_interceptor.py
@@ -231,7 +231,7 @@ def _get_scoped_token_signing_key() -> str:
 
     # 1. Check for explicit environment variable (Local/Tests precedence)
     explicit = os.environ.get("SCOPED_TOKEN_SIGNING_KEY")
-    if explicit:
+    if explicit and platform_env == "local":
         if len(explicit) < 32:
             logger.warning("SCOPED_TOKEN_SIGNING_KEY is too short (min 32 bytes recommended)")
         return explicit

--- a/tests/unit/test_issue_119.py
+++ b/tests/unit/test_issue_119.py
@@ -58,9 +58,36 @@ def test_scoped_token_signing_key_from_secret_works():
             assert mock_get_secret.call_count == 1
 
 
+def test_scoped_token_signing_key_fails_in_prod_even_if_set():
+    # In prod, it must fail if no secret ARN is configured,
+    # even if an explicit key env var is present
+    env = {
+        "PLATFORM_ENV": "prod",
+        "SCOPED_TOKEN_SIGNING_KEY": "some-explicit-key-that-is-32-bytes-long",
+        "SCOPED_TOKEN_SIGNING_KEY_SECRET_ARN": "",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        msg = "SCOPED_TOKEN_SIGNING_KEY or SCOPED_TOKEN_SIGNING_KEY_SECRET_ARN must be configured"
+        with pytest.raises(RuntimeError, match=msg):
+            request_interceptor._get_scoped_token_signing_key()
+
+
+def test_scoped_token_signing_key_works_in_local_if_set():
+    # In local, explicit environment variable should still work
+    env = {
+        "PLATFORM_ENV": "local",
+        "SCOPED_TOKEN_SIGNING_KEY": "local-explicit-signing-key-32-bytes",
+        "SCOPED_TOKEN_SIGNING_KEY_SECRET_ARN": "",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        key = request_interceptor._get_scoped_token_signing_key()
+        assert key == "local-explicit-signing-key-32-bytes"
+
+
 def test_scoped_token_signing_key_length_warning(caplog):
     short_key = "too-short"
-    with patch.dict(os.environ, {"SCOPED_TOKEN_SIGNING_KEY": short_key}, clear=False):
+    env = {"PLATFORM_ENV": "local", "SCOPED_TOKEN_SIGNING_KEY": short_key}
+    with patch.dict(os.environ, env, clear=False):
         key = request_interceptor._get_scoped_token_signing_key()
         assert key == short_key
         assert "SCOPED_TOKEN_SIGNING_KEY is too short" in caplog.text

--- a/tests/unit/test_request_interceptor.py
+++ b/tests/unit/test_request_interceptor.py
@@ -14,6 +14,7 @@ OS_ENV = {
     "TOOLS_TABLE": "platform-tools-dev",
     "SCOPED_TOKEN_SIGNING_KEY": "unit-test-signing-key-with-32-bytes-minimum",
     "SCOPED_TOKEN_ISSUER": "platform-gateway",
+    "PLATFORM_ENV": "local",
 }
 
 


### PR DESCRIPTION
Closes #143. This PR restricts the use of the SCOPED_TOKEN_SIGNING_KEY environment variable to environments where PLATFORM_ENV is set to 'local'. In all other environments, a secret ARN must be configured in SCOPED_TOKEN_SIGNING_KEY_SECRET_ARN.