### PR TITLE
TASK-166: rebuild northbound streaming on supported AWS response streaming

### DIFF
--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -650,6 +650,10 @@ export class PlatformStack extends cdk.Stack {
 
     const tenantApiIntegration = new apigateway.LambdaIntegration(this.tenantApiFn, { proxy: true });
     const bridgeIntegration = new apigateway.LambdaIntegration(bridgeAlias, { proxy: true });
+    const bridgeStreamingIntegration = new apigateway.LambdaIntegration(bridgeAlias, {
+      proxy: true,
+      responseTransferMode: apigateway.ResponseTransferMode.STREAM,
+    });
 
     health.addMethod('GET', tenantApiIntegration, securedMethodOptions);
     sessions.addMethod('GET', tenantApiIntegration, securedMethodOptions);
@@ -681,7 +685,7 @@ export class PlatformStack extends cdk.Stack {
 
     agents.addMethod('GET', bridgeIntegration, securedMethodOptions);
     agentByName.addMethod('GET', bridgeIntegration, securedMethodOptions);
-    agentInvoke.addMethod('POST', bridgeIntegration, securedMethodOptions);
+    agentInvoke.addMethod('POST', bridgeStreamingIntegration, securedMethodOptions);
     jobById.addMethod(
       'GET',
       bridgeIntegration,

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -340,6 +340,23 @@ def get_agent_record(agent_name: str, version: str | None = None) -> AgentRecord
         return None
 
 
+def _send_streaming_response(
+    response_stream: Any,
+    status_code: int,
+    body_bytes: bytes,
+    headers: dict[str, str] | None = None,
+) -> None:
+    """Send a buffered response via response_stream (metadata preamble + body)."""
+    effective_headers = headers or {"Content-Type": "application/json"}
+    preamble = {
+        "statusCode": status_code,
+        "headers": effective_headers,
+    }
+    # For REST API response streaming, the preamble is a JSON object followed by a null byte.
+    response_stream.write(json.dumps(preamble).encode("utf-8") + b"\0")
+    response_stream.write(body_bytes)
+
+
 def error_response(
     status_code: int,
     code: str,
@@ -692,10 +709,10 @@ def get_jitter() -> str:
     return secrets.token_hex(1)
 
 
-@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
-@tracer.capture_lambda_handler
-def handler(event: dict[str, Any], context: LambdaContext, response_stream: Any = None) -> Any:
-    """Bridge Lambda entry point."""
+def _handler_core(
+    event: dict[str, Any], context: LambdaContext, response_stream: Any = None
+) -> Any:
+    """Core logic for Bridge Lambda."""
     request_id = context.aws_request_id
 
     # 1. Parse Authorizer Context
@@ -792,6 +809,27 @@ def handler(event: dict[str, Any], context: LambdaContext, response_stream: Any 
     return invoke_agent(
         agent, tenant_context, prompt, session_id, webhook_id, request_id, response_stream
     )
+
+
+@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
+@tracer.capture_lambda_handler
+def handler(event: dict[str, Any], context: LambdaContext, response_stream: Any = None) -> Any:
+    """Bridge Lambda entry point."""
+    result = _handler_core(event, context, response_stream)
+
+    # If response_stream is present and we have a standard response dict, stream it.
+    if response_stream and isinstance(result, dict) and "statusCode" in result:
+        body = result.get("body", "")
+        body_bytes = body.encode("utf-8") if isinstance(body, str) else bytes(body or b"")
+        _send_streaming_response(
+            response_stream,
+            status_code=result["statusCode"],
+            headers=result.get("headers"),
+            body_bytes=body_bytes,
+        )
+        return None
+
+    return result
 
 
 def _http_method(event: dict[str, Any]) -> str:
@@ -1475,6 +1513,13 @@ def invoke_real_runtime(
                 session_id=runtime_session_id,
             )
 
+        # Send preamble for streaming (ADR-003 supported REST API streaming)
+        preamble = {
+            "statusCode": 200,
+            "headers": {"Content-Type": "text/event-stream"},
+        }
+        response_stream.write(json.dumps(preamble).encode("utf-8") + b"\0")
+
         try:
             for line in _iter_runtime_lines(runtime_body):
                 if line:
@@ -1761,6 +1806,13 @@ def handle_streaming_invocation(
         )
 
     effective_session_id = session_id or "mock-session-id"
+
+    # Send preamble for streaming
+    preamble = {
+        "statusCode": 200,
+        "headers": {"Content-Type": "text/event-stream"},
+    }
+    response_stream.write(json.dumps(preamble).encode("utf-8") + b"\0")
 
     with requests.post(
         f"{url}/invocations", headers=headers, json=payload, stream=True, timeout=900

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -435,6 +435,38 @@ def test_handler_streaming(setup_data):
         assert response is None
         mock_stream.write.assert_called()
 
+        # The first write should be the preamble
+        preamble_call = mock_stream.write.call_args_list[0][0][0]
+        assert b"statusCode" in preamble_call
+        assert b"text/event-stream" in preamble_call
+        assert preamble_call.endswith(b"\0")
+
+
+def test_handler_non_streaming_with_response_stream(setup_data):
+    event = {
+        "path": "/v1/agents",
+        "httpMethod": "GET",
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+            }
+        },
+    }
+    mock_stream = MagicMock()
+
+    response = handler(event, FakeLambdaContext(), response_stream=mock_stream)
+
+    assert response is None
+    # Check that it wrote to the stream
+    mock_stream.write.assert_called()
+    # The first write should be the preamble
+    preamble_call = mock_stream.write.call_args_list[0][0][0]
+    assert b"statusCode" in preamble_call
+    assert b"application/json" in preamble_call
+    assert preamble_call.endswith(b"\0")
+
 
 def test_handler_session_id_propagation(setup_data):
     event = {

--- a/tests/unit/test_bridge_streaming.py
+++ b/tests/unit/test_bridge_streaming.py
@@ -1,0 +1,121 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+
+from src.bridge.handler import _send_streaming_response, handler
+
+
+class FakeLambdaContext:
+    def __init__(self):
+        self.aws_request_id = "test-request-id"
+        self.function_name = "test-function"
+        self.memory_limit_in_mb = 128
+        self.invoked_function_arn = "arn:aws:lambda:eu-west-2:123456789012:function:test-function"
+
+
+@pytest.fixture
+def authorizer_event():
+    return {
+        "requestContext": {
+            "authorizer": {
+                "lambda": {
+                    "tenantid": "t-001",
+                    "appid": "app-001",
+                    "tier": "basic",
+                    "sub": "user-1",
+                }
+            }
+        }
+    }
+
+
+def test_send_streaming_response():
+    mock_stream = MagicMock()
+    body = b"hello world"
+    headers = {"Content-Type": "text/plain"}
+
+    _send_streaming_response(mock_stream, 200, body, headers)
+
+    assert mock_stream.write.call_count == 2
+    preamble = json.loads(mock_stream.write.call_args_list[0][0][0].decode("utf-8").rstrip("\0"))
+    assert preamble["statusCode"] == 200
+    assert preamble["headers"] == headers
+    assert mock_stream.write.call_args_list[1][0][0] == body
+
+
+@patch("src.bridge.handler.get_agent_record")
+@patch("src.bridge.handler.invoke_agent")
+def test_handler_wraps_non_streaming_response(mock_invoke, mock_get_agent, authorizer_event):
+    mock_stream = MagicMock()
+    mock_get_agent.return_value = MagicMock(tier_minimum="basic")
+
+    mock_invoke.return_value = {
+        "statusCode": 201,
+        "headers": {"X-Test": "Value"},
+        "body": json.dumps({"result": "ok"}),
+    }
+
+    event = {
+        **authorizer_event,
+        "httpMethod": "POST",
+        "path": "/v1/agents/test-agent/invoke",
+        "pathParameters": {"agentName": "test-agent"},
+        "body": json.dumps({"input": "hi"}),
+    }
+
+    result = handler(event, FakeLambdaContext(), response_stream=mock_stream)
+
+    assert result is None
+    assert mock_stream.write.call_count == 2
+    preamble = json.loads(mock_stream.write.call_args_list[0][0][0].decode("utf-8").rstrip("\0"))
+    assert preamble["statusCode"] == 201
+    assert preamble["headers"]["X-Test"] == "Value"
+    assert json.loads(mock_stream.write.call_args_list[1][0][0].decode("utf-8")) == {"result": "ok"}
+
+
+@patch("src.bridge.handler.get_agent_record")
+@patch("src.bridge.handler.invoke_agent")
+def test_handler_returns_directly_when_no_stream(mock_invoke, mock_get_agent, authorizer_event):
+    mock_get_agent.return_value = MagicMock(tier_minimum="basic")
+    expected_response = {"statusCode": 200, "body": "ok"}
+    mock_invoke.return_value = expected_response
+
+    event = {
+        **authorizer_event,
+        "httpMethod": "POST",
+        "path": "/v1/agents/test-agent/invoke",
+        "pathParameters": {"agentName": "test-agent"},
+        "body": json.dumps({"input": "hi"}),
+    }
+
+    result = handler(event, FakeLambdaContext(), response_stream=None)
+    assert result == expected_response
+
+
+@patch("src.bridge.handler.get_agent_record")
+@patch("src.bridge.handler.invoke_agent")
+def test_handler_handles_streaming_agent_result_none(mock_invoke, mock_get_agent, authorizer_event):
+    mock_stream = MagicMock()
+    mock_get_agent.return_value = MagicMock(tier_minimum="basic")
+    mock_invoke.return_value = None  # Streaming agent returns None
+
+    event = {
+        **authorizer_event,
+        "httpMethod": "POST",
+        "path": "/v1/agents/test-agent/invoke",
+        "pathParameters": {"agentName": "test-agent"},
+        "body": json.dumps({"input": "hi"}),
+    }
+
+    result = handler(event, FakeLambdaContext(), response_stream=mock_stream)
+    assert result is None
+    # No extra writes from handler wrapper since result is None
+    mock_stream.write.assert_not_called()


### PR DESCRIPTION
Rebuilds northbound streaming to use supported AWS response streaming for REST API Gateway.

### Changes:
- **CDK Infrastructure**: Configured the `agentInvoke` route with a dedicated `LambdaIntegration` using `ResponseTransferMode.STREAM`. This enables API Gateway to handle `InvokeWithResponseStream` calls from Lambda.
- **Bridge Lambda Code**:
    - Refactored the main `handler` to wrap all response paths (standard, errors, and non-invocation routes) for the `response_stream` when it is provided by the runtime.
    - Implemented the required REST API response streaming protocol: a JSON preamble containing `statusCode` and `headers`, followed by a null byte (`\0`) separator.
    - Updated `invoke_real_runtime` and `handle_streaming_invocation` to send the correct `text/event-stream` preamble before starting SSE streams.
- **Testing**:
    - Added comprehensive unit tests in `tests/unit/test_bridge_streaming.py` verifying the preamble logic and response wrapping.
    - Updated existing tests in `tests/unit/test_bridge_handler.py` to match the new streaming behavior.

### Validation:
- `make validate-local` passed (lint, typecheck, pytest, cdk synth, cfn-guard).
- `make validate-pre-push` passed.
- Unit tests for both streaming and non-streaming response paths verified preamble and null-byte separator.
