### PR TITLE
Fix platform failover API lock and SSM updates

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -599,16 +599,24 @@ paths:
                   type: string
       responses:
         "200":
-          description: Failover initiated
+          description: Failover completed or confirmed idempotent
           content:
             application/json:
               schema:
                 type: object
+                required: [status, region, previousRegion, lockId, changed]
                 properties:
                   status:
                     type: string
+                    enum: [completed]
                   region:
                     type: string
+                  previousRegion:
+                    type: string
+                  lockId:
+                    type: string
+                  changed:
+                    type: boolean
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -31,6 +31,9 @@ logger = Logger(service="tenant-api")
 _TENANTS_TABLE_ENV = "TENANTS_TABLE_NAME"
 _EVENT_BUS_ENV = "EVENT_BUS_NAME"
 _API_KEY_SECRET_PREFIX_ENV = "TENANT_API_KEY_SECRET_PREFIX"  # pragma: allowlist secret
+_OPS_LOCKS_TABLE_ENV = "OPS_LOCKS_TABLE"
+_RUNTIME_REGION_PARAM_ENV = "RUNTIME_REGION_PARAM"
+_FAILOVER_LOCK_NAME_ENV = "FAILOVER_LOCK_NAME"
 _DELETE_RETENTION_DAYS = 30
 _ADMIN_ROLES = {"Platform.Admin"}
 _SELF_SERVICE_ADMIN_ROLES = {"Platform.Admin", "Platform.Operator"}
@@ -39,6 +42,9 @@ _TENANT_ID_MIN_LENGTH = 3
 _TENANT_ID_MAX_LENGTH = 32
 _TENANT_ID_PATTERN = re.compile(r"^[a-z](?:[a-z0-9-]{1,30}[a-z0-9])$")
 _RESERVED_TENANT_IDS = frozenset({"admin", "root", "system", "stub"})
+_DEFAULT_OPS_LOCKS_TABLE = "platform-ops-locks"
+_DEFAULT_RUNTIME_REGION_PARAM = "/platform/config/runtime-region"
+_DEFAULT_FAILOVER_LOCK_NAME = "platform-runtime-failover"
 
 
 @dataclass(frozen=True)
@@ -60,6 +66,7 @@ class TenantApiDependencies:
     secretsmanager: Any
     events: Any
     dynamodb: Any
+    ssm: Any
     usage_client: Any
     memory_provisioner: Any
 
@@ -216,6 +223,18 @@ def _secret_prefix() -> str:
     return os.environ.get(_API_KEY_SECRET_PREFIX_ENV, "platform/tenants")
 
 
+def _ops_locks_table_name() -> str:
+    return os.environ.get(_OPS_LOCKS_TABLE_ENV, _DEFAULT_OPS_LOCKS_TABLE)
+
+
+def _runtime_region_param_name() -> str:
+    return os.environ.get(_RUNTIME_REGION_PARAM_ENV, _DEFAULT_RUNTIME_REGION_PARAM)
+
+
+def _failover_lock_name() -> str:
+    return os.environ.get(_FAILOVER_LOCK_NAME_ENV, _DEFAULT_FAILOVER_LOCK_NAME)
+
+
 def _dependencies() -> TenantApiDependencies:
     region = os.environ["AWS_REGION"]
     session = boto3.session.Session(region_name=region)
@@ -223,6 +242,7 @@ def _dependencies() -> TenantApiDependencies:
         secretsmanager=session.client("secretsmanager"),
         events=session.client("events"),
         dynamodb=session.resource("dynamodb"),
+        ssm=session.client("ssm"),
         usage_client=_NoopUsageClient(),
         memory_provisioner=_NoopMemoryProvisioner(),
     )
@@ -269,6 +289,14 @@ def _db_for_tenant(
         app_id=app_id,
     )
     return TenantScopedDynamoDB(tenant_context)
+
+
+def _control_plane_db(caller: CallerIdentity) -> TenantScopedDynamoDB:
+    return _db_for_tenant(
+        tenant_id=caller.tenant_id or "platform-admin",
+        caller=caller,
+        app_id=caller.app_id or "platform-admin",
+    )
 
 
 def _normalize_tier(value: Any) -> str:
@@ -331,6 +359,14 @@ def _read_tenant_record(
 ) -> dict[str, Any] | None:
     db = _db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
     return db.get_item(_tenants_table_name(), _tenant_key(tenant_id))
+
+
+def _read_failover_lock_record(caller: CallerIdentity) -> dict[str, Any] | None:
+    db = _control_plane_db(caller)
+    return db.get_item(
+        _ops_locks_table_name(),
+        {"PK": f"LOCK#{_failover_lock_name()}", "SK": "METADATA"},
+    )
 
 
 def _build_update_expression(
@@ -881,15 +917,129 @@ def _handle_platform_failover(
     if not target_region or not lock_id:
         raise ValueError("targetRegion and lockId are required")
 
-    # TODO: Verify lock_id against platform-ops-locks table
-    # TODO: Update SSM /platform/config/runtime-region
+    lock_record = _read_failover_lock_record(caller)
+    if lock_record is None:
+        logger.warning(
+            "Platform failover rejected: lock missing",
+            extra={
+                "actor": caller.sub,
+                "lock_id": lock_id,
+                "target_region": target_region,
+                "lock_name": _failover_lock_name(),
+            },
+        )
+        return _error(409, "LOCK_NOT_HELD", "Runtime failover lock is not currently held")
+
+    current_lock_id = _str_or_none(lock_record.get("lockId") or lock_record.get("lock_id"))
+    acquired_by = _str_or_none(lock_record.get("acquiredBy") or lock_record.get("acquired_by"))
+    ttl_raw = lock_record.get("ttl")
+    if ttl_raw is None:
+        raise ValueError("Failover lock record is invalid")
+    try:
+        ttl = int(ttl_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Failover lock record is invalid") from exc
+
+    now_epoch = int(_now_utc().timestamp())
+    if ttl <= now_epoch:
+        logger.warning(
+            "Platform failover rejected: lock expired",
+            extra={
+                "actor": caller.sub,
+                "lock_id": lock_id,
+                "current_lock_id": current_lock_id,
+                "target_region": target_region,
+                "lock_owner": acquired_by,
+                "lock_expires_at": ttl,
+            },
+        )
+        return _error(409, "LOCK_EXPIRED", "Runtime failover lock has expired")
+
+    if current_lock_id != lock_id:
+        logger.warning(
+            "Platform failover rejected: lock mismatch",
+            extra={
+                "actor": caller.sub,
+                "lock_id": lock_id,
+                "current_lock_id": current_lock_id,
+                "target_region": target_region,
+                "lock_owner": acquired_by,
+            },
+        )
+        return _error(
+            409,
+            "LOCK_MISMATCH",
+            "Runtime failover lock is held by another actor or session",
+        )
+
+    current_region = str(
+        deps.ssm.get_parameter(Name=_runtime_region_param_name())["Parameter"]["Value"]
+    ).strip()
+    if current_region == target_region:
+        logger.info(
+            "Platform failover already completed",
+            extra={
+                "actor": caller.sub,
+                "lock_id": lock_id,
+                "lock_owner": acquired_by,
+                "previous_region": current_region,
+                "target_region": target_region,
+                "changed": False,
+            },
+        )
+        return _response(
+            200,
+            {
+                "status": "completed",
+                "region": target_region,
+                "previousRegion": current_region,
+                "lockId": lock_id,
+                "changed": False,
+            },
+        )
+
+    try:
+        deps.ssm.put_parameter(
+            Name=_runtime_region_param_name(),
+            Value=target_region,
+            Type="String",
+            Overwrite=True,
+        )
+    except ClientError:
+        logger.exception(
+            "Platform failover SSM update failed",
+            extra={
+                "actor": caller.sub,
+                "lock_id": lock_id,
+                "lock_owner": acquired_by,
+                "previous_region": current_region,
+                "target_region": target_region,
+            },
+        )
+        raise
 
     logger.info(
-        "Platform failover triggered",
-        extra={"target_region": target_region, "lock_id": lock_id, "actor": caller.sub},
+        "Platform failover completed",
+        extra={
+            "actor": caller.sub,
+            "lock_id": lock_id,
+            "lock_owner": acquired_by,
+            "previous_region": current_region,
+            "target_region": target_region,
+            "changed": True,
+        },
     )
 
-    return _response(200, {"status": "initiated", "region": target_region})
+    return _response(
+        200,
+        {
+            "status": "completed",
+            "region": target_region,
+            "previousRegion": current_region,
+            "lockId": lock_id,
+            "changed": True,
+        },
+    )
 
 
 def _handle_health() -> dict[str, Any]:

--- a/tests/integration/test_platform_failover_route_integration.py
+++ b/tests/integration/test_platform_failover_route_integration.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import boto3
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+bridge_handler = importlib.import_module("src.bridge.handler")
+tenant_api_handler = importlib.import_module("src.tenant_api.handler")
+
+
+def _load_failover_lock_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "failover_lock_script_integration", repo_root / "scripts" / "failover_lock.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+failover_lock = _load_failover_lock_module()
+
+
+class FakeLambdaContext:
+    function_name = "tenant-api"
+    memory_limit_in_mb = 256
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:111111111111:function:tenant-api"
+    aws_request_id = "req-platform-failover-integration"
+
+
+class _FakeEvents:
+    def put_events(self, **kwargs: Any) -> dict[str, Any]:
+        return {"FailedEntryCount": 0, "Entries": [{"EventId": "evt-1"}]}
+
+
+class _FakeSecretsManager:
+    pass
+
+
+class _FakeUsageClient:
+    pass
+
+
+class _FakeMemoryProvisioner:
+    pass
+
+
+def _create_table(ddb: Any, table_name: str) -> None:
+    ddb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _failover_event(lock_id: str) -> dict[str, Any]:
+    return {
+        "httpMethod": "POST",
+        "path": "/v1/platform/failover",
+        "body": json.dumps({"targetRegion": "eu-central-1", "lockId": lock_id}),
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-admin",
+                "appid": "app-admin",
+                "tier": "premium",
+                "sub": "user-123",
+                "roles": ["Platform.Admin"],
+            }
+        },
+    }
+
+
+def test_failover_route_updates_ssm_and_bridge_reads_new_runtime_region(monkeypatch) -> None:
+    with mock_aws():
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+        monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-2")
+        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        monkeypatch.setenv("OPS_LOCKS_TABLE", "platform-ops-locks")
+        monkeypatch.setenv("RUNTIME_REGION_PARAM", "/platform/config/runtime-region")
+
+        ddb_resource = boto3.resource("dynamodb", region_name="eu-west-2")
+        ddb_client = boto3.client("dynamodb", region_name="eu-west-2")
+        ssm = boto3.client("ssm", region_name="eu-west-2")
+        _create_table(ddb_resource, "platform-ops-locks")
+        ssm.put_parameter(Name="/platform/config/runtime-region", Value="eu-west-1", Type="String")
+        ssm.put_parameter(
+            Name="/platform/config/mock-runtime-url",
+            Value="http://localhost:8765",
+            Type="String",
+        )
+
+        lock_record = failover_lock.acquire_lock(
+            ddb_client,
+            table_name="platform-ops-locks",
+            acquired_by="ops@example.com",
+        )
+
+        deps = tenant_api_handler.TenantApiDependencies(
+            secretsmanager=_FakeSecretsManager(),
+            events=_FakeEvents(),
+            dynamodb=ddb_resource,
+            ssm=ssm,
+            usage_client=_FakeUsageClient(),
+            memory_provisioner=_FakeMemoryProvisioner(),
+        )
+        monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
+
+        response = tenant_api_handler.lambda_handler(
+            _failover_event(lock_record.lock_id), FakeLambdaContext()
+        )
+
+        assert response["statusCode"] == 200
+        assert json.loads(response["body"])["status"] == "completed"
+
+        bridge_handler._ssm_client = None
+        bridge_handler._config_cache = {}
+        bridge_handler._config_cache_expiry = 0
+        config = bridge_handler.get_config(force_refresh=True)
+
+        assert config["runtime_region"] == "eu-central-1"

--- a/tests/unit/test_ops_api.py
+++ b/tests/unit/test_ops_api.py
@@ -17,6 +17,7 @@ from tests.unit.test_tenant_api_handler import (
     FakeMemoryProvisioner,
     FakeScopedDb,
     FakeSecretsManager,
+    FakeSsm,
     FakeUsageClient,
     _body,
     _invoke,
@@ -35,6 +36,7 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
         secretsmanager=FakeSecretsManager(),
         events=FakeEvents(),
         dynamodb=FakeDynamoDbResource(),
+        ssm=FakeSsm(),
         usage_client=FakeUsageClient(),
         memory_provisioner=FakeMemoryProvisioner(),
     )

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -178,6 +178,25 @@ class FakeLambdaContext:
     aws_request_id = "req-123"
 
 
+class FakeSsm:
+    def __init__(self) -> None:
+        self.parameters = {"/platform/config/runtime-region": "eu-west-1"}
+        self.get_calls: list[dict[str, Any]] = []
+        self.put_calls: list[dict[str, Any]] = []
+        self.put_error: Exception | None = None
+
+    def get_parameter(self, *, Name: str) -> dict[str, Any]:  # noqa: N803 - boto3 compatibility
+        self.get_calls.append({"Name": Name})
+        return {"Parameter": {"Name": Name, "Value": self.parameters[Name]}}
+
+    def put_parameter(self, **kwargs: Any) -> dict[str, Any]:
+        self.put_calls.append(dict(kwargs))
+        if self.put_error is not None:
+            raise self.put_error
+        self.parameters[str(kwargs["Name"])] = str(kwargs["Value"])
+        return {"Version": 1}
+
+
 @pytest.fixture
 def fixed_now() -> datetime:
     return datetime(2026, 2, 25, 12, 0, 0, tzinfo=UTC)
@@ -190,6 +209,7 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
         secretsmanager=FakeSecretsManager(),
         events=FakeEvents(),
         dynamodb=FakeDynamoDbResource(),
+        ssm=FakeSsm(),
         usage_client=FakeUsageClient(),
         memory_provisioner=FakeMemoryProvisioner(),
     )
@@ -197,6 +217,8 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     monkeypatch.setenv("TENANTS_TABLE_NAME", "platform-tenants")
     monkeypatch.setenv("EVENT_BUS_NAME", "platform-bus")
     monkeypatch.setenv("TENANT_API_KEY_SECRET_PREFIX", "platform/tenants")
+    monkeypatch.setenv("OPS_LOCKS_TABLE", "platform-ops-locks")
+    monkeypatch.setenv("RUNTIME_REGION_PARAM", "/platform/config/runtime-region")
     monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
     monkeypatch.setattr(tenant_api_handler, "_db_for_tenant", lambda **_kwargs: db)
     monkeypatch.setattr(tenant_api_handler, "_now_utc", lambda: fixed_now)
@@ -252,6 +274,23 @@ def _last_event_detail(fake_state: dict[str, Any]) -> tuple[str, dict[str, Any]]
     assert calls, "expected EventBridge put_events call"
     entry = calls[-1]["Entries"][0]
     return entry["DetailType"], json.loads(entry["Detail"])
+
+
+def _seed_failover_lock(
+    fake_state: dict[str, Any],
+    *,
+    lock_id: str = "lock-123",
+    ttl: int | None = None,
+    acquired_by: str = "ops@example.com",
+) -> None:
+    expires_at = ttl if ttl is not None else int(datetime.now(UTC).timestamp()) + 300
+    fake_state["db"].items[("LOCK#platform-runtime-failover", "METADATA")] = {
+        "PK": "LOCK#platform-runtime-failover",
+        "SK": "METADATA",
+        "lockId": lock_id,
+        "acquiredBy": acquired_by,
+        "ttl": expires_at,
+    }
 
 
 def test_create_tenant_writes_record_provisions_memory_secret_and_emits_event(
@@ -666,13 +705,134 @@ def test_audit_export_returns_presigned_url_stub(fake_state: dict[str, Any]) -> 
     assert body["tenantId"] == "t-005"
 
 
-def test_platform_failover_requires_lock_and_admin(fake_state: dict[str, Any]) -> None:
+def test_platform_failover_updates_runtime_region_when_lock_is_valid(
+    fake_state: dict[str, Any], fixed_now: datetime
+) -> None:
+    _seed_failover_lock(fake_state, ttl=int(fixed_now.timestamp()) + 300)
     event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
     event["path"] = "/v1/platform/failover"
     response = _invoke(event)
 
     assert response["statusCode"] == 200
-    assert _body(response)["status"] == "initiated"
+    assert _body(response) == {
+        "status": "completed",
+        "region": "eu-central-1",
+        "previousRegion": "eu-west-1",
+        "lockId": "lock-123",
+        "changed": True,
+    }
+    assert fake_state["deps"].ssm.parameters["/platform/config/runtime-region"] == "eu-central-1"
+    assert fake_state["deps"].ssm.put_calls == [
+        {
+            "Name": "/platform/config/runtime-region",
+            "Value": "eu-central-1",
+            "Type": "String",
+            "Overwrite": True,
+        }
+    ]
+
+
+def test_platform_failover_is_idempotent_when_target_region_is_already_active(
+    fake_state: dict[str, Any], fixed_now: datetime
+) -> None:
+    _seed_failover_lock(fake_state, ttl=int(fixed_now.timestamp()) + 300)
+    fake_state["deps"].ssm.parameters["/platform/config/runtime-region"] = "eu-central-1"
+    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event["path"] = "/v1/platform/failover"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 200
+    assert _body(response) == {
+        "status": "completed",
+        "region": "eu-central-1",
+        "previousRegion": "eu-central-1",
+        "lockId": "lock-123",
+        "changed": False,
+    }
+    assert fake_state["deps"].ssm.put_calls == []
+
+
+def test_platform_failover_rejects_missing_lock(fake_state: dict[str, Any]) -> None:
+    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event["path"] = "/v1/platform/failover"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 409
+    assert _body(response)["error"]["code"] == "LOCK_NOT_HELD"
+    assert fake_state["deps"].ssm.put_calls == []
+
+
+def test_platform_failover_rejects_expired_lock(
+    fake_state: dict[str, Any], fixed_now: datetime
+) -> None:
+    _seed_failover_lock(fake_state, ttl=int(fixed_now.timestamp()) - 1)
+    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event["path"] = "/v1/platform/failover"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 409
+    assert _body(response)["error"]["code"] == "LOCK_EXPIRED"
+    assert fake_state["deps"].ssm.put_calls == []
+
+
+def test_platform_failover_rejects_lock_owned_by_another_actor(
+    fake_state: dict[str, Any], fixed_now: datetime
+) -> None:
+    _seed_failover_lock(fake_state, lock_id="other-lock", ttl=int(fixed_now.timestamp()) + 300)
+    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event["path"] = "/v1/platform/failover"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 409
+    assert _body(response)["error"]["code"] == "LOCK_MISMATCH"
+    assert fake_state["deps"].ssm.put_calls == []
+
+
+def test_platform_failover_ssm_update_failure_returns_error_and_logs_context(
+    fake_state: dict[str, Any], fixed_now: datetime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_failover_lock(fake_state, ttl=int(fixed_now.timestamp()) + 300)
+    fake_state["deps"].ssm.put_error = tenant_api_handler.ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+        "PutParameter",
+    )
+    logged: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture_exception(message: str, *args: Any, **kwargs: Any) -> None:
+        extra = kwargs.get("extra")
+        if message == "Platform failover SSM update failed" and isinstance(extra, dict):
+            logged.append((message, dict(extra)))
+
+    monkeypatch.setattr(tenant_api_handler.logger, "exception", _capture_exception)
+    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event["path"] = "/v1/platform/failover"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 502
+    assert _body(response)["error"]["code"] == "AWS_CLIENT_ERROR"
+    assert fake_state["deps"].ssm.parameters["/platform/config/runtime-region"] == "eu-west-1"
+    assert logged == [
+        (
+            "Platform failover SSM update failed",
+            {
+                "actor": "user-123",
+                "lock_id": "lock-123",
+                "lock_owner": "ops@example.com",
+                "previous_region": "eu-west-1",
+                "target_region": "eu-central-1",
+            },
+        )
+    ]
+
+
+def test_platform_failover_requires_platform_admin_role(fake_state: dict[str, Any]) -> None:
+    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event["path"] = "/v1/platform/failover"
 
     # Non-admin forbidden
     event_non_admin = _event(method="POST", roles=[], body={"targetRegion": "x", "lockId": "y"})


### PR DESCRIPTION
Closes #152.

## Summary
- verify the failover `lockId` against `platform-ops-locks` before any runtime-region change
- update `/platform/config/runtime-region` in SSM only after a valid, non-expired lock is confirmed
- return completed/idempotent success semantics and explicit lock rejection errors instead of the old optimistic stub
- add unit and integration coverage for valid, missing, expired, mismatched, and SSM-failure paths
- update the OpenAPI success contract to match the implemented failover response

## Validation Evidence
- `uv run pytest tests/unit/test_tenant_api_handler.py tests/unit/test_ops_api.py tests/unit/test_openapi_contract_routes.py -q` -> `65 passed in 11.39s`
- `uv run pytest tests/integration/test_platform_failover_route_integration.py -q` -> `1 passed in 132.41s`
- `make validate-local` -> passed
- `make preflight-session` -> PASS
- `make pre-validate-session` -> passed
