### PR TITLE
SPA: build a production app shell with responsive navigation and role-aware routing

### DIFF
--- a/spa/src/App.test.tsx
+++ b/spa/src/App.test.tsx
@@ -1,0 +1,134 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppRoutes } from "./App";
+import { useAuth } from "./auth/useAuth";
+import { createAuthContextValue } from "./test/mockFactories";
+
+vi.mock("./auth/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("./pages/AgentCataloguePage", () => ({
+  AgentCataloguePage: () => <div>Agent Catalogue Page</div>,
+}));
+
+vi.mock("./pages/SessionsPage", () => ({
+  SessionsPage: () => <div>Sessions Page</div>,
+}));
+
+vi.mock("./pages/InvokePage", () => ({
+  InvokePage: () => <div>Invoke Page</div>,
+}));
+
+vi.mock("./pages/TenantPortalPage", () => ({
+  TenantPortalPage: ({ initialSection }: { initialSection?: string }) => (
+    <div>Tenant Portal Page {initialSection}</div>
+  ),
+}));
+
+vi.mock("./pages/AdminPage", () => ({
+  AdminPage: ({ initialSection }: { initialSection?: string }) => (
+    <div>Admin Page {initialSection}</div>
+  ),
+}));
+
+describe("AppRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects operator users to the operations landing route", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      createAuthContextValue({
+        isAuthenticated: true,
+        account: {
+          idTokenClaims: {
+            roles: ["Platform.Admin"],
+            tenantid: "tenant-acme",
+          },
+        } as never,
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Admin Page overview")).toBeInTheDocument();
+  });
+
+  it("redirects legacy tenant route to the tenant overview", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      createAuthContextValue({
+        isAuthenticated: true,
+        account: {
+          idTokenClaims: {
+            roles: ["Agent.Invoke"],
+            tenantid: "tenant-acme",
+          },
+        } as never,
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/tenant"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Tenant Portal Page overview")).toBeInTheDocument();
+  });
+
+  it("denies operator routes for non-operator users with clear messaging", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      createAuthContextValue({
+        isAuthenticated: true,
+        account: {
+          idTokenClaims: {
+            roles: ["Agent.Invoke"],
+            tenantid: "tenant-acme",
+          },
+        } as never,
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/operations/overview"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Platform operator routes require the `Platform\.Admin` or `Platform\.Operator` role\./i),
+    ).toBeInTheDocument();
+  });
+
+  it("blocks tenant routes when tenant context is absent", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      createAuthContextValue({
+        isAuthenticated: true,
+        account: {
+          idTokenClaims: {
+            roles: ["Agent.Invoke"],
+          },
+        } as never,
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/access"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Tenant Route Unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/token does not contain tenant context/i)).toBeInTheDocument();
+  });
+});

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -1,11 +1,14 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { Layout } from "./components/Layout";
+import { NotificationProvider } from "./components/Notifications";
+import { PageBanner } from "./components/PageBanner";
 import { AgentCataloguePage } from "./pages/AgentCataloguePage";
 import { InvokePage } from "./pages/InvokePage";
 import { SessionsPage } from "./pages/SessionsPage";
 import { AdminPage } from "./pages/AdminPage";
 import { TenantPortalPage } from "./pages/TenantPortalPage";
 import { useAuth } from "./auth/useAuth";
+import { hasPlatformOperatorRole, resolveTenantId } from "./auth/identity";
 
 function App() {
   const { isAuthenticated, login, isLoading } = useAuth();
@@ -20,35 +23,167 @@ function App() {
   }
 
   if (!isAuthenticated) {
-    return (
-      <div className="min-h-screen bg-gray-100 flex flex-col items-center justify-center p-4">
-        <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full text-center">
-          <h1 className="text-3xl font-bold text-blue-600 mb-6">Agent Platform</h1>
-          <p className="text-gray-600 mb-8">Please sign in with your Entra ID to access the platform.</p>
-          <button
-            onClick={login}
-            className="w-full inline-flex justify-center py-3 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
-            Sign In
-          </button>
-        </div>
-      </div>
-    );
+    return <SignInScreen onLogin={login} />;
   }
 
   return (
-    <Router>
-      <Layout>
-        <Routes>
-          <Route path="/" element={<AgentCataloguePage />} />
-          <Route path="/tenant" element={<TenantPortalPage />} />
-          <Route path="/invoke/:agentName" element={<InvokePage />} />
-          <Route path="/sessions" element={<SessionsPage />} />
-          <Route path="/admin" element={<AdminPage />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </Layout>
-    </Router>
+    <BrowserRouter>
+      <NotificationProvider>
+        <Layout>
+          <AppRoutes />
+        </Layout>
+      </NotificationProvider>
+    </BrowserRouter>
+  );
+}
+
+export function AppRoutes() {
+  const { account } = useAuth();
+  const claims = account?.idTokenClaims;
+  const isOperator = hasPlatformOperatorRole(claims);
+  const tenantId = resolveTenantId(claims);
+
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to={isOperator ? "/operations/overview" : "/agents"} replace />} />
+      <Route path="/agents" element={<AgentCataloguePage />} />
+      <Route path="/invoke/:agentName" element={<InvokePage />} />
+      <Route path="/sessions" element={<SessionsPage />} />
+      <Route path="/tenant" element={<Navigate to="/tenant/overview" replace />} />
+      <Route
+        path="/tenant/overview"
+        element={
+          <RequireTenantContext tenantId={tenantId}>
+            <TenantPortalPage initialSection="overview" />
+          </RequireTenantContext>
+        }
+      />
+      <Route
+        path="/tenant/access"
+        element={
+          <RequireTenantContext tenantId={tenantId}>
+            <TenantPortalPage initialSection="access" />
+          </RequireTenantContext>
+        }
+      />
+      <Route
+        path="/tenant/api-keys"
+        element={
+          <RequireTenantContext tenantId={tenantId}>
+            <TenantPortalPage initialSection="api-keys" />
+          </RequireTenantContext>
+        }
+      />
+      <Route path="/admin" element={<Navigate to="/operations/overview" replace />} />
+      <Route
+        path="/operations/overview"
+        element={
+          <RequireOperatorRoute isOperator={isOperator}>
+            <AdminPage initialSection="overview" />
+          </RequireOperatorRoute>
+        }
+      />
+      <Route
+        path="/operations/tenants"
+        element={
+          <RequireOperatorRoute isOperator={isOperator}>
+            <AdminPage initialSection="tenants" />
+          </RequireOperatorRoute>
+        }
+      />
+      <Route
+        path="/operations/quota"
+        element={
+          <RequireOperatorRoute isOperator={isOperator}>
+            <AdminPage initialSection="quota" />
+          </RequireOperatorRoute>
+        }
+      />
+      <Route path="*" element={<Navigate to={isOperator ? "/operations/overview" : "/agents"} replace />} />
+    </Routes>
+  );
+}
+
+function RequireTenantContext({
+  children,
+  tenantId,
+}: {
+  children: JSX.Element;
+  tenantId: string | null;
+}) {
+  if (!tenantId) {
+    return (
+      <PageBanner title="Tenant Route Unavailable" severity="warning">
+        Your session is authenticated, but the token does not contain tenant context. Use a tenant-scoped account or refresh the session.
+      </PageBanner>
+    );
+  }
+
+  return children;
+}
+
+function RequireOperatorRoute({
+  children,
+  isOperator,
+}: {
+  children: JSX.Element;
+  isOperator: boolean;
+}) {
+  if (!isOperator) {
+    return (
+      <PageBanner title="Access Denied" severity="error">
+        Platform operator routes require the `Platform.Admin` or `Platform.Operator` role.
+      </PageBanner>
+    );
+  }
+
+  return children;
+}
+
+function SignInScreen({ onLogin }: { onLogin: () => Promise<void> }) {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(34,197,94,0.28),_transparent_28%),linear-gradient(180deg,_#08111f_0%,_#0f172a_55%,_#f8fafc_100%)] px-4 py-10">
+      <div className="mx-auto flex min-h-[80vh] max-w-5xl items-center">
+        <div className="grid w-full gap-8 lg:grid-cols-[1.3fr_0.9fr]">
+          <section className="rounded-[2rem] border border-white/10 bg-slate-950/75 p-8 text-white shadow-2xl backdrop-blur">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-300">Agent Platform</p>
+            <h1 className="mt-5 max-w-xl text-4xl font-semibold leading-tight">
+              Production shell for tenant operations and platform oversight.
+            </h1>
+            <p className="mt-4 max-w-2xl text-sm text-slate-300">
+              One shell handles agent invocation, tenant administration, and operator visibility while keeping route access explicit and mobile-safe.
+            </p>
+            <div className="mt-8 grid gap-3 sm:grid-cols-3">
+              <SignInFeature title="Tenant Scoped" description="Tenant identity stays visible in the shell and on protected routes." />
+              <SignInFeature title="Operator Aware" description="Platform controls appear only when the token carries the right role." />
+              <SignInFeature title="Responsive" description="Primary navigation remains usable from phone through desktop." />
+            </div>
+          </section>
+          <section className="rounded-[2rem] bg-white/90 p-8 shadow-2xl ring-1 ring-slate-200">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">Sign In</p>
+            <h2 className="mt-3 text-3xl font-semibold text-slate-950">Use your Entra ID session</h2>
+            <p className="mt-4 text-sm text-slate-600">
+              The shell uses Entra JWT identity for humans and shows tenant plus role context once the session is established.
+            </p>
+            <button
+              onClick={onLogin}
+              className="mt-8 inline-flex w-full justify-center rounded-2xl bg-slate-950 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+            >
+              Sign In
+            </button>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SignInFeature({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+      <p className="text-sm font-semibold">{title}</p>
+      <p className="mt-2 text-sm text-slate-300">{description}</p>
+    </div>
   );
 }
 

--- a/spa/src/api/openapiContract.test.ts
+++ b/spa/src/api/openapiContract.test.ts
@@ -8,10 +8,30 @@ import YAML from "yaml";
 import { SPA_OPENAPI_CONTRACTS } from "./contracts";
 
 type OpenApiDoc = {
-  paths: Record<string, Record<string, any>>;
+  paths: Record<string, Record<string, OpenApiOperation>>;
   components?: {
-    schemas?: Record<string, any>;
+    schemas?: Record<string, OpenApiSchema>;
   };
+};
+
+type OpenApiSchema = {
+  $ref?: string;
+  type?: string;
+  items?: OpenApiSchema;
+  properties?: Record<string, OpenApiSchema>;
+};
+
+type OpenApiOperation = {
+  responses?: Record<
+    string,
+    {
+      content?: {
+        "application/json"?: {
+          schema?: OpenApiSchema;
+        };
+      };
+    }
+  >;
 };
 
 function loadOpenApiDoc(): OpenApiDoc {
@@ -21,7 +41,7 @@ function loadOpenApiDoc(): OpenApiDoc {
   return YAML.parse(yaml) as OpenApiDoc;
 }
 
-function resolveSchema(schema: any, doc: OpenApiDoc): any {
+function resolveSchema(schema: OpenApiSchema | undefined, doc: OpenApiDoc): OpenApiSchema | undefined {
   if (!schema || typeof schema !== "object") {
     return schema;
   }
@@ -30,14 +50,18 @@ function resolveSchema(schema: any, doc: OpenApiDoc): any {
   }
 
   const pointer = String(schema.$ref).replace(/^#\//, "").split("/");
-  let resolved: any = doc;
+  let resolved: unknown = doc;
   for (const segment of pointer) {
-    resolved = resolved?.[segment];
+    if (!resolved || typeof resolved !== "object") {
+      resolved = undefined;
+      break;
+    }
+    resolved = (resolved as Record<string, unknown>)[segment];
   }
   if (!resolved) {
     throw new Error(`Unresolvable OpenAPI reference: ${schema.$ref}`);
   }
-  return resolveSchema(resolved, doc);
+  return resolveSchema(resolved as OpenApiSchema, doc);
 }
 
 describe("SPA/OpenAPI contract drift", () => {

--- a/spa/src/auth/AuthProvider.test.ts
+++ b/spa/src/auth/AuthProvider.test.ts
@@ -45,7 +45,7 @@ describe("acquireTokenWithBffFallback", () => {
     const acquireTokenSilent = vi.fn().mockRejectedValue(new Error("silent-fail"));
     const acquireTokenPopup = vi.fn();
     const bffTokenRefresh = vi.fn().mockResolvedValue({ accessToken: "bff-token" });
-    (getApiClient as any).mockReturnValue({ bffTokenRefresh });
+    vi.mocked(getApiClient).mockReturnValue({ bffTokenRefresh } as never);
 
     const token = await acquireTokenWithBffFallback({
       client: {
@@ -69,7 +69,7 @@ describe("acquireTokenWithBffFallback", () => {
       .mockRejectedValue(new InteractionRequiredAuthError("interaction_required", "login"));
     const acquireTokenPopup = vi.fn().mockResolvedValue({ accessToken: "popup-token" });
     const bffTokenRefresh = vi.fn().mockRejectedValue(new Error("bff-fail"));
-    (getApiClient as any).mockReturnValue({ bffTokenRefresh });
+    vi.mocked(getApiClient).mockReturnValue({ bffTokenRefresh } as never);
 
     const token = await acquireTokenWithBffFallback({
       client: {

--- a/spa/src/auth/AuthProvider.tsx
+++ b/spa/src/auth/AuthProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import {
   EventType,
   InteractionRequiredAuthError,

--- a/spa/src/auth/identity.ts
+++ b/spa/src/auth/identity.ts
@@ -1,0 +1,73 @@
+import type { AccountInfo } from "@azure/msal-browser";
+
+type ClaimsRecord = Record<string, unknown>;
+
+function toClaimsRecord(claims: unknown): ClaimsRecord | null {
+  if (!claims || typeof claims !== "object") {
+    return null;
+  }
+  return claims as ClaimsRecord;
+}
+
+export function resolveTenantId(claims: unknown): string | null {
+  const map = toClaimsRecord(claims);
+  if (!map) {
+    return null;
+  }
+
+  const tenantId = map.tenantid ?? map.tenantId;
+  if (typeof tenantId !== "string") {
+    return null;
+  }
+
+  const trimmed = tenantId.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function resolveRoles(claims: unknown): string[] {
+  const map = toClaimsRecord(claims);
+  if (!map) {
+    return [];
+  }
+
+  const roles = map.roles;
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  return roles.filter((role): role is string => typeof role === "string" && role.trim().length > 0);
+}
+
+export function hasPlatformOperatorRole(claims: unknown): boolean {
+  return resolveRoles(claims).some((role) => role === "Platform.Admin" || role === "Platform.Operator");
+}
+
+export function describeRoleSet(claims: unknown): string {
+  const roles = resolveRoles(claims);
+  if (roles.length === 0) {
+    return "Tenant User";
+  }
+
+  if (roles.includes("Platform.Admin")) {
+    return "Platform Admin";
+  }
+
+  if (roles.includes("Platform.Operator")) {
+    return "Platform Operator";
+  }
+
+  return roles[0];
+}
+
+export function getIdentityContext(account: AccountInfo | null) {
+  const claims = account?.idTokenClaims;
+
+  return {
+    displayName: account?.name ?? "Unknown user",
+    username: account?.username ?? "unknown",
+    tenantId: resolveTenantId(claims),
+    roles: resolveRoles(claims),
+    roleLabel: describeRoleSet(claims),
+    isOperator: hasPlatformOperatorRole(claims),
+  };
+}

--- a/spa/src/components/Layout.test.tsx
+++ b/spa/src/components/Layout.test.tsx
@@ -1,0 +1,87 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAuth } from "../auth/useAuth";
+import { createAuthContextValue } from "../test/mockFactories";
+import { Layout } from "./Layout";
+
+vi.mock("../auth/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../api/client", () => ({
+  getApiClient: vi.fn(),
+}));
+
+describe("Layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders tenant routes for tenant-scoped users and operator routes for operators", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      createAuthContextValue({
+        isAuthenticated: true,
+        account: {
+          name: "Op User",
+          username: "op.user@example.com",
+          idTokenClaims: {
+            tenantid: "tenant-acme",
+            roles: ["Platform.Operator"],
+          },
+        } as never,
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/overview"]}>
+        <Layout>
+          <div>content</div>
+        </Layout>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: /agents/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /access/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /quota/i })).toBeInTheDocument();
+    expect(screen.getAllByText("tenant-acme").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Platform Operator").length).toBeGreaterThan(0);
+  });
+
+  it("keeps mobile navigation operable and closable with escape", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      createAuthContextValue({
+        isAuthenticated: true,
+        account: {
+          name: "Tenant User",
+          username: "tenant.user@example.com",
+          idTokenClaims: {
+            tenantid: "tenant-acme",
+            roles: ["Agent.Invoke"],
+          },
+        } as never,
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agents"]}>
+        <Layout>
+          <div>content</div>
+        </Layout>
+      </MemoryRouter>,
+    );
+
+    const [trigger] = screen.getAllByRole("button", { name: /open navigation/i });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("dialog", { name: /primary navigation/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: /primary navigation/i })).not.toBeInTheDocument();
+  });
+});

--- a/spa/src/components/Layout.tsx
+++ b/spa/src/components/Layout.tsx
@@ -1,81 +1,312 @@
-import React, { useEffect } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Link, NavLink, useLocation } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
 import { getApiClient } from "../api/client";
+import { getIdentityContext } from "../auth/identity";
+import { PageBanner } from "./PageBanner";
 
-export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const { account, logout, isAuthenticated, getAccessToken } = useAuth();
-    const location = useLocation();
-
-    // Initialize ApiClient globally
-    useEffect(() => {
-        if (isAuthenticated) {
-            getApiClient(getAccessToken);
-        }
-    }, [isAuthenticated, getAccessToken]);
-
-    const navItems = [
-        { name: "Catalogue", path: "/" },
-        { name: "Tenant Portal", path: "/tenant" },
-        { name: "Sessions", path: "/sessions" },
-        { name: "Admin", path: "/admin", adminOnly: true },
-    ];
-
-    const isAdmin = account?.idTokenClaims?.roles?.some((role: string) => 
-        role === "Platform.Admin" || role === "Platform.Operator"
-    );
-
-    return (
-        <div className="min-h-screen bg-gray-50 flex flex-col">
-            <header className="bg-white border-b border-gray-200">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="flex justify-between h-16 items-center">
-                        <div className="flex items-center">
-                            <span className="text-xl font-bold text-blue-600 mr-8">Agent Platform</span>
-                            <nav className="hidden md:flex space-x-8">
-                                {navItems.map((item) => (
-                                    (!item.adminOnly || isAdmin) && (
-                                        <Link
-                                            key={item.path}
-                                            to={item.path}
-                                            className={`${
-                                                location.pathname === item.path
-                                                    ? "border-blue-500 text-gray-900"
-                                                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-                                            } inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium`}
-                                        >
-                                            {item.name}
-                                        </Link>
-                                    )
-                                ))}
-                            </nav>
-                        </div>
-                        <div className="flex items-center space-x-4">
-                            {isAuthenticated && account ? (
-                                <>
-                                    <span className="text-sm text-gray-600">{account.name}</span>
-                                    <button
-                                        onClick={logout}
-                                        className="text-sm font-medium text-gray-700 hover:text-blue-600"
-                                    >
-                                        Logout
-                                    </button>
-                                </>
-                            ) : (
-                                <button className="text-sm font-medium text-blue-600">Login</button>
-                            )}
-                        </div>
-                    </div>
-                </div>
-            </header>
-            <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                {children}
-            </main>
-            <footer className="bg-white border-t border-gray-200 py-4">
-                <div className="max-w-7xl mx-auto px-4 text-center text-sm text-gray-500">
-                    &copy; 2026 Agent Platform. All rights reserved.
-                </div>
-            </footer>
-        </div>
-    );
+type LayoutProps = {
+  children: ReactNode;
 };
+
+type NavigationItem = {
+  label: string;
+  path: string;
+  description: string;
+  requiresTenant?: boolean;
+  requiresOperator?: boolean;
+};
+
+type NavigationGroup = {
+  label: string;
+  items: NavigationItem[];
+};
+
+const navigationGroups: NavigationGroup[] = [
+  {
+    label: "Workspace",
+    items: [
+      {
+        label: "Agents",
+        path: "/agents",
+        description: "Browse and invoke platform agents.",
+      },
+      {
+        label: "Sessions",
+        path: "/sessions",
+        description: "Review current and recent activity.",
+      },
+    ],
+  },
+  {
+    label: "Tenant",
+    items: [
+      {
+        label: "Overview",
+        path: "/tenant/overview",
+        description: "Usage, health, and tenant posture.",
+        requiresTenant: true,
+      },
+      {
+        label: "Access",
+        path: "/tenant/access",
+        description: "Invite and manage tenant users.",
+        requiresTenant: true,
+      },
+      {
+        label: "API Keys",
+        path: "/tenant/api-keys",
+        description: "Rotate and inspect machine credentials.",
+        requiresTenant: true,
+      },
+    ],
+  },
+  {
+    label: "Operations",
+    items: [
+      {
+        label: "Overview",
+        path: "/operations/overview",
+        description: "Platform status and operator controls.",
+        requiresOperator: true,
+      },
+      {
+        label: "Tenants",
+        path: "/operations/tenants",
+        description: "Cross-tenant portfolio view.",
+        requiresOperator: true,
+      },
+      {
+        label: "Quota",
+        path: "/operations/quota",
+        description: "Runtime utilisation and headroom.",
+        requiresOperator: true,
+      },
+    ],
+  },
+];
+
+export function Layout({ children }: LayoutProps) {
+  const { account, logout, isAuthenticated, getAccessToken } = useAuth();
+  const location = useLocation();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      getApiClient(getAccessToken);
+    }
+  }, [getAccessToken, isAuthenticated]);
+
+  useEffect(() => {
+    if (!mobileNavOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMobileNavOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [mobileNavOpen]);
+
+  const identity = getIdentityContext(account);
+  const environment = import.meta.env.VITE_ENVIRONMENT_NAME ?? import.meta.env.MODE;
+
+  const availableNavigation = useMemo(
+    () =>
+      navigationGroups
+        .map((group) => ({
+          ...group,
+          items: group.items.filter((item) => {
+            if (item.requiresOperator && !identity.isOperator) {
+              return false;
+            }
+            if (item.requiresTenant && !identity.tenantId) {
+              return false;
+            }
+            return true;
+          }),
+        }))
+        .filter((group) => group.items.length > 0),
+    [identity.isOperator, identity.tenantId],
+  );
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,_rgba(34,197,94,0.22),_transparent_26%),radial-gradient(circle_at_top_right,_rgba(56,189,248,0.20),_transparent_24%),linear-gradient(180deg,_#08111f_0%,_#0f172a_45%,_#e2e8f0_45%,_#f8fafc_100%)]" />
+      <header className="border-b border-white/10 bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              aria-controls="mobile-navigation"
+              aria-expanded={mobileNavOpen}
+              aria-label="Open navigation"
+              onClick={() => setMobileNavOpen((current) => !current)}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-sm font-semibold text-white md:hidden"
+            >
+              Menu
+            </button>
+            <Link to={identity.isOperator ? "/operations/overview" : "/agents"} className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-300">Agent Platform</p>
+              <p className="text-lg font-semibold text-white">Production Shell</p>
+            </Link>
+          </div>
+          <div className="hidden flex-wrap items-center justify-end gap-2 md:flex">
+            <ShellChip label="Env" value={environment.toUpperCase()} />
+            <ShellChip label="Tenant" value={identity.tenantId ?? "Unavailable"} />
+            <ShellChip label="Role" value={identity.roleLabel} />
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="hidden text-right md:block">
+              <p className="text-sm font-medium text-white">{identity.displayName}</p>
+              <p className="text-xs text-slate-400">{identity.username}</p>
+            </div>
+            {isAuthenticated && (
+              <button
+                type="button"
+                onClick={logout}
+                className="rounded-2xl border border-cyan-400/30 bg-cyan-400/10 px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:border-cyan-300 hover:bg-cyan-400/20"
+              >
+                Logout
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {mobileNavOpen && (
+        <div className="fixed inset-0 z-40 bg-slate-950/65 backdrop-blur-sm md:hidden" onClick={() => setMobileNavOpen(false)}>
+          <div
+            id="mobile-navigation"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Primary navigation"
+            className="h-full w-[min(20rem,85vw)] border-r border-white/10 bg-slate-950 px-4 py-6"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <NavigationContent
+              groups={availableNavigation}
+              currentPath={location.pathname}
+              onNavigate={() => setMobileNavOpen(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="mx-auto flex max-w-7xl gap-8 px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+        <aside className="sticky top-6 hidden h-fit w-80 shrink-0 rounded-[2rem] border border-white/10 bg-slate-950/70 p-5 shadow-2xl backdrop-blur md:block">
+          <NavigationContent groups={availableNavigation} currentPath={location.pathname} />
+        </aside>
+        <main className="min-w-0 flex-1 space-y-6">
+          <section className="grid gap-4 lg:grid-cols-[1.5fr_1fr]">
+            <div className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-6 shadow-2xl backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-300">Current Context</p>
+              <h1 className="mt-3 text-3xl font-semibold text-white">Tenant and operator journeys share one shell.</h1>
+              <p className="mt-3 max-w-2xl text-sm text-slate-300">
+                Navigation, route gating, and shell context stay explicit so tenant-scoped work and operator controls do not blur together.
+              </p>
+            </div>
+            <div className="grid gap-3 rounded-[2rem] border border-white/10 bg-white/80 p-6 text-slate-900 shadow-xl">
+              <ShellMetric label="Tenant Context" value={identity.tenantId ?? "Missing"} tone={identity.tenantId ? "default" : "warning"} />
+              <ShellMetric label="Role Surface" value={identity.roleLabel} tone={identity.isOperator ? "success" : "default"} />
+              <ShellMetric label="Route" value={location.pathname} tone="default" mono />
+            </div>
+          </section>
+
+          {!identity.tenantId && (
+            <PageBanner title="Tenant Context Missing" severity="warning">
+              Tenant routes are disabled because the current token does not include a `tenantid` claim.
+            </PageBanner>
+          )}
+
+          {identity.isOperator && (
+            <PageBanner title="Operator Access Active" severity="info">
+              Platform-wide routes are visible because the current session includes `Platform.Admin` or `Platform.Operator`.
+            </PageBanner>
+          )}
+
+          <div className="rounded-[2rem] bg-white/90 p-4 shadow-xl ring-1 ring-slate-200 sm:p-6">
+            {children}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function NavigationContent({
+  groups,
+  currentPath,
+  onNavigate,
+}: {
+  groups: NavigationGroup[];
+  currentPath: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <nav className="space-y-6">
+      {groups.map((group) => (
+        <section key={group.label}>
+          <p className="px-3 text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">{group.label}</p>
+          <div className="mt-3 space-y-2">
+            {group.items.map((item) => (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                onClick={onNavigate}
+                className={({ isActive }) =>
+                  [
+                    "block rounded-2xl border px-4 py-3 transition",
+                    isActive || currentPath === item.path
+                      ? "border-cyan-300/40 bg-cyan-300/10 text-white shadow-lg"
+                      : "border-white/10 bg-white/5 text-slate-300 hover:border-white/20 hover:bg-white/10 hover:text-white",
+                  ].join(" ")
+                }
+              >
+                <p className="text-sm font-semibold">{item.label}</p>
+                <p className="mt-1 text-xs opacity-80">{item.description}</p>
+              </NavLink>
+            ))}
+          </div>
+        </section>
+      ))}
+    </nav>
+  );
+}
+
+function ShellChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200">
+      <span className="text-slate-400">{label}</span> {value}
+    </div>
+  );
+}
+
+function ShellMetric({
+  label,
+  value,
+  tone,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  tone: "default" | "success" | "warning";
+  mono?: boolean;
+}) {
+  const toneStyles = {
+    default: "bg-slate-100 text-slate-900",
+    success: "bg-emerald-50 text-emerald-900",
+    warning: "bg-amber-50 text-amber-900",
+  };
+
+  return (
+    <div className={`rounded-2xl px-4 py-3 ${toneStyles[tone]}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</p>
+      <p className={`mt-1 text-sm font-semibold ${mono ? "font-mono" : ""}`}>{value}</p>
+    </div>
+  );
+}

--- a/spa/src/components/Notifications.test.tsx
+++ b/spa/src/components/Notifications.test.tsx
@@ -1,0 +1,46 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NotificationProvider, useNotifications } from "./Notifications";
+import { PageBanner } from "./PageBanner";
+
+function NotificationProbe() {
+  const { notify } = useNotifications();
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        notify({
+          title: "Quota Warning",
+          message: "eu-west-1 runtime is above 80% utilisation.",
+          severity: "warning",
+        })
+      }
+    >
+      Trigger notification
+    </button>
+  );
+}
+
+describe("Notifications", () => {
+  it("renders predictable severity surfaces for notifications and banners", () => {
+    render(
+      <NotificationProvider>
+        <NotificationProbe />
+        <PageBanner title="Tenant Context Missing" severity="warning">
+          Tenant context is required for this route.
+        </PageBanner>
+      </NotificationProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /trigger notification/i }));
+
+    expect(screen.getByText("Quota Warning")).toBeInTheDocument();
+    expect(screen.getByText("eu-west-1 runtime is above 80% utilisation.")).toBeInTheDocument();
+    expect(screen.getByText("Tenant Context Missing")).toBeInTheDocument();
+    expect(screen.getByText("Tenant context is required for this route.")).toBeInTheDocument();
+  });
+});

--- a/spa/src/components/Notifications.tsx
+++ b/spa/src/components/Notifications.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+type NotificationSeverity = "info" | "success" | "warning" | "error";
+
+type NotificationItem = {
+  id: string;
+  title: string;
+  message: string;
+  severity: NotificationSeverity;
+};
+
+type NotificationInput = Omit<NotificationItem, "id">;
+
+type NotificationContextValue = {
+  notifications: NotificationItem[];
+  notify: (notification: NotificationInput) => string;
+  dismiss: (id: string) => void;
+};
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+const notificationStyles: Record<NotificationSeverity, string> = {
+  info: "border-sky-200 bg-sky-50 text-sky-900",
+  success: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  warning: "border-amber-200 bg-amber-50 text-amber-900",
+  error: "border-rose-200 bg-rose-50 text-rose-900",
+};
+
+type NotificationProviderProps = {
+  children: ReactNode;
+};
+
+export function NotificationProvider({ children }: NotificationProviderProps) {
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setNotifications((current) => current.filter((notification) => notification.id !== id));
+  }, []);
+
+  const notify = useCallback((notification: NotificationInput) => {
+    const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    setNotifications((current) => [...current, { id, ...notification }]);
+    return id;
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      notifications,
+      notify,
+      dismiss,
+    }),
+    [dismiss, notifications, notify],
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+      <NotificationViewport notifications={notifications} onDismiss={dismiss} />
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationContextValue {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error("useNotifications must be used within a NotificationProvider");
+  }
+  return context;
+}
+
+type NotificationViewportProps = {
+  notifications: NotificationItem[];
+  onDismiss: (id: string) => void;
+};
+
+function NotificationViewport({ notifications, onDismiss }: NotificationViewportProps) {
+  return (
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 top-4 z-50 mx-auto flex w-full max-w-5xl flex-col gap-3 px-4"
+    >
+      {notifications.map((notification) => (
+        <article
+          key={notification.id}
+          className={`pointer-events-auto ml-auto w-full max-w-sm rounded-3xl border px-5 py-4 shadow-lg backdrop-blur ${notificationStyles[notification.severity]}`}
+          role="status"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm font-semibold">{notification.title}</p>
+              <p className="mt-1 text-sm">{notification.message}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onDismiss(notification.id)}
+              className="rounded-full border border-current/20 px-2 py-1 text-xs font-semibold"
+            >
+              Dismiss
+            </button>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/spa/src/components/PageBanner.tsx
+++ b/spa/src/components/PageBanner.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+type BannerSeverity = "info" | "success" | "warning" | "error";
+
+const severityStyles: Record<BannerSeverity, string> = {
+  info: "border-sky-200 bg-sky-50 text-sky-900",
+  success: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  warning: "border-amber-200 bg-amber-50 text-amber-900",
+  error: "border-rose-200 bg-rose-50 text-rose-900",
+};
+
+type PageBannerProps = {
+  title: string;
+  severity?: BannerSeverity;
+  children: ReactNode;
+};
+
+export function PageBanner({ title, severity = "info", children }: PageBannerProps) {
+  return (
+    <section
+      aria-live="polite"
+      className={`rounded-3xl border px-5 py-4 shadow-sm ${severityStyles[severity]}`}
+    >
+      <p className="text-sm font-semibold uppercase tracking-[0.2em]">{title}</p>
+      <div className="mt-1 text-sm">{children}</div>
+    </section>
+  );
+}

--- a/spa/src/env.d.ts
+++ b/spa/src/env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_ENTRA_REDIRECT_URI: string;
   readonly VITE_ENTRA_POST_LOGOUT_REDIRECT_URI: string;
+  readonly VITE_ENVIRONMENT_NAME?: string;
 }
 
 interface ImportMeta {

--- a/spa/src/pages/AdminPage.test.tsx
+++ b/spa/src/pages/AdminPage.test.tsx
@@ -94,9 +94,8 @@ describe("AdminPage", () => {
     render(<AdminPage />);
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Access Denied: Platform.Operator role required."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Access Denied")).toBeInTheDocument();
+      expect(screen.getByText("Platform operator role required.")).toBeInTheDocument();
     });
     expect(request).not.toHaveBeenCalled();
   });

--- a/spa/src/pages/AdminPage.tsx
+++ b/spa/src/pages/AdminPage.tsx
@@ -1,169 +1,180 @@
 import React, { useEffect, useState } from "react";
 import {
-    HealthResponseDto,
-    PlatformQuotaResponseDto,
-    TenantAdminRow,
-    TenantsListResponseDto,
-    toTenantAdminRow,
+  HealthResponseDto,
+  PlatformQuotaResponseDto,
+  TenantAdminRow,
+  TenantsListResponseDto,
+  toTenantAdminRow,
 } from "../api/contracts";
 import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
+import { hasPlatformOperatorRole } from "../auth/identity";
+import { PageBanner } from "../components/PageBanner";
 
-export const AdminPage: React.FC = () => {
-    const [health, setHealth] = useState<HealthResponseDto | null>(null);
-    const [tenants, setTenants] = useState<TenantAdminRow[]>([]);
-    const [quota, setQuota] = useState<PlatformQuotaResponseDto["utilisation"]>([]);
-    const [loading, setLoading] = useState(true);
-    const [_error, setError] = useState<string | null>(null);
-    const { getAccessToken, account, isAuthenticated } = useAuth();
+type AdminPageProps = {
+  initialSection?: "overview" | "tenants" | "quota";
+};
 
-    const isAdmin = account?.idTokenClaims?.roles?.some((role: string) => 
-        role === "Platform.Admin" || role === "Platform.Operator"
-    );
+const sectionBannerCopy: Record<NonNullable<AdminPageProps["initialSection"]>, string> = {
+  overview: "Platform health and cross-region runtime posture are in view.",
+  tenants: "Tenant portfolio data is surfaced here for operator review.",
+  quota: "Quota headroom is highlighted here before runtime saturation becomes an incident.",
+};
 
-    useEffect(() => {
-        if (!isAdmin || !isAuthenticated) {
-            if (!isAdmin) setLoading(false);
-            return;
-        }
-        const fetchAdminData = async () => {
-            try {
-                const client = getApiClient(getAccessToken);
+export const AdminPage: React.FC<AdminPageProps> = ({ initialSection = "overview" }) => {
+  const [health, setHealth] = useState<HealthResponseDto | null>(null);
+  const [tenants, setTenants] = useState<TenantAdminRow[]>([]);
+  const [quota, setQuota] = useState<PlatformQuotaResponseDto["utilisation"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [_error, setError] = useState<string | null>(null);
+  const { getAccessToken, account, isAuthenticated } = useAuth();
 
-                const [healthData, tenantsData, quotaData] = await Promise.all([
-                    client.request<HealthResponseDto>("/v1/health"),
-                    client.request<TenantsListResponseDto>("/v1/tenants"),
-                    client.request<PlatformQuotaResponseDto>("/v1/platform/quota").catch(() => ({ utilisation: [] }))
-                ]);
+  const isAdmin = hasPlatformOperatorRole(account?.idTokenClaims);
 
-                setHealth(healthData);
-                setTenants((tenantsData.items || []).map(toTenantAdminRow));
-                setQuota(quotaData.utilisation || []);
-            } catch (err: any) {
-                setError(err.message);
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchAdminData();
-    }, [getAccessToken, isAdmin, isAuthenticated]);
-
-
-    if (loading) return <div>Loading admin data...</div>;
-
-    if (!isAdmin) {
-        return (
-            <div className="bg-red-50 border-l-4 border-red-400 p-4">
-                <div className="flex">
-                    <div className="ml-3">
-                        <p className="text-sm text-red-700">Access Denied: Platform.Operator role required.</p>
-                    </div>
-                </div>
-            </div>
-        );
+  useEffect(() => {
+    if (!isAdmin || !isAuthenticated) {
+      if (!isAdmin) {
+        setLoading(false);
+      }
+      return;
     }
 
-    if (_error) {
-        return (
-            <div className="bg-red-50 border-l-4 border-red-400 p-4">
-                <p className="text-sm text-red-700">{_error}</p>
-            </div>
-        );
-    }
+    const fetchAdminData = async () => {
+      try {
+        const client = getApiClient(getAccessToken);
 
+        const [healthData, tenantsData, quotaData] = await Promise.all([
+          client.request<HealthResponseDto>("/v1/health"),
+          client.request<TenantsListResponseDto>("/v1/tenants"),
+          client
+            .request<PlatformQuotaResponseDto>("/v1/platform/quota")
+            .catch(() => ({ utilisation: [] })),
+        ]);
+
+        setHealth(healthData);
+        setTenants((tenantsData.items || []).map(toTenantAdminRow));
+        setQuota(quotaData.utilisation || []);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : "Failed to load admin data.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchAdminData();
+  }, [getAccessToken, isAdmin, isAuthenticated]);
+
+  if (loading) {
+    return <div>Loading admin data...</div>;
+  }
+
+  if (!isAdmin) {
     return (
-        <div className="space-y-8">
-            <div>
-                <h1 className="text-3xl font-bold text-gray-900">Platform Admin</h1>
-                <p className="mt-2 text-gray-600">Global platform health and tenant management.</p>
-            </div>
-
-            {/* Health Section */}
-            <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
-                <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
-                    <h3 className="text-lg leading-6 font-medium text-gray-900">Platform Health</h3>
-                </div>
-                <div className="px-4 py-5 sm:p-6 flex items-center space-x-4">
-                    <div className={`h-4 w-4 rounded-full ${
-                        health?.status === "ok" ? "bg-green-400" : "bg-red-400"
-                    } animate-pulse`}></div>
-                    <span className="text-lg font-semibold uppercase">{health?.status || "Unknown"}</span>
-                    <span className="text-sm text-gray-500">Version: {health?.version}</span>
-                    <span className="text-sm text-gray-500">Last Check: {health?.timestamp ? new Date(health.timestamp).toLocaleTimeString() : "N/A"}</span>
-                </div>
-            </section>
-
-            {/* Quota Section */}
-            <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
-                <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
-                    <h3 className="text-lg leading-6 font-medium text-gray-900">AgentCore Quota Utilisation</h3>
-                </div>
-                <div className="px-4 py-5 sm:p-6">
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        {quota.map((q) => (
-                            <div key={q.region} className="border rounded-md p-4">
-                                <div className="flex justify-between mb-1">
-                                    <span className="text-sm font-medium text-gray-700">{q.region} - {q.quotaName}</span>
-                                    <span className="text-sm font-medium text-gray-700">{q.utilisationPercentage}%</span>
-                                </div>
-                                <div className="w-full bg-gray-200 rounded-full h-2.5">
-                                    <div 
-                                        className={`h-2.5 rounded-full ${
-                                            q.utilisationPercentage > 80 ? "bg-red-600" : "bg-blue-600"
-                                        }`} 
-                                        style={{ width: `${q.utilisationPercentage}%` }}
-                                    ></div>
-                                </div>
-                                <div className="mt-2 text-xs text-gray-500">
-                                    {q.currentValue} / {q.limit} sessions
-                                </div>
-                            </div>
-                        ))}
-                        {quota.length === 0 && <p className="text-sm text-gray-500">No quota data available.</p>}
-                    </div>
-                </div>
-            </section>
-
-            {/* Tenants Section */}
-            <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
-                <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200 flex justify-between items-center">
-                    <h3 className="text-lg leading-6 font-medium text-gray-900">Tenants</h3>
-                    <span className="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-0.5 rounded-full">
-                        {tenants.length} Total
-                    </span>
-                </div>
-                <div className="overflow-x-auto">
-                    <table className="min-w-full divide-y divide-gray-200">
-                        <thead className="bg-gray-50">
-                            <tr>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tenant ID</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tier</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Region</th>
-                            </tr>
-                        </thead>
-                        <tbody className="bg-white divide-y divide-gray-200">
-                            {tenants.map((tenant) => (
-                                <tr key={tenant.tenantId}>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{tenant.tenantId}</td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{tenant.displayName}</td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize">{tenant.tier}</td>
-                                    <td className="px-6 py-4 whitespace-nowrap">
-                                        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                                            tenant.status === "active" ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"
-                                        }`}>
-                                            {tenant.status}
-                                        </span>
-                                    </td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{tenant.runtimeRegion ?? "N/A"}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </section>
-        </div>
+      <PageBanner title="Access Denied" severity="error">
+        Platform operator role required.
+      </PageBanner>
     );
+  }
+
+  if (_error) {
+    return (
+      <PageBanner title="Admin Request Failed" severity="error">
+        {_error}
+      </PageBanner>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Platform Admin</h1>
+        <p className="mt-2 text-gray-600">Global platform health and tenant management.</p>
+      </div>
+
+      <PageBanner title={`Operations / ${initialSection}`} severity="info">
+        {sectionBannerCopy[initialSection]}
+      </PageBanner>
+
+      <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
+        <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
+          <h3 className="text-lg leading-6 font-medium text-gray-900">Platform Health</h3>
+        </div>
+        <div className="px-4 py-5 sm:p-6 flex items-center space-x-4">
+          <div className={`h-4 w-4 rounded-full ${health?.status === "ok" ? "bg-green-400" : "bg-red-400"} animate-pulse`} />
+          <span className="text-lg font-semibold uppercase">{health?.status || "Unknown"}</span>
+          <span className="text-sm text-gray-500">Version: {health?.version}</span>
+          <span className="text-sm text-gray-500">
+            Last Check: {health?.timestamp ? new Date(health.timestamp).toLocaleTimeString() : "N/A"}
+          </span>
+        </div>
+      </section>
+
+      <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
+        <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
+          <h3 className="text-lg leading-6 font-medium text-gray-900">AgentCore Quota Utilisation</h3>
+        </div>
+        <div className="px-4 py-5 sm:p-6">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {quota.map((q) => (
+              <div key={q.region} className="border rounded-md p-4">
+                <div className="flex justify-between mb-1">
+                  <span className="text-sm font-medium text-gray-700">
+                    {q.region} - {q.quotaName}
+                  </span>
+                  <span className="text-sm font-medium text-gray-700">{q.utilisationPercentage}%</span>
+                </div>
+                <div className="w-full bg-gray-200 rounded-full h-2.5">
+                  <div
+                    className={`h-2.5 rounded-full ${q.utilisationPercentage > 80 ? "bg-red-600" : "bg-blue-600"}`}
+                    style={{ width: `${q.utilisationPercentage}%` }}
+                  />
+                </div>
+                <div className="mt-2 text-xs text-gray-500">
+                  {q.currentValue} / {q.limit} sessions
+                </div>
+              </div>
+            ))}
+            {quota.length === 0 && <p className="text-sm text-gray-500">No quota data available.</p>}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
+        <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200 flex justify-between items-center">
+          <h3 className="text-lg leading-6 font-medium text-gray-900">Tenants</h3>
+          <span className="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-0.5 rounded-full">
+            {tenants.length} Total
+          </span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tenant ID</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tier</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Region</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {tenants.map((tenant) => (
+                <tr key={tenant.tenantId}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{tenant.tenantId}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{tenant.displayName}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize">{tenant.tier}</td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${tenant.status === "active" ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"}`}>
+                      {tenant.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{tenant.runtimeRegion ?? "N/A"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
 };

--- a/spa/src/pages/AgentCataloguePage.tsx
+++ b/spa/src/pages/AgentCataloguePage.tsx
@@ -17,9 +17,9 @@ export const AgentCataloguePage: React.FC = () => {
                 const client = getApiClient(getAccessToken);
                 const data = await client.request<AgentsListResponseDto>("/v1/agents");
                 setAgents((data.items || []).map(toAgentCatalogueItem));
-            } catch (err: any) {
+            } catch (err: unknown) {
                 console.error("Failed to fetch agents", err);
-                setError(err.message || "Failed to load agents");
+                setError(err instanceof Error ? err.message : "Failed to load agents");
             } finally {
                 setLoading(false);
             }

--- a/spa/src/pages/InvokePage.test.tsx
+++ b/spa/src/pages/InvokePage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAuthContextValue } from "../test/mockFactories";
 import { asyncAccepted, buildAgent } from "../test/testData";
+import type { Job } from "../types";
 import { InvokePage } from "./InvokePage";
 
 const { getApiClientMock, getAccessTokenMock, navigateMock, requestMock, streamMock, useAuthMock, useJobPollingMock } =
@@ -17,11 +18,15 @@ const { getApiClientMock, getAccessTokenMock, navigateMock, requestMock, streamM
             requestMock: request,
             streamMock: stream,
             useAuthMock: useAuth,
-            useJobPollingMock: vi.fn((_jobId: string | null, _getAccessToken: any) => ({
-                status: null as any,
-                loading: false,
-                error: null as any,
-            })),
+            useJobPollingMock: vi.fn((jobId: string | null, getAccessToken: typeof getAccessTokenMock) => {
+                void jobId;
+                void getAccessToken;
+                return {
+                    status: null as Job | null,
+                    loading: false,
+                    error: null as string | null,
+                };
+            }),
         };
     });
 

--- a/spa/src/pages/InvokePage.tsx
+++ b/spa/src/pages/InvokePage.tsx
@@ -79,7 +79,7 @@ export const InvokePage: React.FC = () => {
                         } else if (!payload.type && typeof payload.output === "string") {
                             setResult((prev) => (prev || "") + payload.output);
                         }
-                    } catch (e) {
+                    } catch {
                         // Fallback for raw text data
                         setResult((prev) => (prev || "") + chunk.data);
                     }

--- a/spa/src/pages/SessionsPage.tsx
+++ b/spa/src/pages/SessionsPage.tsx
@@ -16,8 +16,8 @@ export const SessionsPage: React.FC = () => {
                 const client = getApiClient(getAccessToken);
                 const data = await client.request<SessionsListResponseDto>("/v1/sessions");
                 setSessions((data.items || []).map(toSessionRow));
-            } catch (err: any) {
-                setError(err.message);
+            } catch (err: unknown) {
+                setError(err instanceof Error ? err.message : "Failed to load sessions");
             } finally {
                 setLoading(false);
             }

--- a/spa/src/pages/TenantPortalPage.tsx
+++ b/spa/src/pages/TenantPortalPage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
+import { resolveTenantId } from "../auth/identity";
+import { PageBanner } from "../components/PageBanner";
 
 type TenantUsage = {
     requestsToday?: number;
@@ -37,20 +39,17 @@ type InviteResponse = {
     };
 };
 
-function resolveTenantId(claims: unknown): string | null {
-    if (!claims || typeof claims !== "object") {
-        return null;
-    }
-    const map = claims as Record<string, unknown>;
-    const tenantId = map.tenantid ?? map.tenantId;
-    if (typeof tenantId !== "string") {
-        return null;
-    }
-    const trimmed = tenantId.trim();
-    return trimmed.length > 0 ? trimmed : null;
-}
+type TenantPortalPageProps = {
+    initialSection?: "overview" | "access" | "api-keys";
+};
 
-export const TenantPortalPage: React.FC = () => {
+const sectionMessages: Record<NonNullable<TenantPortalPageProps["initialSection"]>, string> = {
+    overview: "Usage, key posture, and invitation controls are grouped here for the current tenant.",
+    access: "This route focuses the tenant access workflow, including invitation issuance.",
+    "api-keys": "This route focuses machine identity hygiene and rotation cadence.",
+};
+
+export const TenantPortalPage: React.FC<TenantPortalPageProps> = ({ initialSection = "overview" }) => {
     const { getAccessToken, account, isAuthenticated } = useAuth();
     const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
 
@@ -178,6 +177,10 @@ export const TenantPortalPage: React.FC = () => {
                     Self-service controls for tenant <span className="font-medium">{tenant.tenantId}</span>.
                 </p>
             </div>
+
+            <PageBanner title={`Tenant / ${initialSection}`} severity="info">
+                {sectionMessages[initialSection]}
+            </PageBanner>
 
             <section className="bg-white shadow sm:rounded-lg border border-gray-200 overflow-hidden">
                 <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">

--- a/spa/src/vite-env.d.ts
+++ b/spa/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_ENTRA_REDIRECT_URI: string
   readonly VITE_ENTRA_POST_LOGOUT_REDIRECT_URI: string
   readonly VITE_API_BASE_URL: string
+  readonly VITE_ENVIRONMENT_NAME?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #169

## Summary
- build a production app shell with grouped tenant and operator navigation plus mobile drawer support
- add explicit role and tenant route guards, legacy-path redirects, and shell context surfaces
- add notification and status banner primitives with tests for routing, mobile navigation, and notification severity

## Validation
- `npm run test:quick --prefix spa`
- `npm run lint --prefix spa`
- `npm run build --prefix spa`
- `make validate-local`
- `make preflight-session`
- `make pre-validate-session`
