### PR TITLE
fix: authorize tenant runtime invocation in the failover region

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,8 @@ Client
       Resolves executionRoleArn from tenant metadata
         (fallback: SSM /platform/tenants/{tenantId}/execution-role-arn)
       Validates IAM role ARN/account match, then assumes tenant execution role via STS
+        Role policy authorises AgentCore runtime invocation only in the approved
+        runtime region set (current primary eu-west-1, failover eu-central-1)
       Reads active runtime region from SSM (cached 60s)
       Invokes AgentCore Runtime in the active runtime region (default eu-west-1)
         via bedrock-agentcore SDK

--- a/infra/cdk/bin/app.ts
+++ b/infra/cdk/bin/app.ts
@@ -30,7 +30,8 @@ if (!env) {
 // eu-west-2 is the platform home region (see ARCHITECTURE.md, ADR-009).
 // This is an architectural constant, not runtime configuration.
 const HOME_REGION = 'eu-west-2';
-const RUNTIME_REGION = 'eu-west-1';
+const PRIMARY_RUNTIME_REGION = 'eu-west-1';
+const FAILOVER_RUNTIME_REGION = 'eu-central-1';
 
 const awsEnv: cdk.Environment = {
   account: process.env['CDK_DEFAULT_ACCOUNT'],
@@ -38,7 +39,7 @@ const awsEnv: cdk.Environment = {
 };
 const runtimeEnv: cdk.Environment = {
   account: process.env['CDK_DEFAULT_ACCOUNT'],
-  region: RUNTIME_REGION,
+  region: PRIMARY_RUNTIME_REGION,
 };
 
 // 1. NetworkStack
@@ -73,6 +74,7 @@ new TenantStack(app, stackId, {
   description: tenantId
     ? `Platform resources for tenant ${tenantId} — ${env}`
     : `Platform per-tenant resources stub — ${env}`,
+  authorizedRuntimeRegions: [PRIMARY_RUNTIME_REGION, FAILOVER_RUNTIME_REGION],
 });
 
 // 5. ObservabilityStack
@@ -100,6 +102,6 @@ new ObservabilityStack(app, `platform-observability-${env}`, {
 // 6. AgentCoreStack (cross-region: deploys config for eu-west-1 Runtime)
 new AgentCoreStack(app, `platform-agentcore-${env}`, {
   env: runtimeEnv,
-  description: `Platform AgentCore configuration (${RUNTIME_REGION}) — ${env}`,
+  description: `Platform AgentCore configuration (${PRIMARY_RUNTIME_REGION}) — ${env}`,
   homeRegion: HOME_REGION,
 });

--- a/infra/cdk/lib/tenant-stack.ts
+++ b/infra/cdk/lib/tenant-stack.ts
@@ -21,8 +21,29 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
+export interface TenantStackProps extends cdk.StackProps {
+  readonly authorizedRuntimeRegions?: readonly string[];
+}
+
+const DEFAULT_AUTHORIZED_RUNTIME_REGIONS = ['eu-west-1', 'eu-central-1'] as const;
+
+function resolveAuthorizedRuntimeRegions(
+  configuredRegions?: readonly string[],
+): string[] {
+  const regions = (configuredRegions ?? DEFAULT_AUTHORIZED_RUNTIME_REGIONS)
+    .map((region) => region.trim())
+    .filter((region) => region.length > 0);
+
+  const uniqueRegions = Array.from(new Set(regions));
+  if (uniqueRegions.length === 0) {
+    throw new Error('authorizedRuntimeRegions must include at least one region');
+  }
+
+  return uniqueRegions;
+}
+
 export class TenantStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: TenantStackProps) {
     super(scope, id, props);
 
     const env = this.node.tryGetContext('env');
@@ -33,6 +54,9 @@ export class TenantStack extends cdk.Stack {
     const tenantId = this.node.tryGetContext('tenantId') || 'stub';
     const tier = this.node.tryGetContext('tier') || 'basic';
     const accountId = this.node.tryGetContext('accountId') || cdk.Aws.ACCOUNT_ID;
+    const authorizedRuntimeRegions = resolveAuthorizedRuntimeRegions(
+      props?.authorizedRuntimeRegions,
+    );
 
     const isStub = tenantId === 'stub';
 
@@ -106,13 +130,15 @@ export class TenantStack extends cdk.Stack {
       }),
     );
 
-    // Permission to invoke AgentCore Runtime in eu-west-1
+    // Permission to invoke AgentCore Runtime only in the approved primary/failover regions.
     executionRole.addToPolicy(
       new iam.PolicyStatement({
         sid: 'AgentCoreRuntimeAccess',
         effect: iam.Effect.ALLOW,
         actions: ['bedrock-agentcore:InvokeRuntime'],
-        resources: [`arn:aws:bedrock-agentcore:eu-west-1:${accountId}:runtime/*`],
+        resources: authorizedRuntimeRegions.map(
+          (region) => `arn:aws:bedrock-agentcore:${region}:${accountId}:runtime/*`,
+        ),
       }),
     );
 

--- a/infra/cdk/test/tenant-stack.test.ts
+++ b/infra/cdk/test/tenant-stack.test.ts
@@ -3,13 +3,32 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { TenantStack } from '../lib/tenant-stack';
 
 describe('TenantStack (TASK-025)', () => {
-  const synthTemplate = (context: Record<string, string>) => {
+  const synthTemplate = (
+    context: Record<string, string>,
+    authorizedRuntimeRegions = ['eu-west-1', 'eu-central-1'],
+  ) => {
     const app = new cdk.App({ context });
     const stack = new TenantStack(app, 'platform-tenant-test', {
       env: { region: 'eu-west-2' },
+      authorizedRuntimeRegions,
     });
     return Template.fromStack(stack);
   };
+
+  const runtimeAccessStatement = (template: Template) => {
+    const policies = template.findResources('AWS::IAM::Policy') as Record<
+      string,
+      { Properties?: { PolicyDocument?: { Statement?: Array<Record<string, unknown>> } } }
+    >;
+    const statement = Object.values(policies)
+      .flatMap((policy) => policy.Properties?.PolicyDocument?.Statement ?? [])
+      .find((candidate) => candidate.Sid === 'AgentCoreRuntimeAccess');
+
+    expect(statement).toBeDefined();
+    return statement as { Action: string[]; Resource: string[]; Sid: string };
+  };
+
+  const asArray = (value: string | string[]) => (Array.isArray(value) ? value : [value]);
 
   const defaultContext = {
     env: 'dev',
@@ -44,7 +63,7 @@ describe('TenantStack (TASK-025)', () => {
             Resource: Match.anyValue(),
             Condition: Match.objectLike({
               'ForAllValues:StringLike': {
-                'dynamodb:LeadingKeys': Match.arrayWith(['TENANT#t-test123*', 'JOB#*']),
+                'dynamodb:LeadingKeys': ['TENANT#t-test123*'],
               },
             }),
           }),
@@ -118,6 +137,29 @@ describe('TenantStack (TASK-025)', () => {
       Name: '/platform/tenants/t-test123/api-key-id',
       Type: 'String',
     });
+  });
+
+  test('limits runtime invocation permissions to the approved primary and failover regions', () => {
+    const template = synthTemplate(defaultContext);
+    const statement = runtimeAccessStatement(template);
+
+    expect(asArray(statement.Action)).toEqual(['bedrock-agentcore:InvokeRuntime']);
+    expect(asArray(statement.Resource)).toEqual([
+      'arn:aws:bedrock-agentcore:eu-west-1:123456789012:runtime/*',
+      'arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime/*',
+    ]);
+    expect(asArray(statement.Resource)).not.toContain(
+      'arn:aws:bedrock-agentcore:*:123456789012:runtime/*',
+    );
+  });
+
+  test('supports explicit runtime allowlists without widening beyond the configured regions', () => {
+    const template = synthTemplate(defaultContext, ['eu-west-1']);
+    const statement = runtimeAccessStatement(template);
+
+    expect(asArray(statement.Resource)).toEqual([
+      'arn:aws:bedrock-agentcore:eu-west-1:123456789012:runtime/*',
+    ]);
   });
 
   test('fails if context is missing', () => {


### PR DESCRIPTION
## Summary
- authorize TenantStack runtime invocation for both approved runtime regions instead of hardcoding eu-west-1
- pass the approved runtime region allowlist from the CDK app entrypoint
- add Jest coverage for primary-plus-failover authorization and primary-only scoped configuration
- document the approved runtime region set in architecture request flow notes

Closes #153

## Validation
- `export PATH="/home/julesb/.nvm/versions/node/v20.20.0/bin:$PATH" && npx --no-install jest --runInBand test/tenant-stack.test.ts`
- `export PATH="/home/julesb/.nvm/versions/node/v20.20.0/bin:$PATH" && npx --no-install tsc --noEmit -p infra/cdk/tsconfig.json`
- `export PATH="/home/julesb/.nvm/versions/node/v20.20.0/bin:$PATH" && make validate-local`
- `export PATH="/home/julesb/.nvm/versions/node/v20.20.0/bin:$PATH" && make preflight-session`
- `export PATH="/home/julesb/.nvm/versions/node/v20.20.0/bin:$PATH" && make pre-validate-session`
