### PR TITLE
BUG: Implement real AgentCore Runtime invocation in bridge

### DIFF
--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -23,7 +23,13 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Key
-from botocore.exceptions import ClientError
+from botocore.config import Config
+from botocore.exceptions import (
+    ClientError,
+    ConnectTimeoutError,
+    EndpointConnectionError,
+    ReadTimeoutError,
+)
 from data_access import TenantScopedDynamoDB, TenantScopedS3
 from data_access.models import (
     AgentRecord,
@@ -57,8 +63,19 @@ TENANT_EXECUTION_ROLE_PARAM_TEMPLATE = os.environ.get(
     "TENANT_EXECUTION_ROLE_PARAM_TEMPLATE", "/platform/tenants/{tenant_id}/execution-role-arn"
 )
 JOB_RESULT_URL_EXPIRY_SECONDS = int(os.environ.get("JOB_RESULT_URL_EXPIRY_SECONDS", "3600"))
+AGENTCORE_RUNTIME_ENDPOINT_URL = os.environ.get("BEDROCK_AGENTCORE_DP_ENDPOINT")
+AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS = int(
+    os.environ.get("AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS", "5")
+)
+AGENTCORE_RUNTIME_READ_TIMEOUT_SECONDS = int(
+    os.environ.get("AGENTCORE_RUNTIME_READ_TIMEOUT_SECONDS", "900")
+)
 IAM_ROLE_ARN_PATTERN = re.compile(
     r"^arn:(?:aws|aws-us-gov|aws-cn):iam::(?P<account_id>\d{12}):role/(?P<role_name>[\w+=,.@\-_/]+)$"
+)
+RUNTIME_ARN_PATTERN = re.compile(
+    r"^arn:(?P<partition>aws|aws-us-gov|aws-cn):bedrock-agentcore:(?P<region>[a-z0-9-]+):"
+    r"(?P<account_id>\d{12}):runtime/(?P<runtime_id>[\w+=,.@\-_/]+)$"
 )
 
 # TTL constants from models
@@ -102,6 +119,32 @@ def get_dynamodb():
         region = os.environ.get("AWS_REGION", "eu-west-2")
         _dynamodb_resource = boto3.resource("dynamodb", region_name=region)
     return _dynamodb_resource
+
+
+def get_runtime_client(region: str, credentials: dict[str, Any] | None = None) -> Any:
+    session_kwargs: dict[str, Any] = {"region_name": region}
+    if credentials:
+        session_kwargs.update(
+            {
+                "aws_access_key_id": credentials["AccessKeyId"],
+                "aws_secret_access_key": credentials["SecretAccessKey"],
+                "aws_session_token": credentials["SessionToken"],
+            }
+        )
+
+    session = boto3.Session(**session_kwargs)
+    client_kwargs: dict[str, Any] = {
+        "service_name": "bedrock-agentcore",
+        "region_name": region,
+        "config": Config(
+            connect_timeout=AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=AGENTCORE_RUNTIME_READ_TIMEOUT_SECONDS,
+            retries={"max_attempts": 1, "mode": "standard"},
+        ),
+    }
+    if AGENTCORE_RUNTIME_ENDPOINT_URL:
+        client_kwargs["endpoint_url"] = AGENTCORE_RUNTIME_ENDPOINT_URL
+    return session.client(**client_kwargs)
 
 
 def get_config(force_refresh: bool = False) -> dict[str, Any]:
@@ -297,11 +340,20 @@ def get_agent_record(agent_name: str, version: str | None = None) -> AgentRecord
         return None
 
 
-def error_response(status_code: int, code: str, message: str, request_id: str) -> dict[str, Any]:
+def error_response(
+    status_code: int,
+    code: str,
+    message: str,
+    request_id: str,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
     """Return a standard error response as per openapi.yaml."""
+    response_headers = {"Content-Type": "application/json"}
+    if headers:
+        response_headers.update(headers)
     return {
         "statusCode": status_code,
-        "headers": {"Content-Type": "application/json"},
+        "headers": response_headers,
         "body": json.dumps({"error": {"code": code, "message": message, "requestId": request_id}}),
     }
 
@@ -390,6 +442,249 @@ def assume_tenant_role(tenant_id: str, role_arn: str) -> dict[str, Any] | None:
     except Exception:
         logger.exception("Failed to assume tenant role", extra={"role_arn": role_arn})
         raise
+
+
+def _validate_runtime_arn(runtime_arn: str) -> re.Match[str]:
+    match = RUNTIME_ARN_PATTERN.fullmatch(runtime_arn)
+    if not match:
+        raise ValueError("Agent runtime ARN is malformed")
+    return match
+
+
+def _runtime_arn_for_region(runtime_arn: str, active_region: str) -> tuple[str, str]:
+    match = _validate_runtime_arn(runtime_arn)
+    runtime_id = match.group("runtime_id")
+    account_id = match.group("account_id")
+    partition = match.group("partition")
+    active_runtime_arn = (
+        f"arn:{partition}:bedrock-agentcore:{active_region}:{account_id}:runtime/{runtime_id}"
+    )
+    return active_runtime_arn, account_id
+
+
+def _runtime_accept_header(mode: InvocationMode) -> str:
+    if mode == InvocationMode.STREAMING:
+        return "text/event-stream"
+    return "application/json"
+
+
+def _build_runtime_payload(
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    prompt: str,
+    session_id: str | None,
+) -> bytes:
+    payload: dict[str, Any] = {
+        "prompt": prompt,
+        "input": prompt,
+        "mode": str(agent.invocation_mode),
+        "appid": tenant_context.app_id,
+        "tenantId": tenant_context.tenant_id,
+        "agentName": agent.agent_name,
+        "agentVersion": agent.version,
+    }
+    if session_id:
+        payload["sessionId"] = session_id
+    return json.dumps(payload).encode("utf-8")
+
+
+def _close_runtime_body(body: Any) -> None:
+    try:
+        close = getattr(body, "close", None)
+        if callable(close):
+            close()
+    except Exception:
+        logger.debug("Failed to close runtime response body")
+
+
+def _iter_runtime_lines(body: Any) -> Any:
+    if hasattr(body, "iter_lines"):
+        return body.iter_lines()
+    data = b""
+    if hasattr(body, "read"):
+        data = body.read()
+    elif isinstance(body, (bytes, bytearray)):
+        data = bytes(body)
+    if isinstance(data, bytes):
+        return data.splitlines()
+    return []
+
+
+def _read_runtime_body_text(body: Any) -> str:
+    try:
+        if hasattr(body, "read"):
+            payload = body.read()
+        elif isinstance(body, (bytes, bytearray)):
+            payload = bytes(body)
+        elif body is None:
+            payload = b""
+        else:
+            payload = str(body).encode("utf-8")
+        return payload.decode("utf-8") if isinstance(payload, bytes) else str(payload)
+    finally:
+        _close_runtime_body(body)
+
+
+def _collect_sse_text(body: Any, session_id: str | None) -> tuple[str, str | None]:
+    full_text = ""
+    effective_session_id = session_id
+    try:
+        for line in _iter_runtime_lines(body):
+            if not line:
+                continue
+            decoded_line = line.decode("utf-8") if isinstance(line, bytes) else str(line)
+            if not decoded_line.startswith("data: "):
+                continue
+            data = decoded_line[6:]
+            if data == "[DONE]":
+                break
+            try:
+                chunk = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if chunk.get("type") == "text":
+                full_text += str(chunk.get("content", ""))
+            elif chunk.get("type") == "session":
+                effective_session_id = (
+                    _coerce_optional_string(chunk.get("sessionId")) or effective_session_id
+                )
+    finally:
+        _close_runtime_body(body)
+    return full_text, effective_session_id
+
+
+def _extract_runtime_output(payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("output", "echo", "result", "message"):
+            value = payload.get(key)
+            if value is None:
+                continue
+            if isinstance(value, str):
+                return value
+            return json.dumps(value, ensure_ascii=False)
+    if isinstance(payload, str):
+        return payload
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _is_runtime_unavailable_error(exc: Exception) -> bool:
+    if isinstance(exc, requests.exceptions.HTTPError) and exc.response.status_code == 503:
+        return True
+    if isinstance(exc, (EndpointConnectionError, ConnectTimeoutError)):
+        return True
+    if isinstance(exc, ClientError):
+        http_status = int(exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0))
+        error_code = str(exc.response.get("Error", {}).get("Code", ""))
+        return http_status == 503 or error_code == "ServiceUnavailableException"
+    return False
+
+
+def _map_runtime_exception(
+    exc: Exception,
+) -> tuple[int, str, str, InvocationStatus, dict[str, str] | None]:
+    if isinstance(exc, (ReadTimeoutError, requests.exceptions.ReadTimeout)):
+        return (
+            504,
+            "GATEWAY_TIMEOUT",
+            "Agent runtime timed out",
+            InvocationStatus.TIMEOUT,
+            None,
+        )
+
+    if isinstance(exc, ClientError):
+        error = exc.response.get("Error", {})
+        error_code = str(error.get("Code", ""))
+        message = str(error.get("Message", "")) or "Agent runtime request failed"
+        http_status = int(exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0))
+
+        if (
+            error_code in {"ThrottlingException", "ServiceQuotaExceededException"}
+            or http_status == 429
+        ):
+            return (
+                429,
+                "THROTTLED",
+                "Agent runtime throttled the request",
+                InvocationStatus.THROTTLED,
+                {"Retry-After": "1"},
+            )
+        if error_code in {"AccessDeniedException", "UnauthorizedException"} or http_status in {
+            401,
+            403,
+        }:
+            return (
+                502,
+                "BAD_GATEWAY",
+                "Agent runtime authentication failed",
+                InvocationStatus.ERROR,
+                None,
+            )
+        if _is_runtime_unavailable_error(exc):
+            return (
+                503,
+                "SERVICE_UNAVAILABLE",
+                "Agent runtime is unavailable",
+                InvocationStatus.ERROR,
+                None,
+            )
+        return 502, "BAD_GATEWAY", message, InvocationStatus.ERROR, None
+
+    if isinstance(exc, (EndpointConnectionError, ConnectTimeoutError)):
+        return (
+            503,
+            "SERVICE_UNAVAILABLE",
+            "Agent runtime is unavailable",
+            InvocationStatus.ERROR,
+            None,
+        )
+
+    return (
+        502,
+        "BAD_GATEWAY",
+        "Failed to communicate with agent runtime",
+        InvocationStatus.ERROR,
+        None,
+    )
+
+
+def _runtime_failure_response(
+    tenant_context: TenantContext,
+    agent: AgentRecord,
+    invocation_id: str,
+    start_time: float,
+    mode: InvocationMode,
+    runtime_region: str,
+    request_id: str,
+    exc: Exception | None = None,
+    *,
+    status_code: int | None = None,
+    code: str | None = None,
+    message: str | None = None,
+    invocation_status: InvocationStatus | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    if exc is not None:
+        status_code, code, message, invocation_status, headers = _map_runtime_exception(exc)
+    else:
+        headers = None
+        status_code = status_code or 500
+        code = code or "INTERNAL_ERROR"
+        message = message or "Agent runtime invocation failed"
+        invocation_status = invocation_status or InvocationStatus.ERROR
+
+    latency_ms = int((time.time() - start_time) * 1000)
+    log_invocation(
+        tenant_context,
+        agent,
+        invocation_id,
+        invocation_status,
+        latency_ms,
+        mode,
+        session_id=session_id,
+        error_code=code,
+        runtime_region=runtime_region,
+    )
+    return error_response(status_code, code, message, request_id, headers=headers)
 
 
 def get_jitter() -> str:
@@ -889,6 +1184,8 @@ def invoke_agent(
     """Invoke the agent with failover and retry logic."""
     config = get_config()
     mock_url = config.get("mock_runtime_url")
+    invocation_id = str(uuid.uuid4())
+    start_time = time.time()
 
     try:
         if mock_url:
@@ -901,6 +1198,8 @@ def invoke_agent(
                 webhook_id,
                 request_id,
                 response_stream,
+                invocation_id,
+                start_time,
             )
         else:
             return invoke_real_runtime(
@@ -912,34 +1211,31 @@ def invoke_agent(
                 webhook_id,
                 request_id,
                 response_stream,
+                invocation_id,
+                start_time,
             )
     except Exception as e:
-        # Check if it's a 503 or ServiceUnavailableException
-        is_unavailable = False
-        if isinstance(e, requests.exceptions.HTTPError) and e.response.status_code == 503:
-            is_unavailable = True
-        # Add real AWS exception check here in Phase 3
-
-        if is_unavailable:
+        if _is_runtime_unavailable_error(e):
             logger.warning("Runtime unavailable, attempting failover")
             new_region = trigger_failover(config["runtime_region"])
             # Update config for retry
             config = get_config(force_refresh=True)
             mock_url = config.get("mock_runtime_url")
 
-            # Retry once
-            if mock_url:
-                return invoke_mock_runtime(
-                    mock_url,
-                    agent,
-                    tenant_context,
-                    prompt,
-                    session_id,
-                    webhook_id,
-                    request_id,
-                    response_stream,
-                )
-            else:
+            try:
+                if mock_url:
+                    return invoke_mock_runtime(
+                        mock_url,
+                        agent,
+                        tenant_context,
+                        prompt,
+                        session_id,
+                        webhook_id,
+                        request_id,
+                        response_stream,
+                        invocation_id,
+                        start_time,
+                    )
                 return invoke_real_runtime(
                     new_region,
                     agent,
@@ -949,11 +1245,34 @@ def invoke_agent(
                     webhook_id,
                     request_id,
                     response_stream,
+                    invocation_id,
+                    start_time,
+                )
+            except Exception as retry_exc:
+                logger.exception("Invocation failed after failover retry")
+                return _runtime_failure_response(
+                    tenant_context,
+                    agent,
+                    invocation_id,
+                    start_time,
+                    agent.invocation_mode,
+                    new_region,
+                    request_id,
+                    retry_exc,
+                    session_id=session_id,
                 )
 
         logger.exception("Invocation failed")
-        return error_response(
-            502, "BAD_GATEWAY", "Failed to communicate with agent runtime", request_id
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            config["runtime_region"],
+            request_id,
+            e,
+            session_id=session_id,
         )
 
 
@@ -966,16 +1285,42 @@ def invoke_real_runtime(
     webhook_id: str | None,
     request_id: str,
     response_stream: Any,
+    invocation_id: str,
+    start_time: float,
 ) -> Any:
-    """Invoke the real AgentCore Runtime (Phase 3)."""
+    """Invoke the real AgentCore Runtime."""
     # 1. Get tenant record to find account_id
     tenant = get_tenant_record(tenant_context)
     if not tenant:
-        return error_response(500, "INTERNAL_ERROR", "Tenant record not found", request_id)
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Tenant record not found",
+            session_id=session_id,
+        )
 
     account_id = tenant.get("account_id") or tenant.get("accountId")
     if not account_id:
-        return error_response(500, "INTERNAL_ERROR", "Tenant account_id not configured", request_id)
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Tenant account_id not configured",
+            session_id=session_id,
+        )
 
     account_id_str = str(account_id)
     try:
@@ -989,21 +1334,52 @@ def invoke_real_runtime(
             "Tenant execution role ARN validation failed",
             extra={"tenant_id": tenant_context.tenant_id, "account_id": account_id_str},
         )
-        return error_response(500, "INTERNAL_ERROR", str(exc), request_id)
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message=str(exc),
+            session_id=session_id,
+        )
     except Exception:
-        return error_response(
-            500, "INTERNAL_ERROR", "Failed to resolve tenant execution role ARN", request_id
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Failed to resolve tenant execution role ARN",
+            session_id=session_id,
         )
 
     if not execution_role_arn:
-        return error_response(
-            500, "INTERNAL_ERROR", "Tenant execution role ARN not configured", request_id
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Tenant execution role ARN not configured",
+            session_id=session_id,
         )
 
     # 2. Assume tenant role
     try:
-        # returns credentials; will be used in Phase 3 to initialize SDK client
-        assume_tenant_role(tenant_context.tenant_id, execution_role_arn)
+        runtime_credentials = assume_tenant_role(tenant_context.tenant_id, execution_role_arn)
         logger.info(
             "Assumed tenant role",
             extra={
@@ -1013,13 +1389,224 @@ def invoke_real_runtime(
             },
         )
     except Exception:
-        return error_response(500, "INTERNAL_ERROR", "Failed to assume tenant role", request_id)
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Failed to assume tenant role",
+            session_id=session_id,
+        )
 
-    # 3. Invoke with SDK (Phase 3)
-    # TODO: Implement with bedrock-agentcore SDK
-    return error_response(
-        501, "NOT_IMPLEMENTED", "Real Runtime invocation not yet implemented", request_id
+    runtime_arn_raw = _coerce_optional_string(agent.runtime_arn)
+    if runtime_arn_raw is None:
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Agent runtime ARN not configured",
+            session_id=session_id,
+        )
+
+    try:
+        active_runtime_arn, runtime_account_id = _runtime_arn_for_region(runtime_arn_raw, region)
+    except ValueError as exc:
+        return _runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message=str(exc),
+            session_id=session_id,
+        )
+
+    payload = _build_runtime_payload(agent, tenant_context, prompt, session_id)
+    runtime_client = get_runtime_client(region, credentials=runtime_credentials)
+    invoke_kwargs: dict[str, Any] = {
+        "agentRuntimeArn": active_runtime_arn,
+        "contentType": "application/json",
+        "accept": _runtime_accept_header(agent.invocation_mode),
+        "accountId": runtime_account_id,
+        "traceId": request_id,
+        "payload": payload,
+    }
+    if tenant_context.sub:
+        invoke_kwargs["runtimeUserId"] = tenant_context.sub
+    if session_id:
+        invoke_kwargs["runtimeSessionId"] = session_id
+
+    runtime_response = runtime_client.invoke_agent_runtime(**invoke_kwargs)
+    runtime_body = runtime_response.get("response")
+    runtime_content_type = str(runtime_response.get("contentType", "application/json")).lower()
+    runtime_session_id = (
+        _coerce_optional_string(runtime_response.get("runtimeSessionId")) or session_id
     )
+
+    if agent.invocation_mode == InvocationMode.STREAMING:
+        if not response_stream:
+            _close_runtime_body(runtime_body)
+            return _runtime_failure_response(
+                tenant_context,
+                agent,
+                invocation_id,
+                start_time,
+                agent.invocation_mode,
+                region,
+                request_id,
+                status_code=500,
+                code="INTERNAL_ERROR",
+                message="Response streaming not enabled for this Lambda",
+                session_id=runtime_session_id,
+            )
+
+        try:
+            for line in _iter_runtime_lines(runtime_body):
+                if line:
+                    response_stream.write(line + b"\n\n")
+        finally:
+            _close_runtime_body(runtime_body)
+
+        latency_ms = int((time.time() - start_time) * 1000)
+        log_invocation(
+            tenant_context,
+            agent,
+            invocation_id,
+            InvocationStatus.SUCCESS,
+            latency_ms,
+            InvocationMode.STREAMING,
+            session_id=runtime_session_id,
+            runtime_region=region,
+        )
+        return None
+
+    if runtime_content_type.startswith("text/event-stream"):
+        output_text, runtime_session_id = _collect_sse_text(runtime_body, runtime_session_id)
+        runtime_payload: Any = {"output": output_text}
+    else:
+        body_text = _read_runtime_body_text(runtime_body)
+        runtime_payload = json.loads(body_text or "{}")
+
+    if agent.invocation_mode == InvocationMode.ASYNC:
+        job_id = str(uuid.uuid4())
+        now_iso = datetime.now(UTC).isoformat()
+        now_ts = int(time.time())
+        webhook_url: str | None = None
+
+        if webhook_id:
+            registration = get_webhook_registration(tenant_context, webhook_id)
+            if registration is None:
+                return _runtime_failure_response(
+                    tenant_context,
+                    agent,
+                    invocation_id,
+                    start_time,
+                    agent.invocation_mode,
+                    region,
+                    request_id,
+                    status_code=404,
+                    code="NOT_FOUND",
+                    message=f"Webhook '{webhook_id}' not found",
+                    session_id=runtime_session_id,
+                )
+            webhook_url = _coerce_optional_string(registration.get("callback_url"))
+            if webhook_url is None:
+                return _runtime_failure_response(
+                    tenant_context,
+                    agent,
+                    invocation_id,
+                    start_time,
+                    agent.invocation_mode,
+                    region,
+                    request_id,
+                    status_code=500,
+                    code="INTERNAL_ERROR",
+                    message="Webhook registration missing callback URL",
+                    session_id=runtime_session_id,
+                )
+
+        job_record = JobRecord(
+            job_id=job_id,
+            tenant_id=tenant_context.tenant_id,
+            agent_name=agent.agent_name,
+            status=JobStatus.PENDING,
+            created_at=now_iso,
+            ttl=now_ts + JOB_TTL_SECONDS,
+            webhook_url=webhook_url,
+        )
+        log_job(tenant_context, job_record)
+
+        latency_ms = int((time.time() - start_time) * 1000)
+        log_invocation(
+            tenant_context,
+            agent,
+            invocation_id,
+            InvocationStatus.SUCCESS,
+            latency_ms,
+            InvocationMode.ASYNC,
+            job_id=job_id,
+            session_id=runtime_session_id or session_id or "async-session",
+            runtime_region=region,
+        )
+
+        return {
+            "statusCode": 202,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(
+                {
+                    "jobId": job_id,
+                    "status": "accepted",
+                    "mode": "async",
+                    "pollUrl": f"/v1/jobs/{job_id}",
+                    "webhookDelivery": "registered" if webhook_url else "not_registered",
+                }
+            ),
+        }
+
+    latency_ms = int((time.time() - start_time) * 1000)
+    output_text = _extract_runtime_output(runtime_payload)
+    log_invocation(
+        tenant_context,
+        agent,
+        invocation_id,
+        InvocationStatus.SUCCESS,
+        latency_ms,
+        InvocationMode.SYNC,
+        session_id=runtime_session_id or "unknown-session",
+        runtime_region=region,
+    )
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(
+            {
+                "invocationId": invocation_id,
+                "agentName": agent.agent_name,
+                "agentVersion": agent.version,
+                "mode": InvocationMode.SYNC,
+                "status": InvocationStatus.SUCCESS,
+                "output": output_text,
+                "sessionId": runtime_session_id,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "usage": {"inputTokens": 0, "outputTokens": 0, "latencyMs": latency_ms},
+            }
+        ),
+    }
 
 
 def invoke_mock_runtime(
@@ -1031,11 +1618,10 @@ def invoke_mock_runtime(
     webhook_id: str | None,
     request_id: str,
     response_stream: Any,
+    invocation_id: str,
+    start_time: float,
 ) -> Any:
     """Invoke the mock runtime via HTTP."""
-    invocation_id = str(uuid.uuid4())
-    start_time = time.time()
-
     headers = {
         "x-tenant-id": tenant_context.tenant_id,
         "x-app-id": tenant_context.app_id,
@@ -1285,6 +1871,8 @@ def log_invocation(
     mode: InvocationMode,
     job_id: str | None = None,
     session_id: str | None = None,
+    error_code: str | None = None,
+    runtime_region: str | None = None,
 ) -> None:
     """Write invocation audit record to DynamoDB using data-access-lib."""
     try:
@@ -1306,11 +1894,12 @@ def log_invocation(
             output_tokens=0,
             latency_ms=latency_ms,
             status=status,
-            runtime_region=get_config()["runtime_region"],
+            runtime_region=runtime_region or get_config()["runtime_region"],
             invocation_mode=mode,
             timestamp=now_iso,
             ttl=now_ts + INVOCATION_TTL_SECONDS,
             jitter=jitter,
+            error_code=error_code,
             job_id=job_id,
         )
 

--- a/tests/integration/test_bridge_role_resolution_contract.py
+++ b/tests/integration/test_bridge_role_resolution_contract.py
@@ -71,6 +71,7 @@ def _seed_agent(ddb: Any) -> None:
             "deployed_at": "2026-01-01T00:00:00Z",
             "invocation_mode": "sync",
             "streaming_enabled": False,
+            "runtime_arn": "arn:aws:bedrock-agentcore:eu-west-1:210987654321:runtime/echo-agent",
         }
     )
 
@@ -114,14 +115,23 @@ def test_handler_assume_role_uses_tenant_record_arn(mock_aws_services):
             return_value={"runtime_region": "eu-west-1", "mock_runtime_url": None},
         ),
         patch("src.bridge.handler.get_sts") as mock_get_sts,
+        patch("src.bridge.handler.get_runtime_client") as mock_get_runtime_client,
     ):
         mock_sts = MagicMock()
         mock_get_sts.return_value = mock_sts
         mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
+        runtime_client = MagicMock()
+        runtime_client.invoke_agent_runtime.return_value = {
+            "contentType": "application/json",
+            "runtimeSessionId": "runtime-session-id-123456789012345",
+            "response": MagicMock(read=MagicMock(return_value=b'{"echo":"hello"}')),
+            "statusCode": 200,
+        }
+        mock_get_runtime_client.return_value = runtime_client
 
         response = handler(_invoke_event(), FakeLambdaContext())
 
-    assert response["statusCode"] == 501
+    assert response["statusCode"] == 200
     _, kwargs = mock_sts.assume_role.call_args
     assert kwargs["RoleArn"] == "arn:aws:iam::123456789012:role/custom-record-role"
 
@@ -153,13 +163,22 @@ def test_handler_assume_role_uses_ssm_arn_when_tenant_record_missing_field(mock_
             return_value={"runtime_region": "eu-west-1", "mock_runtime_url": None},
         ),
         patch("src.bridge.handler.get_sts") as mock_get_sts,
+        patch("src.bridge.handler.get_runtime_client") as mock_get_runtime_client,
     ):
         mock_sts = MagicMock()
         mock_get_sts.return_value = mock_sts
         mock_sts.assume_role.return_value = {"Credentials": {"AccessKeyId": "foo"}}
+        runtime_client = MagicMock()
+        runtime_client.invoke_agent_runtime.return_value = {
+            "contentType": "application/json",
+            "runtimeSessionId": "runtime-session-id-123456789012345",
+            "response": MagicMock(read=MagicMock(return_value=b'{"echo":"hello"}')),
+            "statusCode": 200,
+        }
+        mock_get_runtime_client.return_value = runtime_client
 
         response = handler(_invoke_event(), FakeLambdaContext())
 
-    assert response["statusCode"] == 501
+    assert response["statusCode"] == 200
     _, kwargs = mock_sts.assume_role.call_args
     assert kwargs["RoleArn"] == "arn:aws:iam::123456789012:role/custom-ssm-role"

--- a/tests/unit/test_bridge_role_arn.py
+++ b/tests/unit/test_bridge_role_arn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import sys
@@ -7,13 +8,16 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 # Add project root and data-access-lib to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
 
-from src.bridge.handler import assume_tenant_role, invoke_real_runtime
+from data_access.models import InvocationMode
+
+from src.bridge.handler import assume_tenant_role, invoke_agent, invoke_real_runtime
 
 
 @pytest.fixture
@@ -39,6 +43,37 @@ def _error_message(response: dict[str, str]) -> str:
     return str(body["error"]["message"])
 
 
+def _agent(mode: InvocationMode = InvocationMode.SYNC) -> MagicMock:
+    agent = MagicMock()
+    agent.agent_name = "echo-agent"
+    agent.version = "1.0.0"
+    agent.invocation_mode = mode
+    agent.runtime_arn = "arn:aws:bedrock-agentcore:eu-west-1:210987654321:runtime/echo-agent"
+    return agent
+
+
+def _tenant_context() -> MagicMock:
+    tenant_context = MagicMock()
+    tenant_context.tenant_id = "t-123"
+    tenant_context.app_id = "app-123"
+    tenant_context.sub = "user-123"
+    return tenant_context
+
+
+def _runtime_response(
+    payload: bytes,
+    *,
+    content_type: str = "application/json",
+    runtime_session_id: str = "runtime-session-id-123456789012345",
+) -> dict[str, object]:
+    return {
+        "contentType": content_type,
+        "runtimeSessionId": runtime_session_id,
+        "response": io.BytesIO(payload),
+        "statusCode": 200,
+    }
+
+
 def test_assume_tenant_role_uses_provided_arn(mock_aws_services):
     tenant_id = "t-123"
     provided_arn = "arn:aws:iam::123456789012:role/custom-role"
@@ -52,35 +87,105 @@ def test_assume_tenant_role_uses_provided_arn(mock_aws_services):
         assert kwargs["RoleArn"] == provided_arn
 
 
+@patch("src.bridge.handler.get_runtime_client")
 @patch("src.bridge.handler.get_tenant_record")
 @patch("src.bridge.handler.assume_tenant_role")
-def test_invoke_real_runtime_uses_arn_from_record(mock_assume, mock_get_record, mock_aws_services):
-    tenant_context = MagicMock()
-    tenant_context.tenant_id = "t-123"
+def test_invoke_real_runtime_uses_arn_from_record(
+    mock_assume, mock_get_record, mock_get_runtime_client, mock_aws_services
+):
+    tenant_context = _tenant_context()
+    agent = _agent()
+    runtime_client = MagicMock()
+    runtime_client.invoke_agent_runtime.return_value = _runtime_response(b'{"echo":"Echo: prompt"}')
+    mock_get_runtime_client.return_value = runtime_client
+    mock_assume.return_value = {
+        "AccessKeyId": "assumed-akid",
+        "SecretAccessKey": "assumed-secret",  # pragma: allowlist secret
+        "SessionToken": "assumed-token",
+    }
     mock_get_record.return_value = {
         "account_id": "123456789012",
         "executionRoleArn": "arn:aws:iam::123456789012:role/record-role",
     }
-    agent = MagicMock()
-    # We expect it to return 501 eventually, but we want to check assume_tenant_role call
-    from src.bridge.handler import invoke_real_runtime
 
-    invoke_real_runtime("eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None)
+    response = invoke_real_runtime(
+        "eu-west-1",
+        agent,
+        tenant_context,
+        "prompt",
+        None,
+        None,
+        "req-1",
+        None,
+        "inv-1",
+        0.0,
+    )
+
+    assert response["statusCode"] == 200
     mock_assume.assert_called_once_with("t-123", "arn:aws:iam::123456789012:role/record-role")
+    mock_get_runtime_client.assert_called_once_with(
+        "eu-west-1",
+        credentials={
+            "AccessKeyId": "assumed-akid",
+            "SecretAccessKey": "assumed-secret",  # pragma: allowlist secret
+            "SessionToken": "assumed-token",
+        },
+    )
+    _, kwargs = runtime_client.invoke_agent_runtime.call_args
+    assert kwargs["agentRuntimeArn"] == (
+        "arn:aws:bedrock-agentcore:eu-west-1:210987654321:runtime/echo-agent"
+    )
+    assert kwargs["payload"] == json.dumps(
+        {
+            "prompt": "prompt",
+            "input": "prompt",
+            "mode": "sync",
+            "appid": "app-123",
+            "tenantId": "t-123",
+            "agentName": "echo-agent",
+            "agentVersion": "1.0.0",
+        }
+    ).encode("utf-8")
 
 
+@patch("src.bridge.handler.get_runtime_client")
 @patch("src.bridge.handler.get_tenant_record")
 @patch("src.bridge.handler._get_execution_role_arn_from_ssm")
 @patch("src.bridge.handler.assume_tenant_role")
 def test_invoke_real_runtime_uses_ssm_arn_when_record_missing(
-    mock_assume, mock_get_role_from_ssm, mock_get_record, mock_aws_services
+    mock_assume,
+    mock_get_role_from_ssm,
+    mock_get_record,
+    mock_get_runtime_client,
+    mock_aws_services,
 ):
-    tenant_context = MagicMock()
-    tenant_context.tenant_id = "t-123"
+    tenant_context = _tenant_context()
+    agent = _agent()
+    runtime_client = MagicMock()
+    runtime_client.invoke_agent_runtime.return_value = _runtime_response(b'{"echo":"Echo: prompt"}')
+    mock_get_runtime_client.return_value = runtime_client
+    mock_assume.return_value = {
+        "AccessKeyId": "assumed-akid",
+        "SecretAccessKey": "assumed-secret",  # pragma: allowlist secret
+        "SessionToken": "assumed-token",
+    }
     mock_get_record.return_value = {"account_id": "123456789012"}
     mock_get_role_from_ssm.return_value = "arn:aws:iam::123456789012:role/ssm-role"
-    agent = MagicMock()
-    invoke_real_runtime("eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None)
+
+    response = invoke_real_runtime(
+        "eu-west-1",
+        agent,
+        tenant_context,
+        "prompt",
+        None,
+        None,
+        "req-1",
+        None,
+        "inv-1",
+        0.0,
+    )
+
+    assert response["statusCode"] == 200
     mock_assume.assert_called_once_with("t-123", "arn:aws:iam::123456789012:role/ssm-role")
     mock_get_role_from_ssm.assert_called_once_with("t-123")
 
@@ -91,14 +196,22 @@ def test_invoke_real_runtime_uses_ssm_arn_when_record_missing(
 def test_invoke_real_runtime_errors_when_execution_role_arn_missing(
     mock_assume, mock_get_role_from_ssm, mock_get_record, mock_aws_services
 ):
-    tenant_context = MagicMock()
-    tenant_context.tenant_id = "t-123"
+    tenant_context = _tenant_context()
     mock_get_record.return_value = {"account_id": "123456789012"}
     mock_get_role_from_ssm.return_value = None
-    agent = MagicMock()
+    agent = _agent()
 
     response = invoke_real_runtime(
-        "eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None
+        "eu-west-1",
+        agent,
+        tenant_context,
+        "prompt",
+        None,
+        None,
+        "req-1",
+        None,
+        "inv-1",
+        0.0,
     )
 
     assert response["statusCode"] == 500
@@ -112,14 +225,22 @@ def test_invoke_real_runtime_errors_when_execution_role_arn_missing(
 def test_invoke_real_runtime_errors_when_execution_role_arn_malformed(
     mock_assume, mock_get_role_from_ssm, mock_get_record, mock_aws_services
 ):
-    tenant_context = MagicMock()
-    tenant_context.tenant_id = "t-123"
+    tenant_context = _tenant_context()
     mock_get_record.return_value = {"account_id": "123456789012"}
     mock_get_role_from_ssm.return_value = "not-an-arn"
-    agent = MagicMock()
+    agent = _agent()
 
     response = invoke_real_runtime(
-        "eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None
+        "eu-west-1",
+        agent,
+        tenant_context,
+        "prompt",
+        None,
+        None,
+        "req-1",
+        None,
+        "inv-1",
+        0.0,
     )
 
     assert response["statusCode"] == 500
@@ -132,18 +253,127 @@ def test_invoke_real_runtime_errors_when_execution_role_arn_malformed(
 def test_invoke_real_runtime_errors_when_execution_role_arn_account_mismatch(
     mock_assume, mock_get_record, mock_aws_services
 ):
-    tenant_context = MagicMock()
-    tenant_context.tenant_id = "t-123"
+    tenant_context = _tenant_context()
     mock_get_record.return_value = {
         "account_id": "123456789012",
         "executionRoleArn": "arn:aws:iam::999999999999:role/record-role",
     }
-    agent = MagicMock()
+    agent = _agent()
 
     response = invoke_real_runtime(
-        "eu-west-1", agent, tenant_context, "prompt", None, None, "req-1", None
+        "eu-west-1",
+        agent,
+        tenant_context,
+        "prompt",
+        None,
+        None,
+        "req-1",
+        None,
+        "inv-1",
+        0.0,
     )
 
     assert response["statusCode"] == 500
     assert _error_message(response) == "Tenant execution role ARN account mismatch"
     mock_assume.assert_not_called()
+
+
+@patch("src.bridge.handler.get_runtime_client")
+@patch("src.bridge.handler.get_tenant_record")
+@patch("src.bridge.handler.assume_tenant_role")
+def test_invoke_real_runtime_rewrites_runtime_arn_to_active_region(
+    mock_assume, mock_get_record, mock_get_runtime_client, mock_aws_services
+):
+    tenant_context = _tenant_context()
+    agent = _agent()
+    runtime_client = MagicMock()
+    runtime_client.invoke_agent_runtime.return_value = _runtime_response(b'{"echo":"Echo: prompt"}')
+    mock_get_runtime_client.return_value = runtime_client
+    mock_assume.return_value = {
+        "AccessKeyId": "assumed-akid",
+        "SecretAccessKey": "assumed-secret",  # pragma: allowlist secret
+        "SessionToken": "assumed-token",
+    }
+    mock_get_record.return_value = {
+        "account_id": "123456789012",
+        "executionRoleArn": "arn:aws:iam::123456789012:role/record-role",
+    }
+
+    response = invoke_real_runtime(
+        "eu-central-1",
+        agent,
+        tenant_context,
+        "prompt",
+        None,
+        None,
+        "req-1",
+        None,
+        "inv-1",
+        0.0,
+    )
+
+    assert response["statusCode"] == 200
+    _, kwargs = runtime_client.invoke_agent_runtime.call_args
+    assert kwargs["agentRuntimeArn"] == (
+        "arn:aws:bedrock-agentcore:eu-central-1:210987654321:runtime/echo-agent"
+    )
+
+
+def test_invoke_agent_maps_runtime_throttling_to_platform_error():
+    tenant_context = _tenant_context()
+    agent = _agent()
+    throttled = ClientError(
+        {
+            "Error": {"Code": "ThrottlingException", "Message": "slow down"},
+            "ResponseMetadata": {"HTTPStatusCode": 429},
+        },
+        "InvokeAgentRuntime",
+    )
+
+    with (
+        patch(
+            "src.bridge.handler.get_config",
+            return_value={"runtime_region": "eu-west-1", "mock_runtime_url": None},
+        ),
+        patch("src.bridge.handler.invoke_real_runtime", side_effect=throttled),
+        patch("src.bridge.handler.log_invocation") as mock_log_invocation,
+    ):
+        response = invoke_agent(agent, tenant_context, "prompt", None, None, "req-1", None)
+
+    assert response["statusCode"] == 429
+    body = json.loads(response["body"])
+    assert body["error"]["code"] == "THROTTLED"
+    assert response["headers"]["Retry-After"] == "1"
+    _, kwargs = mock_log_invocation.call_args
+    assert kwargs["error_code"] == "THROTTLED"
+
+
+def test_invoke_agent_retries_real_runtime_after_failover():
+    tenant_context = _tenant_context()
+    agent = _agent()
+    service_unavailable = ClientError(
+        {
+            "Error": {"Code": "ServiceUnavailableException", "Message": "unavailable"},
+            "ResponseMetadata": {"HTTPStatusCode": 503},
+        },
+        "InvokeAgentRuntime",
+    )
+    success_response = {"statusCode": 200, "headers": {}, "body": json.dumps({"status": "success"})}
+
+    with (
+        patch(
+            "src.bridge.handler.get_config",
+            return_value={"runtime_region": "eu-west-1", "mock_runtime_url": None},
+        ),
+        patch("src.bridge.handler.trigger_failover", return_value="eu-central-1") as mock_failover,
+        patch(
+            "src.bridge.handler.invoke_real_runtime",
+            side_effect=[service_unavailable, success_response],
+        ) as mock_invoke_real_runtime,
+    ):
+        response = invoke_agent(agent, tenant_context, "prompt", None, None, "req-1", None)
+
+    assert response["statusCode"] == 200
+    mock_failover.assert_called_once_with("eu-west-1")
+    assert mock_invoke_real_runtime.call_args_list[0].args[0] == "eu-west-1"
+    assert mock_invoke_real_runtime.call_args_list[1].args[0] == "eu-central-1"


### PR DESCRIPTION
## Summary
- replace the bridge placeholder real-runtime path with a Bedrock AgentCore runtime invocation that uses the active runtime region and assumed-role credentials
- keep mock mode, failover behavior, tenant context propagation, and structured error mapping intact across sync, streaming, and async flows
- add unit and integration coverage for runtime region rewriting, credential usage, throttling mapping, failover retry, and the no-longer-501 integration path

## Validation
- `make preflight-session` PASS
- `make pre-validate-session` PASS
- `make validate-local` PASS
- `timeout 300s uv run pytest -p no:cov tests/unit/test_bridge_role_arn.py -q` PASS (`9 passed`)
- `timeout 300s uv run pytest -p no:cov tests/integration/test_bridge_role_resolution_contract.py -q` PASS (`2 passed`)
- `timeout 300s uv run pytest -p no:cov tests/unit/test_bridge_handler.py::test_handler_sync_success tests/unit/test_bridge_handler.py::test_handler_async_accepted tests/unit/test_bridge_handler.py::test_handler_streaming tests/unit/test_bridge_handler.py::test_handler_session_id_propagation tests/unit/test_bridge_handler.py::test_handler_session_id_from_runtime tests/unit/test_bridge_failover.py::test_handler_failover_on_503 tests/unit/test_bridge_failover.py::test_handler_failover_already_in_progress` PASS (`7 passed`)

Closes #151
