### PR TITLE
Heal invalid tenant execution role ARNs from SSM backfill

### DIFF
--- a/scripts/backfill_tenant_execution_role_arn.py
+++ b/scripts/backfill_tenant_execution_role_arn.py
@@ -98,9 +98,10 @@ def _scan_tenant_rows(table: Any, *, tenant_id: str | None) -> list[TenantRow]:
             row = _tenant_row(item)
             if row is not None:
                 rows.append(row)
-        if "LastEvaluatedKey" not in response:
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
             break
-        scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+        scan_kwargs["ExclusiveStartKey"] = last_evaluated_key
     return rows
 
 
@@ -135,68 +136,80 @@ def run(args: argparse.Namespace) -> int:
         print("No tenant rows found")
         return 1
 
-    verified = 0
+    already_valid = 0
+    ready_from_ssm = 0
+    repaired = 0
     backfilled = 0
     unresolved = 0
-    malformed = 0
+    invalid_record = 0
+    invalid_ssm = 0
 
     for row in rows:
         current = row.execution_role_arn
-        if current:
-            validation_error = _validate_role_arn(current, row.account_id)
-            if validation_error is None:
-                verified += 1
-                print(f"[verified] tenant={row.tenant_id} source=record roleArn={current}")
-                continue
-            malformed += 1
+        record_error = _validate_role_arn(current, row.account_id) if current else None
+        if current and record_error is None:
+            already_valid += 1
+            print(f"[verified] tenant={row.tenant_id} source=record roleArn={current}")
+            continue
+        if current and record_error is not None:
+            invalid_record += 1
             print(
-                "[invalid] "
+                "[invalid-record] "
                 f"tenant={row.tenant_id} "
                 "source=record "
-                f"error={validation_error} "
+                f"error={record_error} "
                 f"roleArn={current}"
             )
-            continue
 
         resolved = _read_execution_role_from_ssm(
             ssm,
             tenant_id=row.tenant_id,
             param_template=args.param_template,
         )
+        reason = "record-invalid" if current else "record-missing"
         if not resolved:
             unresolved += 1
-            print(f"[missing] tenant={row.tenant_id} source=ssm")
+            print(f"[unresolved] tenant={row.tenant_id} source=ssm reason={reason}")
             continue
 
         validation_error = _validate_role_arn(resolved, row.account_id)
         if validation_error is not None:
-            malformed += 1
+            invalid_ssm += 1
             print(
-                "[invalid] "
+                "[invalid-ssm] "
                 f"tenant={row.tenant_id} "
                 "source=ssm "
+                f"reason={reason} "
                 f"error={validation_error} "
                 f"roleArn={resolved}"
             )
             continue
 
-        verified += 1
+        if current:
+            repaired += 1
+        else:
+            ready_from_ssm += 1
         if args.apply:
             _apply_backfill(table, row=row, execution_role_arn=resolved)
             backfilled += 1
-            print(f"[backfilled] tenant={row.tenant_id} roleArn={resolved}")
+            print(
+                f"[backfilled] tenant={row.tenant_id} source=ssm reason={reason} roleArn={resolved}"
+            )
         else:
-            print(f"[ready] tenant={row.tenant_id} roleArn={resolved}")
+            print(f"[ready] tenant={row.tenant_id} source=ssm reason={reason} roleArn={resolved}")
 
     print(
         "Summary:",
         f"scanned={len(rows)}",
-        f"verified={verified}",
+        f"already_valid={already_valid}",
+        f"ready_from_ssm={ready_from_ssm}",
+        f"repaired={repaired}",
         f"backfilled={backfilled}",
         f"unresolved={unresolved}",
-        f"invalid={malformed}",
+        f"invalid_record={invalid_record}",
+        f"invalid_ssm={invalid_ssm}",
     )
-    if unresolved > 0 or malformed > 0:
+    if unresolved > 0 or invalid_ssm > 0:
         return 1
     return 0
 

--- a/tests/unit/test_backfill_tenant_execution_role_arn.py
+++ b/tests/unit/test_backfill_tenant_execution_role_arn.py
@@ -3,91 +3,155 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
-import boto3
 import pytest
-from moto import mock_aws
+from botocore.exceptions import ClientError
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts import backfill_tenant_execution_role_arn as script
 
 
-@pytest.fixture
-def aws_credentials(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")  # pragma: allowlist secret
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")  # pragma: allowlist secret
-    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
-    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-2")
-    monkeypatch.setenv("AWS_REGION", "eu-west-2")
+class FakeTable:
+    def __init__(self, *items: dict[str, str]):
+        self.items = {(str(item["PK"]), str(item["SK"])): dict(item) for item in items}
+
+    def get_item(self, *, Key: dict[str, str]) -> dict[str, dict[str, str]]:
+        item = self.items.get((Key["PK"], Key["SK"]))
+        if item is None:
+            return {}
+        return {"Item": dict(item)}
+
+    def scan(self, **_: object) -> dict[str, object]:
+        return {"Items": [dict(item) for item in self.items.values()], "LastEvaluatedKey": None}
+
+    def update_item(
+        self,
+        *,
+        Key: dict[str, str],
+        UpdateExpression: str,
+        ExpressionAttributeValues: dict[str, str],
+        ConditionExpression: str,
+    ) -> None:
+        assert "executionRoleArn" in UpdateExpression
+        assert ConditionExpression == "attribute_exists(PK) AND attribute_exists(SK)"
+        item = self.items[(Key["PK"], Key["SK"])]
+        item["executionRoleArn"] = ExpressionAttributeValues[":executionRoleArn"]
+        item["execution_role_arn"] = ExpressionAttributeValues[":executionRoleArn"]
+        item["updatedAt"] = ExpressionAttributeValues[":updatedAt"]
 
 
-@pytest.fixture
-def mock_aws_services(aws_credentials):
-    with mock_aws():
-        yield
+class FakeDynamoResource:
+    def __init__(self, table: FakeTable):
+        self._table = table
+
+    def Table(self, table_name: str) -> FakeTable:
+        assert table_name == "platform-tenants"
+        return self._table
 
 
-def _create_tenants_table() -> None:
-    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
-    ddb.create_table(
-        TableName="platform-tenants",
-        KeySchema=[
-            {"AttributeName": "PK", "KeyType": "HASH"},
-            {"AttributeName": "SK", "KeyType": "RANGE"},
-        ],
-        AttributeDefinitions=[
-            {"AttributeName": "PK", "AttributeType": "S"},
-            {"AttributeName": "SK", "AttributeType": "S"},
-        ],
-        BillingMode="PAY_PER_REQUEST",
+class FakeSsmClient:
+    def __init__(self, parameters: dict[str, str | None]):
+        self.parameters = dict(parameters)
+        self.requests: list[str] = []
+
+    def get_parameter(self, *, Name: str) -> dict[str, dict[str, str | None]]:
+        self.requests.append(Name)
+        if Name not in self.parameters:
+            raise ClientError({"Error": {"Code": "ParameterNotFound"}}, "GetParameter")
+        return {"Parameter": {"Value": self.parameters[Name]}}
+
+
+class FakeSession:
+    def __init__(self, *, table: FakeTable, ssm: FakeSsmClient):
+        self._ddb = FakeDynamoResource(table)
+        self._ssm = ssm
+
+    def resource(self, service_name: str) -> FakeDynamoResource:
+        assert service_name == "dynamodb"
+        return self._ddb
+
+    def client(self, service_name: str) -> FakeSsmClient:
+        assert service_name == "ssm"
+        return self._ssm
+
+
+def _run(
+    *,
+    table: FakeTable,
+    parameters: dict[str, str | None],
+    apply: bool,
+    tenant_id: str | None = None,
+) -> tuple[int, FakeSsmClient]:
+    fake_ssm = FakeSsmClient(parameters)
+    fake_session = FakeSession(table=table, ssm=fake_ssm)
+    args = argparse.Namespace(
+        region="eu-west-2",
+        table_name="platform-tenants",
+        param_template="/platform/tenants/{tenant_id}/execution-role-arn",
+        tenant_id=tenant_id,
+        apply=apply,
     )
+    with patch.object(script.boto3.session, "Session", return_value=fake_session):
+        rc = script.run(args)
+    return rc, fake_ssm
 
 
-def test_backfill_apply_sets_execution_role_fields(mock_aws_services):
-    _create_tenants_table()
-    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
-    ssm = boto3.client("ssm", region_name="eu-west-2")
-    table = ddb.Table("platform-tenants")
-
-    table.put_item(
-        Item={
+@pytest.mark.parametrize(
+    ("invalid_record_arn", "expected_error"),
+    [
+        ("not-an-arn", "malformed"),
+        ("arn:aws:iam::999999999999:role/wrong-account-role", "account-mismatch"),
+    ],
+)
+def test_backfill_apply_repairs_invalid_record_from_ssm(
+    capsys: pytest.CaptureFixture[str],
+    invalid_record_arn: str,
+    expected_error: str,
+) -> None:
+    table = FakeTable(
+        {
             "PK": "TENANT#t-001",
             "SK": "METADATA",
             "tenantId": "t-001",
             "accountId": "123456789012",
+            "executionRoleArn": invalid_record_arn,
         }
     )
-    ssm.put_parameter(
-        Name="/platform/tenants/t-001/execution-role-arn",
-        Value="arn:aws:iam::123456789012:role/tenant-custom-role",
-        Type="String",
-    )
 
-    rc = script.run(
-        argparse.Namespace(
-            region="eu-west-2",
-            table_name="platform-tenants",
-            param_template="/platform/tenants/{tenant_id}/execution-role-arn",
-            tenant_id=None,
-            apply=True,
-        )
+    rc, fake_ssm = _run(
+        table=table,
+        parameters={
+            "/platform/tenants/t-001/execution-role-arn": (
+                "arn:aws:iam::123456789012:role/tenant-custom-role"
+            )
+        },
+        apply=True,
     )
 
     assert rc == 0
     item = table.get_item(Key={"PK": "TENANT#t-001", "SK": "METADATA"})["Item"]
     assert item["executionRoleArn"] == "arn:aws:iam::123456789012:role/tenant-custom-role"
     assert item["execution_role_arn"] == "arn:aws:iam::123456789012:role/tenant-custom-role"
+    assert fake_ssm.requests == ["/platform/tenants/t-001/execution-role-arn"]
+    output = capsys.readouterr().out
+    assert f"[invalid-record] tenant=t-001 source=record error={expected_error}" in output
+    assert (
+        "[backfilled] tenant=t-001 source=ssm reason=record-invalid "
+        "roleArn=arn:aws:iam::123456789012:role/tenant-custom-role"
+    ) in output
+    assert "already_valid=0" in output
+    assert "repaired=1" in output
+    assert "invalid_record=1" in output
+    assert "invalid_ssm=0" in output
 
 
-def test_backfill_fails_on_account_mismatch(mock_aws_services):
-    _create_tenants_table()
-    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
-    table = ddb.Table("platform-tenants")
-
-    table.put_item(
-        Item={
+def test_backfill_fails_closed_when_record_invalid_and_ssm_invalid(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    table = FakeTable(
+        {
             "PK": "TENANT#t-002",
             "SK": "METADATA",
             "tenantId": "t-002",
@@ -96,14 +160,60 @@ def test_backfill_fails_on_account_mismatch(mock_aws_services):
         }
     )
 
-    rc = script.run(
-        argparse.Namespace(
-            region="eu-west-2",
-            table_name="platform-tenants",
-            param_template="/platform/tenants/{tenant_id}/execution-role-arn",
-            tenant_id=None,
-            apply=False,
-        )
+    rc, fake_ssm = _run(
+        table=table,
+        parameters={"/platform/tenants/t-002/execution-role-arn": "not-an-arn"},
+        apply=False,
     )
 
     assert rc == 1
+    assert fake_ssm.requests == ["/platform/tenants/t-002/execution-role-arn"]
+    output = capsys.readouterr().out
+    assert "[invalid-record] tenant=t-002 source=record error=account-mismatch" in output
+    assert (
+        "[invalid-ssm] tenant=t-002 source=ssm reason=record-invalid error=malformed "
+        "roleArn=not-an-arn"
+    ) in output
+    assert "invalid_record=1" in output
+    assert "invalid_ssm=1" in output
+    assert "repaired=0" in output
+
+
+def test_backfill_valid_record_skips_ssm_lookup(capsys: pytest.CaptureFixture[str]) -> None:
+    table = FakeTable(
+        {
+            "PK": "TENANT#t-003",
+            "SK": "METADATA",
+            "tenantId": "t-003",
+            "accountId": "123456789012",
+            "executionRoleArn": "arn:aws:iam::123456789012:role/already-valid",
+        }
+    )
+
+    rc, fake_ssm = _run(table=table, parameters={}, apply=False)
+
+    assert rc == 0
+    assert fake_ssm.requests == []
+    output = capsys.readouterr().out
+    assert (
+        "[verified] tenant=t-003 source=record roleArn=arn:aws:iam::123456789012:role/already-valid"
+        in output
+    )
+    assert "already_valid=1" in output
+    assert "repaired=0" in output
+    assert "ready_from_ssm=0" in output
+
+
+def test_scan_stops_when_last_evaluated_key_is_none() -> None:
+    table = FakeTable(
+        {
+            "PK": "TENANT#t-004",
+            "SK": "METADATA",
+            "tenantId": "t-004",
+            "accountId": "123456789012",
+        }
+    )
+
+    rows = script._scan_tenant_rows(table, tenant_id=None)
+
+    assert [row.tenant_id for row in rows] == ["t-004"]


### PR DESCRIPTION
Closes #146

## Summary
- allow the tenant execution-role backfill to consult authoritative SSM when the tenant record ARN is missing or invalid
- distinguish already-valid, ready-from-SSM, repaired, unresolved, invalid-record, and invalid-SSM outcomes in operator output and summary counts
- replace the backfill unit tests with fast in-memory fakes covering repair, fail-closed, valid-record skip, and scan pagination behavior

## Validation Evidence
- `uv run pytest tests/unit/test_backfill_tenant_execution_role_arn.py`
- `uv run pytest tests/unit/test_backfill_tenant_execution_role_arn.py tests/unit/test_openapi_contract_routes.py`
- `make validate-local`
- `make preflight-session`
- `make pre-validate-session`

## Notes
- bridge runtime role-ARN resolution remains unchanged and fail-closed
- local `infra/cdk/node_modules` was installed with `npm ci` so repo validation could run cleanly in this worktree