### PR TITLE
TASK-144: Fix tenant listing to use TenantScopedDynamoDB.scan correctly

### DIFF
--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -107,13 +107,13 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
 
     # 1. Query invocations for the day
     # SK starts with INV#timestamp
-    invocations = db.query(
+    result = db.query(
         INVOCATIONS_TABLE,
         sk_condition=Key("SK").between(f"INV#{start_time}", f"INV#{end_time}"),
     )
 
-    day_input = sum(int(inv.get("input_tokens", 0)) for inv in invocations)
-    day_output = sum(int(inv.get("output_tokens", 0)) for inv in invocations)
+    day_input = sum(int(inv.get("input_tokens", 0)) for inv in result.items)
+    day_output = sum(int(inv.get("output_tokens", 0)) for inv in result.items)
 
     # 2. Apply pricing
     pricing = _get_pricing(tier)

--- a/src/data-access-lib/src/data_access/__init__.py
+++ b/src/data-access-lib/src/data_access/__init__.py
@@ -10,6 +10,12 @@ ADRs: ADR-012
 
 from data_access.client import TenantScopedDynamoDB, TenantScopedS3
 from data_access.exceptions import TenantAccessViolation
-from data_access.models import TenantContext
+from data_access.models import PaginatedItems, TenantContext
 
-__all__ = ["TenantContext", "TenantAccessViolation", "TenantScopedDynamoDB", "TenantScopedS3"]
+__all__ = [
+    "TenantContext",
+    "TenantAccessViolation",
+    "TenantScopedDynamoDB",
+    "TenantScopedS3",
+    "PaginatedItems",
+]

--- a/src/data-access-lib/src/data_access/client.py
+++ b/src/data-access-lib/src/data_access/client.py
@@ -26,7 +26,7 @@ from aws_lambda_powertools import Logger
 from boto3.dynamodb.conditions import ConditionBase, Key
 
 from data_access.exceptions import TenantAccessViolation
-from data_access.models import TenantContext
+from data_access.models import PaginatedItems, TenantContext
 
 logger = Logger(service="data-access-lib")
 
@@ -206,7 +206,7 @@ class TenantScopedDynamoDB:
         limit: int | None = None,
         scan_index_forward: bool = True,
         exclusive_start_key: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> PaginatedItems:
         """Query the caller's tenant partition.
 
         The PK is always forced to TENANT#{tenant_id}; the caller cannot
@@ -214,8 +214,8 @@ class TenantScopedDynamoDB:
         attribute name is "PK" (platform single-table design convention).
         An optional SK condition is ANDed onto the key condition.
 
-        Returns the first page of matching items.  Pass exclusive_start_key
-        for subsequent pages.
+        Returns a PaginatedItems object. Pass result.last_evaluated_key
+        to exclusive_start_key for subsequent pages.
         """
         table = self._dynamodb.Table(table_name)
         pk_condition = Key("PK").eq(f"{_TENANT_PK_PREFIX}{self._tenant_id}")
@@ -235,18 +235,21 @@ class TenantScopedDynamoDB:
             kwargs["ExclusiveStartKey"] = exclusive_start_key
 
         response = table.query(**kwargs)
-        return response.get("Items", [])
+        return PaginatedItems(
+            items=response.get("Items", []),
+            last_evaluated_key=response.get("LastEvaluatedKey"),
+        )
 
     def scan(
         self,
         table_name: str,
         *,
-        filter_expression: ConditionBase | None = None,
+        filter_expression: ConditionBase | str | None = None,
         limit: int | None = None,
         exclusive_start_key: dict[str, Any] | None = None,
         expression_attribute_names: dict[str, str] | None = None,
         expression_attribute_values: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> PaginatedItems:
         """Scan a table.
 
         SECURITY: Scanning is an administrative operation.  Isolation is
@@ -255,6 +258,9 @@ class TenantScopedDynamoDB:
 
         Lambda handlers must perform their own authorization (e.g. roles claim
         check) before calling this method.
+
+        Returns a PaginatedItems object. Pass result.last_evaluated_key
+        to exclusive_start_key for subsequent pages.
         """
         table = self._dynamodb.Table(table_name)
         kwargs: dict[str, Any] = {}
@@ -270,10 +276,10 @@ class TenantScopedDynamoDB:
             kwargs["ExpressionAttributeValues"] = expression_attribute_values
 
         response = table.scan(**kwargs)
-        # Handle pagination by returning the LastEvaluatedKey in the result if we want it?
-        # But for now, let's keep it simple and just return items.
-        # To support pagination properly, we should probably return (items, last_key).
-        return response.get("Items", [])
+        return PaginatedItems(
+            items=response.get("Items", []),
+            last_evaluated_key=response.get("LastEvaluatedKey"),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/data-access-lib/src/data_access/models.py
+++ b/src/data-access-lib/src/data_access/models.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # TTL constants (seconds)
@@ -376,6 +377,19 @@ class BillingSummaryRecord:
     @property
     def sk(self) -> str:
         return f"BILLING#{self.year_month}"
+
+
+# ---------------------------------------------------------------------------
+# Pagination — shared response structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PaginatedItems:
+    """A page of DynamoDB items with an optional resumption key."""
+
+    items: list[dict[str, Any]]
+    last_evaluated_key: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/data-access-lib/tests/test_client.py
+++ b/src/data-access-lib/tests/test_client.py
@@ -18,7 +18,12 @@ from unittest.mock import MagicMock
 
 import boto3
 import pytest
-from data_access import TenantAccessViolation, TenantContext, TenantScopedDynamoDB, TenantScopedS3
+from data_access import (
+    TenantAccessViolation,
+    TenantContext,
+    TenantScopedDynamoDB,
+    TenantScopedS3,
+)
 from data_access.client import _emit_tenant_violation_metric
 from data_access.models import TenantTier
 from moto import mock_aws
@@ -437,9 +442,9 @@ class TestTenantScopedDynamoDBQuery:
             # One item for another tenant (written directly — bypassing lib)
             table.put_item(Item={"PK": f"TENANT#{OTHER_TENANT_ID}", "SK": "INV#001"})
 
-            items = db.query(TABLE_NAME)
-        assert len(items) == 2
-        assert all(i["PK"] == f"TENANT#{TENANT_ID}" for i in items)
+            result = db.query(TABLE_NAME)
+        assert len(result.items) == 2
+        assert all(i["PK"] == f"TENANT#{TENANT_ID}" for i in result.items)
 
     def test_query_with_sk_condition(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
         from boto3.dynamodb.conditions import Key
@@ -451,8 +456,8 @@ class TestTenantScopedDynamoDBQuery:
             table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": "INV#002"})
             table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": "SESS#001"})
 
-            items = db.query(TABLE_NAME, sk_condition=Key("SK").begins_with("INV#"))
-        assert len(items) == 2
+            result = db.query(TABLE_NAME, sk_condition=Key("SK").begins_with("INV#"))
+        assert len(result.items) == 2
 
     def test_query_with_limit(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
         with mock_aws():
@@ -461,8 +466,8 @@ class TestTenantScopedDynamoDBQuery:
             for i in range(5):
                 table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": f"INV#{i:03d}"})
 
-            items = db.query(TABLE_NAME, limit=2)
-        assert len(items) == 2
+            result = db.query(TABLE_NAME, limit=2)
+        assert len(result.items) == 2
 
     def test_query_with_scan_index_forward_false(
         self, ctx: TenantContext, mock_cw: MagicMock
@@ -473,10 +478,10 @@ class TestTenantScopedDynamoDBQuery:
             table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": "INV#001"})
             table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": "INV#002"})
 
-            items = db.query(TABLE_NAME, scan_index_forward=False)
+            result = db.query(TABLE_NAME, scan_index_forward=False)
         # Reversed order
-        assert items[0]["SK"] == "INV#002"
-        assert items[1]["SK"] == "INV#001"
+        assert result.items[0]["SK"] == "INV#002"
+        assert result.items[1]["SK"] == "INV#001"
 
     def test_query_with_exclusive_start_key(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
         with mock_aws():
@@ -486,13 +491,16 @@ class TestTenantScopedDynamoDBQuery:
                 table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": f"INV#{i:03d}"})
 
             # First page
-            first_page = db.query(TABLE_NAME, limit=2)
+            result1 = db.query(TABLE_NAME, limit=2)
+            assert result1.last_evaluated_key is not None
+
             # Second page
-            second_page = db.query(
+            result2 = db.query(
                 TABLE_NAME,
-                exclusive_start_key={"PK": first_page[-1]["PK"], "SK": first_page[-1]["SK"]},
+                exclusive_start_key=result1.last_evaluated_key,
             )
-        assert len(second_page) == 1
+        assert len(result2.items) == 1
+        assert result2.last_evaluated_key is None
 
     def test_query_optional_kwargs_via_mock(self, ctx: TenantContext) -> None:
         """Verify index_name and filter_expression kwargs are forwarded."""
@@ -517,8 +525,8 @@ class TestTenantScopedDynamoDBQuery:
     def test_query_empty_result(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
         with mock_aws():
             db, _ = _make_dynamo_db(ctx, cw=mock_cw)
-            items = db.query(TABLE_NAME)
-        assert items == []
+            result = db.query(TABLE_NAME)
+        assert result.items == []
 
     def test_query_always_uses_caller_partition(
         self, ctx: TenantContext, mock_cw: MagicMock
@@ -531,9 +539,64 @@ class TestTenantScopedDynamoDBQuery:
             table.put_item(Item={"PK": f"TENANT#{OTHER_TENANT_ID}", "SK": "INV#001"})
 
             # Query should return nothing (only our partition)
-            items = db.query(TABLE_NAME)
-        assert items == []
+            result = db.query(TABLE_NAME)
+        assert result.items == []
         mock_cw.put_metric_data.assert_not_called()
+
+
+# ===========================================================================
+# TenantScopedDynamoDB — scan
+# ===========================================================================
+
+
+class TestTenantScopedDynamoDBScan:
+    def test_scan_returns_all_items_regardless_of_tenant(
+        self, ctx: TenantContext, mock_cw: MagicMock
+    ) -> None:
+        """Scan does not enforce tenant isolation — returns everything in the table."""
+        with mock_aws():
+            db, dynamo = _make_dynamo_db(ctx, cw=mock_cw)
+            table = dynamo.Table(TABLE_NAME)
+            table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": "INV#001"})
+            table.put_item(Item={"PK": f"TENANT#{OTHER_TENANT_ID}", "SK": "INV#002"})
+
+            result = db.scan(TABLE_NAME)
+        assert len(result.items) == 2
+
+    def test_scan_with_limit_and_pagination(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
+        with mock_aws():
+            db, dynamo = _make_dynamo_db(ctx, cw=mock_cw)
+            table = dynamo.Table(TABLE_NAME)
+            for i in range(5):
+                table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": f"INV#{i:03d}"})
+
+            # Page 1
+            result1 = db.scan(TABLE_NAME, limit=2)
+            assert len(result1.items) == 2
+            assert result1.last_evaluated_key is not None
+
+            # Page 2
+            result2 = db.scan(TABLE_NAME, limit=2, exclusive_start_key=result1.last_evaluated_key)
+            assert len(result2.items) == 2
+            assert result2.last_evaluated_key is not None
+
+            # Page 3
+            result3 = db.scan(TABLE_NAME, limit=2, exclusive_start_key=result2.last_evaluated_key)
+            assert len(result3.items) == 1
+            assert result3.last_evaluated_key is None
+
+    def test_scan_with_filter_expression(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
+        from boto3.dynamodb.conditions import Attr
+
+        with mock_aws():
+            db, dynamo = _make_dynamo_db(ctx, cw=mock_cw)
+            table = dynamo.Table(TABLE_NAME)
+            table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": "INV#001", "status": "ok"})
+            table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": "INV#002", "status": "fail"})
+
+            result = db.scan(TABLE_NAME, filter_expression=Attr("status").eq("ok"))
+        assert len(result.items) == 1
+        assert result.items[0]["SK"] == "INV#001"
 
 
 # ===========================================================================

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -530,12 +530,14 @@ def _handle_list(
         app_id=caller.app_id or "system",
     )
 
-    scan_kwargs: dict[str, Any] = {
-        "TableName": _tenants_table_name(),
-        "Limit": limit,
+    scan_params: dict[str, Any] = {
+        "limit": limit,
     }
     if next_token:
-        scan_kwargs["ExclusiveStartKey"] = json.loads(next_token)
+        try:
+            scan_params["exclusive_start_key"] = json.loads(next_token)
+        except json.JSONDecodeError:
+            raise ValueError("Invalid nextToken")
 
     filter_exprs = []
     expr_values = {}
@@ -551,18 +553,20 @@ def _handle_list(
         expr_values[":t"] = tier_filter.lower()
 
     if filter_exprs:
-        scan_kwargs["FilterExpression"] = " AND ".join(filter_exprs)
-        scan_kwargs["ExpressionAttributeNames"] = expr_names
-        scan_kwargs["ExpressionAttributeValues"] = expr_values
+        scan_params["filter_expression"] = " AND ".join(filter_exprs)
+        scan_params["expression_attribute_names"] = expr_names
+        scan_params["expression_attribute_values"] = expr_values
 
     # Scan the table using data-access-lib
-    items = db.scan(_tenants_table_name(), **scan_kwargs)
+    result = db.scan(_tenants_table_name(), **scan_params)
 
     return _response(
         200,
         {
-            "items": [_serialize_tenant(item) for item in items],
-            "nextToken": None,  # TODO: Implement paged scan in data-access-lib
+            "items": [_serialize_tenant(item) for item in result.items],
+            "nextToken": (
+                json.dumps(result.last_evaluated_key) if result.last_evaluated_key else None
+            ),
         },
     )
 

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -11,6 +11,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from data_access.models import PaginatedItems
+
 from src.tenant_api import handler as tenant_api_handler
 
 
@@ -67,19 +69,46 @@ class FakeScopedDb:
     def scan(
         self,
         _table_name: str | None = None,
-        **kwargs: Any,
-    ) -> list[dict[str, Any]] | dict[str, Any]:
+        *,
+        filter_expression: Any | None = None,
+        limit: int | None = None,
+        exclusive_start_key: dict[str, Any] | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+    ) -> PaginatedItems:
+        # Match real lib: _table_name is NOT None if we use it correctly
         results = [dict(item) for item in self.items.values()]
         # Simple filter implementation for tests
-        status_filter = kwargs.get("ExpressionAttributeValues", {}).get(":s")
-        tier_filter = kwargs.get("ExpressionAttributeValues", {}).get(":t")
+        status_filter = (expression_attribute_values or {}).get(":s")
+        tier_filter = (expression_attribute_values or {}).get(":t")
         if status_filter:
             results = [r for r in results if r.get("status") == status_filter]
         if tier_filter:
             results = [r for r in results if r.get("tier") == tier_filter]
-        if _table_name is None:
-            return {"Items": results}
-        return results
+
+        # Paginated results simulation
+        last_key = None
+        if limit and len(results) > limit:
+            # Not really accurate for DynamoDB but enough for tests
+            last_key = {"PK": results[limit - 1]["PK"], "SK": results[limit - 1]["SK"]}
+            results = results[:limit]
+
+        return PaginatedItems(items=results, last_evaluated_key=last_key)
+
+    def query(
+        self,
+        _table_name: str | None = None,
+        *,
+        sk_condition: Any | None = None,
+        filter_expression: Any | None = None,
+        index_name: str | None = None,
+        limit: int | None = None,
+        scan_index_forward: bool = True,
+        exclusive_start_key: dict[str, Any] | None = None,
+    ) -> PaginatedItems:
+        # Mock query — just return some items
+        results = [dict(item) for item in self.items.values()]
+        return PaginatedItems(items=results)
 
 
 class FakeSecretsManager:


### PR DESCRIPTION
Fixes #144 by updating TenantScopedDynamoDB.scan and query to return PaginatedItems, and fixing the parameter mismatch in the tenant API handler.