### PR TITLE
issue-155: make AgentCore runtime network posture explicit

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,15 @@ but this platform continues to use the ADR-009 London-home / Dublin-runtime topo
 That deployment policy remains in force pending an explicit architecture review and
 controlled migration plan.
 
+Current runtime network posture: `AWS::BedrockAgentCore::Runtime` remains in
+`NetworkMode: PUBLIC` by explicit exception, not by omission. The reason is structural:
+the approved ADR-009 deployment path places Runtime in eu-west-1, while this repository
+currently provisions VPC infrastructure only in eu-west-2. Moving Runtime to `VPC`
+requires a dedicated eu-west-1 VPC design covering subnets, security groups, required
+service endpoints, and egress policy. Until that exists and a successor ADR approves
+the migration, the runtime stack records the exception in CloudFormation metadata and
+tests/guard rules enforce that `PUBLIC` cannot remain an undocumented default.
+
 Policy in AgentCore is GA and baseline Cedar enforcement is now wired into the
 platform. Additional policy tuning remains an ongoing platform task.
 
@@ -90,6 +99,7 @@ Client
       Writes INVOCATION record to DynamoDB on completion
   → AgentCore Runtime eu-west-1
       Firecracker microVM isolation per session
+      NetworkMode PUBLIC by explicit exception until runtime-region VPC exists
       Calls tools via AgentCore Gateway eu-west-2
       Gateway policy engine: Cedar evaluation (LOG_ONLY in dev/staging, ENFORCE in prod)
       Gateway REQUEST interceptor: issues scoped act-on-behalf token

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -58,6 +58,15 @@ Threat: attacker intercepts active AgentCore Runtime session
 Mitigation: HTTPS everywhere, scoped tokens per session, session ID is UUID4 (not guessable),
 Runtime microVM isolation prevents cross-session access at compute level
 
+### 8a. Runtime Public Network Drift
+Threat: AgentCore Runtime remains internet-addressable by silent default even after the
+platform claims a stronger network posture
+Mitigation: the runtime stack now records `PUBLIC` as an explicit exception tied to
+ADR-009 and the absence of eu-west-1 runtime VPC infrastructure. CDK tests and
+cfn-guard fail if `PUBLIC` is present without the documented exception metadata and
+revisit trigger. Migration to `VPC` is deferred until runtime-region subnets, security
+groups, endpoints, and egress controls are designed and approved.
+
 ### 9. Data Exfiltration via Agent
 Threat: agent accumulates and exfiltrates tenant data
 Mitigation: RESPONSE interceptor PII redaction, tool access filtered by tier,
@@ -83,6 +92,7 @@ CloudTrail records all AWS API calls including Secrets Manager reads
 | cfn-guard IaC policy           | 7                            | GitLab CI validate stage  |
 | CloudTrail + VPC Flow Logs     | 10                           | ObservabilityStack        |
 | PII redaction (RESPONSE)       | 9                            | RESPONSE interceptor      |
+| Explicit runtime posture gate  | 8a                           | AgentCoreStack + cfn-guard + CDK tests |
 
 ## Data Classification
 

--- a/infra/cdk/bin/app.ts
+++ b/infra/cdk/bin/app.ts
@@ -104,4 +104,5 @@ new AgentCoreStack(app, `platform-agentcore-${env}`, {
   env: runtimeEnv,
   description: `Platform AgentCore configuration (${PRIMARY_RUNTIME_REGION}) — ${env}`,
   homeRegion: HOME_REGION,
+  runtimeNetworkPosture: 'PUBLIC_WITH_COMPENSATING_CONTROLS',
 });

--- a/infra/cdk/lib/agentcore-stack.ts
+++ b/infra/cdk/lib/agentcore-stack.ts
@@ -15,6 +15,7 @@ import { Construct } from 'constructs';
 
 export interface AgentCoreStackProps extends cdk.StackProps {
   readonly homeRegion: string;
+  readonly runtimeNetworkPosture: 'PUBLIC_WITH_COMPENSATING_CONTROLS';
 }
 
 export class AgentCoreStack extends cdk.Stack {
@@ -28,6 +29,11 @@ export class AgentCoreStack extends cdk.Stack {
 
     if (!cdk.Token.isUnresolved(runtimeRegion) && runtimeRegion !== 'eu-west-1') {
       throw new Error('AgentCoreStack must be deployed in eu-west-1');
+    }
+    if (props.runtimeNetworkPosture !== 'PUBLIC_WITH_COMPENSATING_CONTROLS') {
+      throw new Error(
+        'AgentCoreStack requires an explicit runtime network posture decision for the current deployment path',
+      );
     }
 
     const runtimeExecutionRoleArn = new cdk.CfnParameter(this, 'RuntimeExecutionRoleArn', {
@@ -96,9 +102,27 @@ export class AgentCoreStack extends cdk.Stack {
           component: 'agentcore-runtime',
           environment: envName,
           homeRegion: props.homeRegion,
+          networkMode: 'PUBLIC',
+          networkPosture: props.runtimeNetworkPosture,
         },
       },
     });
+    runtime.cfnOptions.metadata = {
+      RuntimeNetworkPosture: {
+        Decision: props.runtimeNetworkPosture,
+        Justification: 'ADR-009_NO_RUNTIME_REGION_VPC',
+        Rationale:
+          'The approved ADR-009 topology deploys the runtime in eu-west-1, while this repository only provisions VPC infrastructure in eu-west-2. A VPC migration requires dedicated eu-west-1 subnets, security groups, and service endpoints before NetworkMode can move to VPC.',
+        CompensatingControls: [
+          'Custom JWT authorizer enforces Entra discovery URL and allowed audience',
+          'Request headers are allowlisted to authorization, x-tenant-id, and x-app-id',
+          'Tenant execution roles restrict invocation to approved runtime regions only',
+          'Runtime region remains fixed to eu-west-1 until a successor ADR approves a topology change',
+        ],
+        RevisitTrigger:
+          'Revisit when runtime-region VPC infrastructure exists in eu-west-1 and a successor ADR or approved design authorises migration to NetworkMode=VPC.',
+      },
+    };
 
     const runtimeEndpoint = new cdk.CfnResource(this, 'AgentCoreRuntimeEndpoint', {
       type: 'AWS::BedrockAgentCore::RuntimeEndpoint',
@@ -168,6 +192,14 @@ export class AgentCoreStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'AgentCoreRuntimeRegion', {
       value: runtimeRegion,
       description: 'Runtime compute region for AgentCore execution',
+    });
+    new cdk.CfnOutput(this, 'AgentCoreRuntimeNetworkMode', {
+      value: 'PUBLIC',
+      description: 'Explicitly approved runtime network mode for the current deployment path',
+    });
+    new cdk.CfnOutput(this, 'AgentCoreRuntimeNetworkPostureDecision', {
+      value: props.runtimeNetworkPosture,
+      description: 'Explicit network posture decision guarding against silent runtime network drift',
     });
     new cdk.CfnOutput(this, 'AgentCoreRuntimeName', {
       value: runtimeName,

--- a/infra/cdk/test/agentcore-stack.test.ts
+++ b/infra/cdk/test/agentcore-stack.test.ts
@@ -15,6 +15,7 @@ describe('AgentCoreStack (TASK-024)', () => {
     const stack = new AgentCoreStack(app, 'platform-agentcore-dev', {
       env: { region: 'eu-west-1' },
       homeRegion: 'eu-west-2',
+      runtimeNetworkPosture: 'PUBLIC_WITH_COMPENSATING_CONTROLS',
     });
 
     return Template.fromStack(stack);
@@ -41,6 +42,27 @@ describe('AgentCoreStack (TASK-024)', () => {
       },
       RequestHeaderConfiguration: {
         RequestHeaderAllowlist: ['authorization', 'x-tenant-id', 'x-app-id'],
+      },
+    });
+  });
+
+  test('records the public runtime posture as an explicit, reviewable exception', () => {
+    template.hasResource('AWS::BedrockAgentCore::Runtime', {
+      Metadata: {
+        RuntimeNetworkPosture: {
+          Decision: 'PUBLIC_WITH_COMPENSATING_CONTROLS',
+          Justification: 'ADR-009_NO_RUNTIME_REGION_VPC',
+          RevisitTrigger: Match.stringLikeRegexp('NetworkMode=VPC'),
+        },
+      },
+      Properties: {
+        NetworkConfiguration: {
+          NetworkMode: 'PUBLIC',
+        },
+        Tags: Match.objectLike({
+          networkMode: 'PUBLIC',
+          networkPosture: 'PUBLIC_WITH_COMPENSATING_CONTROLS',
+        }),
       },
     });
   });
@@ -86,6 +108,12 @@ describe('AgentCoreStack (TASK-024)', () => {
   test('exports runtime region and memory template parameter name', () => {
     template.hasOutput('AgentCoreRuntimeRegion', {
       Value: 'eu-west-1',
+    });
+    template.hasOutput('AgentCoreRuntimeNetworkMode', {
+      Value: 'PUBLIC',
+    });
+    template.hasOutput('AgentCoreRuntimeNetworkPostureDecision', {
+      Value: 'PUBLIC_WITH_COMPENSATING_CONTROLS',
     });
 
     template.hasOutput('TenantMemoryTemplateParameterName', {

--- a/infra/guard/platform-security.guard
+++ b/infra/guard/platform-security.guard
@@ -9,6 +9,7 @@ let iam_policies = Resources.*[ Type == 'AWS::IAM::Policy' ]
 let s3_buckets = Resources.*[ Type == 'AWS::S3::Bucket' ]
 let dynamodb_tables = Resources.*[ Type == 'AWS::DynamoDB::Table' ]
 let lambda_functions = Resources.*[ Type == 'AWS::Lambda::Function' ]
+let agentcore_runtimes = Resources.*[ Type == 'AWS::BedrockAgentCore::Runtime' ]
 
 # no_wildcard_iam_action
 rule no_wildcard_iam_action {
@@ -175,6 +176,28 @@ rule lambda_in_vpc {
             %lambda_functions.Properties.VpcConfig {
                 SubnetIds exists
                 SecurityGroupIds exists
+            }
+        }
+    }
+}
+
+# agentcore_runtime_network_mode_explicit
+rule agentcore_runtime_network_mode_explicit {
+    when %agentcore_runtimes exists {
+        %agentcore_runtimes.Properties.NetworkConfiguration.NetworkMode exists
+    }
+}
+
+# agentcore_runtime_public_requires_exception_metadata
+rule agentcore_runtime_public_requires_exception_metadata {
+    when %agentcore_runtimes exists {
+        %agentcore_runtimes {
+            when Properties.NetworkConfiguration.NetworkMode == "PUBLIC" {
+                Metadata.RuntimeNetworkPosture {
+                    Decision == "PUBLIC_WITH_COMPENSATING_CONTROLS"
+                    Justification == "ADR-009_NO_RUNTIME_REGION_VPC"
+                    RevisitTrigger exists
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- make the AgentCore runtime network posture an explicit CDK decision instead of an implicit `PUBLIC` default
- record the current `PUBLIC` posture as a documented ADR-009 exception in CloudFormation metadata, outputs, and tags
- enforce the posture with CDK tests and `cfn-guard`, and align architecture/security docs with the implemented state

## Issue
- Closes #155

## Validation Evidence
- `make validate-local`
- `make preflight-session`
- `make pre-validate-session`
- `npx --no-install jest --runInBand --runTestsByPath test/agentcore-stack.test.ts`
- `npx --no-install cdk synth platform-agentcore-dev --context env=dev --output cdk.out.wt155`
- `cfn-guard validate --rules infra/guard/platform-security.guard --data infra/cdk/cdk.out.wt155/*.template.json`

## Notes
- AWS supports `NetworkMode: VPC`, but this repo currently provisions VPC infrastructure only in `eu-west-2` while ADR-009 keeps Runtime in `eu-west-1`. This change prevents `PUBLIC` from remaining an undocumented assumption until runtime-region VPC infrastructure is designed and approved.
