### PR TITLE
Fix prod deploy gate to require real protected-environment approval

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,8 @@ variables:
   CANARY_POLICY_PROD: "canary-10%-15m"
   STAGING_ROLLOUT_WINDOW_MINUTES: "30"
   PROD_ROLLOUT_WINDOW_MINUTES: "15"
-  PROD_APPROVAL_MODE: "protected-environment-two-reviewer"
+  GITLAB_PROTECTED_ENVIRONMENT_NAME: "prod"
+  GITLAB_PROTECTED_ENV_REQUIRED_APPROVALS: "2"
   # Default roles (should be overridden in GitLab CI/CD variables)
   AWS_ROLE_ARN_VALIDATE: ${AWS_ROLE_ARN_VALIDATE}
   AWS_ROLE_ARN_DEPLOY_DEV: ${AWS_ROLE_ARN_DEPLOY_DEV}
@@ -103,7 +104,11 @@ validate-pipeline-policy:
   variables:
     AWS_ROLE_ARN: ${AWS_ROLE_ARN_VALIDATE}
   script:
-    - PYTHONPATH=. uv run pytest tests/unit/test_issue_110_ci_policy.py -v --tb=short
+    - >
+      PYTHONPATH=. uv run pytest
+      tests/unit/test_issue_110_ci_policy.py
+      tests/unit/test_check_gitlab_protected_environment.py
+      -v --tb=short
   interruptible: true
 
 # --- TEST STAGE ---
@@ -217,7 +222,10 @@ deploy-prod:
     AWS_ROLE_ARN: ${AWS_ROLE_ARN_DEPLOY_PROD}
     ENV: prod
   script:
-    - test "${PROD_APPROVAL_MODE}" = "protected-environment-two-reviewer"
+    - >
+      uv run python scripts/check_gitlab_protected_environment.py
+      --environment "${GITLAB_PROTECTED_ENVIRONMENT_NAME}"
+      --min-approvals "${GITLAB_PROTECTED_ENV_REQUIRED_APPROVALS}"
     - echo "Applying canary policy for ${ENV}: ${CANARY_POLICY_PROD}"
     - echo "Production rollout observation window: ${PROD_ROLLOUT_WINDOW_MINUTES} minutes"
     - make infra-deploy-prod-ci

--- a/docs/development/AGENT-DEVELOPER-GUIDE.md
+++ b/docs/development/AGENT-DEVELOPER-GUIDE.md
@@ -219,6 +219,26 @@ Pushing to a feature branch triggers: validate → test → push-dev (auto).
 Merge to main triggers: promote-staging (manual gate, requires evaluation score).
 Staging → prod: two-reviewer approval in GitLab.
 
+Production deploys fail closed unless the GitLab project protects the `prod`
+environment and requires at least two approvals. CI verifies that state by
+calling the Protected Environments API before any prod deploy step runs.
+
+Required GitLab project setup:
+- Protect environment `prod`.
+- Require at least 2 approvals on that protected environment.
+- Add protected masked CI/CD variable `GITLAB_PROTECTED_ENV_API_TOKEN` with `read_api` scope.
+
+Operator verification command:
+```bash
+curl --silent --header "PRIVATE-TOKEN: $GITLAB_PROTECTED_ENV_API_TOKEN" \
+  "$CI_API_V4_URL/projects/$CI_PROJECT_ID/protected_environments/prod" | \
+  jq '{name, required_approval_count, approval_rules}'
+```
+
+Failure mode when misconfigured:
+- `deploy-prod` exits before `make infra-deploy-prod-ci` if the token is missing,
+  the `prod` environment is not protected, or the API reports fewer than 2 approvals.
+
 The evaluation gate (promote-staging) runs your golden test cases against the real
 AgentCore Evaluations service in Frankfurt. Your agent will not promote if the
 evaluation score is below the threshold in [tool.agentcore.evaluations].

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -50,7 +50,8 @@ all secrets in Secrets Manager with 30-day rotation, Lambda /tmp caching (not en
 ### 7. Pipeline Compromise
 Threat: malicious code injected via CI/CD pipeline
 Mitigation: GitLab WIF OIDC (no long-lived keys), least-privilege pipeline roles,
-cfn-guard validates all IaC before deploy, two-reviewer approval for production
+cfn-guard validates all IaC before deploy, protected `prod` environment audited
+via GitLab API before deployment, two-reviewer approval for production
 
 ### 8. Session Hijacking
 Threat: attacker intercepts active AgentCore Runtime session
@@ -78,7 +79,7 @@ CloudTrail records all AWS API calls including Secrets Manager reads
 | KMS encryption at rest         | 2, 10                        | All DynamoDB + S3          |
 | HTTPS everywhere               | 8                            | CloudFront, API GW, VPC   |
 | detect-secrets in CI           | 6, 7                         | GitLab CI validate stage  |
-| Two-reviewer prod approval     | 7                            | GitLab protected env      |
+| Two-reviewer prod approval     | 7                            | GitLab protected env + CI API audit |
 | cfn-guard IaC policy           | 7                            | GitLab CI validate stage  |
 | CloudTrail + VPC Flow Logs     | 10                           | ObservabilityStack        |
 | PII redaction (RESPONSE)       | 9                            | RESPONSE interceptor      |

--- a/scripts/check_gitlab_protected_environment.py
+++ b/scripts/check_gitlab_protected_environment.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+check_gitlab_protected_environment.py — Fail closed unless prod deploy approval is real.
+
+Audits the GitLab Protected Environments API before a production deployment starts.
+This replaces mutable string sentinels with a machine-checkable control.
+
+Required CI variables:
+  CI_API_V4_URL
+  CI_PROJECT_ID
+  GITLAB_PROTECTED_ENV_API_TOKEN  (protected + masked, scope: read_api)
+
+Usage:
+    uv run python scripts/check_gitlab_protected_environment.py
+    uv run python scripts/check_gitlab_protected_environment.py \
+      --environment prod \
+      --min-approvals 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+DEFAULT_ENVIRONMENT_NAME = "prod"
+DEFAULT_MIN_APPROVALS = 2
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+class ProtectionCheckError(RuntimeError):
+    """Raised when the GitLab protected-environment control cannot be verified."""
+
+
+@dataclass(frozen=True)
+class ProtectedEnvironmentCheck:
+    environment_name: str
+    required_approval_count: int
+    approval_rule_count: int
+    deploy_access_level_count: int
+
+
+ProtectedEnvironmentFetcher = Callable[[str, str, str, str, float], dict[str, Any]]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-url", help="GitLab API base URL (defaults to CI_API_V4_URL)")
+    parser.add_argument("--project-id", help="GitLab project ID (defaults to CI_PROJECT_ID)")
+    parser.add_argument(
+        "--environment",
+        default=DEFAULT_ENVIRONMENT_NAME,
+        help=f"Protected environment name to verify (default: {DEFAULT_ENVIRONMENT_NAME})",
+    )
+    parser.add_argument(
+        "--min-approvals",
+        type=int,
+        default=DEFAULT_MIN_APPROVALS,
+        help=f"Minimum required approvals (default: {DEFAULT_MIN_APPROVALS})",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"HTTP timeout in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    return parser.parse_args(argv)
+
+
+def require_env(env: Mapping[str, str], name: str) -> str:
+    value = env.get(name, "").strip()
+    if not value:
+        raise ProtectionCheckError(f"Missing required environment variable: {name}")
+    return value
+
+
+def build_api_url(api_url: str, project_id: str, environment_name: str) -> str:
+    project_ref = quote(project_id, safe="")
+    env_ref = quote(environment_name, safe="")
+    return f"{api_url.rstrip('/')}/projects/{project_ref}/protected_environments/{env_ref}"
+
+
+def _coerce_non_negative_int(value: object, *, field_name: str) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        raise ProtectionCheckError(f"{field_name} must be an integer, got boolean")
+    if isinstance(value, int):
+        result = value
+    elif isinstance(value, str) and value.isdigit():
+        result = int(value)
+    else:
+        raise ProtectionCheckError(f"{field_name} must be an integer, got {value!r}")
+    if result < 0:
+        raise ProtectionCheckError(f"{field_name} must be non-negative, got {result}")
+    return result
+
+
+def derive_required_approval_count(payload: Mapping[str, Any]) -> int:
+    top_level = _coerce_non_negative_int(
+        payload.get("required_approval_count"),
+        field_name="required_approval_count",
+    )
+    if top_level is not None:
+        return top_level
+
+    approval_rules = payload.get("approval_rules")
+    if not isinstance(approval_rules, list) or not approval_rules:
+        raise ProtectionCheckError(
+            "GitLab protected environment response is missing approval metadata"
+        )
+
+    total = 0
+    for index, rule in enumerate(approval_rules):
+        if not isinstance(rule, Mapping):
+            raise ProtectionCheckError(f"approval_rules[{index}] must be an object")
+        approvals = _coerce_non_negative_int(
+            rule.get("required_approvals"),
+            field_name=f"approval_rules[{index}].required_approvals",
+        )
+        total += approvals or 0
+    return total
+
+
+def validate_protected_environment(
+    payload: Mapping[str, Any],
+    *,
+    expected_environment_name: str,
+    min_approvals: int,
+) -> ProtectedEnvironmentCheck:
+    actual_environment_name = str(payload.get("name", "")).strip()
+    if actual_environment_name != expected_environment_name:
+        raise ProtectionCheckError(
+            "GitLab protected environment name mismatch: "
+            f"expected {expected_environment_name!r}, got {actual_environment_name!r}"
+        )
+
+    required_approval_count = derive_required_approval_count(payload)
+    if required_approval_count < min_approvals:
+        raise ProtectionCheckError(
+            f"Protected environment {expected_environment_name!r} requires "
+            f"{required_approval_count} approvals; expected at least {min_approvals}"
+        )
+
+    approval_rules = payload.get("approval_rules")
+    approval_rule_count = len(approval_rules) if isinstance(approval_rules, list) else 0
+
+    deploy_access_levels = payload.get("deploy_access_levels")
+    deploy_access_level_count = (
+        len(deploy_access_levels) if isinstance(deploy_access_levels, list) else 0
+    )
+
+    return ProtectedEnvironmentCheck(
+        environment_name=actual_environment_name,
+        required_approval_count=required_approval_count,
+        approval_rule_count=approval_rule_count,
+        deploy_access_level_count=deploy_access_level_count,
+    )
+
+
+def fetch_protected_environment(
+    api_url: str,
+    project_id: str,
+    environment_name: str,
+    api_token: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    request = Request(
+        build_api_url(api_url, project_id, environment_name),
+        headers={
+            "Accept": "application/json",
+            "PRIVATE-TOKEN": api_token,
+        },
+        method="GET",
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            data = json.load(response)
+    except HTTPError as exc:
+        if exc.code == 404:
+            raise ProtectionCheckError(
+                f"Protected environment {environment_name!r} was not found in project "
+                f"{project_id}. Configure GitLab protected-environment approvals first."
+            ) from exc
+        if exc.code in {401, 403}:
+            raise ProtectionCheckError(
+                "GitLab API token cannot read protected environments. Confirm "
+                "GITLAB_PROTECTED_ENV_API_TOKEN is protected, masked, and has read_api scope."
+            ) from exc
+        detail = exc.read().decode("utf-8", errors="replace").strip()
+        raise ProtectionCheckError(
+            f"GitLab protected environment API returned HTTP {exc.code}: {detail or 'no body'}"
+        ) from exc
+    except URLError as exc:
+        raise ProtectionCheckError(f"Unable to reach GitLab API: {exc.reason}") from exc
+
+    if not isinstance(data, dict):
+        raise ProtectionCheckError("GitLab protected environment API returned a non-object JSON")
+    return data
+
+
+def run(
+    *,
+    api_url: str | None = None,
+    project_id: str | None = None,
+    environment_name: str = DEFAULT_ENVIRONMENT_NAME,
+    min_approvals: int = DEFAULT_MIN_APPROVALS,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    env: Mapping[str, str] | None = None,
+    fetcher: ProtectedEnvironmentFetcher = fetch_protected_environment,
+) -> ProtectedEnvironmentCheck:
+    if min_approvals < 1:
+        raise ProtectionCheckError("min_approvals must be at least 1")
+
+    env_map = env if env is not None else os.environ
+    resolved_api_url = api_url or require_env(env_map, "CI_API_V4_URL")
+    resolved_project_id = project_id or require_env(env_map, "CI_PROJECT_ID")
+    api_token = require_env(env_map, "GITLAB_PROTECTED_ENV_API_TOKEN")
+
+    payload = fetcher(
+        resolved_api_url,
+        resolved_project_id,
+        environment_name,
+        api_token,
+        timeout_seconds,
+    )
+    return validate_protected_environment(
+        payload,
+        expected_environment_name=environment_name,
+        min_approvals=min_approvals,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = run(
+            api_url=args.api_url,
+            project_id=args.project_id,
+            environment_name=args.environment,
+            min_approvals=args.min_approvals,
+            timeout_seconds=args.timeout_seconds,
+        )
+    except ProtectionCheckError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "Protected environment verified: "
+        f"name={result.environment_name} "
+        f"required_approvals={result.required_approval_count} "
+        f"approval_rules={result.approval_rule_count} "
+        f"deploy_access_levels={result.deploy_access_level_count}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_gitlab_protected_environment.py
+++ b/tests/unit/test_check_gitlab_protected_environment.py
@@ -1,0 +1,173 @@
+"""Unit tests for scripts/check_gitlab_protected_environment.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "check_gitlab_protected_environment_script",
+        repo_root / "scripts" / "check_gitlab_protected_environment.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+check_script = _load_module()
+
+
+def test_build_api_url_escapes_project_and_environment_names() -> None:
+    url = check_script.build_api_url(
+        "https://gitlab.example.com/api/v4/",
+        "group/platform/project",
+        "prod/blue",
+    )
+    assert (
+        url == "https://gitlab.example.com/api/v4/projects/group%2Fplatform%2Fproject/"
+        "protected_environments/prod%2Fblue"
+    )
+
+
+def test_validate_protected_environment_accepts_top_level_required_approval_count() -> None:
+    result = check_script.validate_protected_environment(
+        {
+            "name": "prod",
+            "required_approval_count": 2,
+            "approval_rules": [{"required_approvals": 2}],
+            "deploy_access_levels": [{"group_id": 1}],
+        },
+        expected_environment_name="prod",
+        min_approvals=2,
+    )
+    assert result.environment_name == "prod"
+    assert result.required_approval_count == 2
+    assert result.approval_rule_count == 1
+    assert result.deploy_access_level_count == 1
+
+
+def test_validate_protected_environment_falls_back_to_approval_rule_sum() -> None:
+    result = check_script.validate_protected_environment(
+        {
+            "name": "prod",
+            "approval_rules": [
+                {"required_approvals": 1},
+                {"required_approvals": "1"},
+            ],
+            "deploy_access_levels": [],
+        },
+        expected_environment_name="prod",
+        min_approvals=2,
+    )
+    assert result.required_approval_count == 2
+
+
+def test_validate_protected_environment_rejects_insufficient_approvals() -> None:
+    with pytest.raises(
+        check_script.ProtectionCheckError,
+        match="requires 1 approvals; expected at least 2",
+    ):
+        check_script.validate_protected_environment(
+            {
+                "name": "prod",
+                "required_approval_count": 1,
+            },
+            expected_environment_name="prod",
+            min_approvals=2,
+        )
+
+
+def test_validate_protected_environment_rejects_missing_approval_metadata() -> None:
+    with pytest.raises(
+        check_script.ProtectionCheckError,
+        match="missing approval metadata",
+    ):
+        check_script.validate_protected_environment(
+            {"name": "prod"},
+            expected_environment_name="prod",
+            min_approvals=2,
+        )
+
+
+def test_run_passes_when_fetcher_returns_real_protected_environment() -> None:
+    calls: list[tuple[str, str, str, str, float]] = []
+
+    def _fetcher(
+        api_url: str,
+        project_id: str,
+        environment_name: str,
+        api_token: str,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        calls.append((api_url, project_id, environment_name, api_token, timeout_seconds))
+        return {
+            "name": "prod",
+            "required_approval_count": 2,
+            "approval_rules": [{"required_approvals": 2}],
+            "deploy_access_levels": [{"group_id": 1}],
+        }
+
+    result = check_script.run(
+        environment_name="prod",
+        min_approvals=2,
+        timeout_seconds=7.5,
+        env={
+            "CI_API_V4_URL": "https://gitlab.example.com/api/v4",
+            "CI_PROJECT_ID": "1234",
+            "GITLAB_PROTECTED_ENV_API_TOKEN": "secret-token",
+        },
+        fetcher=_fetcher,
+    )
+
+    assert result.required_approval_count == 2
+    assert calls == [
+        (
+            "https://gitlab.example.com/api/v4",
+            "1234",
+            "prod",
+            "secret-token",
+            7.5,
+        )
+    ]
+
+
+def test_run_fails_closed_when_protected_environment_is_missing() -> None:
+    def _fetcher(
+        api_url: str,
+        project_id: str,
+        environment_name: str,
+        api_token: str,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        raise check_script.ProtectionCheckError(
+            f"Protected environment {environment_name!r} was not found"
+        )
+
+    with pytest.raises(check_script.ProtectionCheckError, match="was not found"):
+        check_script.run(
+            environment_name="prod",
+            min_approvals=2,
+            env={
+                "CI_API_V4_URL": "https://gitlab.example.com/api/v4",
+                "CI_PROJECT_ID": "1234",
+                "GITLAB_PROTECTED_ENV_API_TOKEN": "secret-token",
+            },
+            fetcher=_fetcher,
+        )
+
+
+def test_main_returns_1_when_api_token_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CI_API_V4_URL", "https://gitlab.example.com/api/v4")
+    monkeypatch.setenv("CI_PROJECT_ID", "1234")
+    monkeypatch.delenv("GITLAB_PROTECTED_ENV_API_TOKEN", raising=False)
+
+    assert check_script.main(["--environment", "prod", "--min-approvals", "2"]) == 1

--- a/tests/unit/test_issue_110_ci_policy.py
+++ b/tests/unit/test_issue_110_ci_policy.py
@@ -19,7 +19,8 @@ def test_canary_policy_variables_are_explicit_per_environment() -> None:
     assert 'CANARY_POLICY_PROD: "canary-10%-15m"' in content
     assert 'STAGING_ROLLOUT_WINDOW_MINUTES: "30"' in content
     assert 'PROD_ROLLOUT_WINDOW_MINUTES: "15"' in content
-    assert 'PROD_APPROVAL_MODE: "protected-environment-two-reviewer"' in content
+    assert 'GITLAB_PROTECTED_ENVIRONMENT_NAME: "prod"' in content
+    assert 'GITLAB_PROTECTED_ENV_REQUIRED_APPROVALS: "2"' in content
 
 
 def test_ci_test_matrix_covers_unit_integration_and_cdk() -> None:
@@ -27,6 +28,13 @@ def test_ci_test_matrix_covers_unit_integration_and_cdk() -> None:
     for name in ("test-unit", "test-integration", "test-cdk"):
         block = _job_block(name, content)
         assert "extends: .test_job_base" in block
+
+
+def test_validate_pipeline_policy_runs_ci_contract_and_protection_script_tests() -> None:
+    content = CI_FILE.read_text(encoding="utf-8")
+    validate = _job_block("validate-pipeline-policy", content)
+    assert "tests/unit/test_issue_110_ci_policy.py" in validate
+    assert "tests/unit/test_check_gitlab_protected_environment.py" in validate
 
 
 def test_staging_and_prod_gates_have_manual_approvals_and_rollout_windows() -> None:
@@ -45,7 +53,10 @@ def test_staging_and_prod_gates_have_manual_approvals_and_rollout_windows() -> N
     assert 'needs: ["staging-rollout-window"]' in prod
     assert "when: manual" in prod
     assert "deployment_tier: production" in prod
-    assert 'test "${PROD_APPROVAL_MODE}" = "protected-environment-two-reviewer"' in prod
+    assert "uv run python scripts/check_gitlab_protected_environment.py" in prod
+    assert '--environment "${GITLAB_PROTECTED_ENVIRONMENT_NAME}"' in prod
+    assert '--min-approvals "${GITLAB_PROTECTED_ENV_REQUIRED_APPROVALS}"' in prod
+    assert 'test "${PROD_APPROVAL_MODE}"' not in prod
 
     prod_window = _job_block("prod-rollout-window", content)
     assert "when: delayed" in prod_window


### PR DESCRIPTION
## Summary
- replace the mutable prod approval sentinel with a GitLab Protected Environments API audit before deploy-prod runs
- add fail-closed Python control logic and regression tests for happy-path and missing/insufficient protection metadata
- document the required GitLab prod environment protection settings, token prerequisite, and operator verification command

## Validation
- make preflight-session
- make pre-validate-session
- make validate-local
- uv run pytest tests/unit/test_issue_110_ci_policy.py tests/unit/test_check_gitlab_protected_environment.py -v --tb=short
- make test-unit (in progress locally; will update before merge)

Closes #142
