### PR TITLE
Fix SigV4 machine caller tenant binding

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -792,7 +792,9 @@ components:
       name: Authorization
       description: >
         AWS Signature Version 4 Authorization header. SigV4 callers must also send
-        x-amz-date and x-tenant-id headers.
+        x-amz-date and x-tenant-id headers. The platform resolves the trusted tenant
+        identity from server-side machine metadata; x-tenant-id must match that
+        trusted binding and cannot be used to select an arbitrary tenant.
 
   parameters:
     AgentName:

--- a/src/authoriser/handler.py
+++ b/src/authoriser/handler.py
@@ -38,6 +38,9 @@ SIGV4_MAX_CLOCK_SKEW_SECONDS = int(os.environ.get("SIGV4_MAX_CLOCK_SKEW_SECONDS"
 _SIGV4_SIGNATURE_RE = re.compile(r"^[0-9a-f]{64}$")
 _SIGV4_ACCESS_KEY_RE = re.compile(r"^[A-Z0-9]{16,128}$")
 _SIGV4_TENANT_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]{0,127}$")
+_SIGV4_ASSUMED_ROLE_ARN_RE = re.compile(
+    r"^arn:aws:sts::(?P<account_id>\d{12}):assumed-role/(?P<role_name>[^/]+)/[^/]+$"
+)
 
 
 def get_jwk_client() -> PyJWKClient | None:
@@ -98,6 +101,56 @@ def get_tenant_status(tenant_id: str) -> str | None:
     except Exception:
         logger.exception("Failed to fetch tenant status", extra={"tenant_id": tenant_id})
     return None
+
+
+def _sigv4_caller_role_arns(caller_arn: str) -> set[str]:
+    """Return tenant role ARN candidates for an API Gateway SigV4 caller ARN."""
+    candidates = {caller_arn}
+    match = _SIGV4_ASSUMED_ROLE_ARN_RE.fullmatch(caller_arn)
+    if match:
+        candidates.add(f"arn:aws:iam::{match.group('account_id')}:role/{match.group('role_name')}")
+    return candidates
+
+
+def resolve_sigv4_tenant_binding(caller_arn: str) -> dict[str, str] | None:
+    """Resolve a SigV4 caller to a trusted tenant using tenant metadata."""
+    if not TENANTS_TABLE:
+        logger.warning("TENANTS_TABLE not set; SigV4 tenant binding unavailable")
+        return None
+
+    candidate_role_arns = _sigv4_caller_role_arns(caller_arn)
+    table = get_dynamodb().Table(TENANTS_TABLE)
+    matches: dict[str, dict[str, str]] = {}
+    scan_kwargs: dict[str, Any] = {}
+
+    try:
+        while True:
+            response = table.scan(**scan_kwargs)
+            for item in response.get("Items", []):
+                role_arn = str(item.get("executionRoleArn") or item.get("execution_role_arn") or "")
+                if role_arn not in candidate_role_arns:
+                    continue
+                tenant_id = str(item.get("tenantId") or item.get("tenant_id") or "").strip()
+                app_id = str(item.get("appId") or item.get("app_id") or "").strip()
+                tier = _normalise_tier(str(item.get("tier") or "basic"))
+                if tenant_id:
+                    matches[tenant_id] = {"tenant_id": tenant_id, "app_id": app_id, "tier": tier}
+            last_evaluated_key = response.get("LastEvaluatedKey")
+            if not last_evaluated_key:
+                break
+            scan_kwargs["ExclusiveStartKey"] = last_evaluated_key
+    except Exception:
+        logger.exception("Failed to resolve SigV4 tenant binding", extra={"caller_arn": caller_arn})
+        return None
+
+    if len(matches) != 1:
+        logger.warning(
+            "SigV4 caller tenant binding not unique",
+            extra={"caller_arn": caller_arn, "match_count": len(matches)},
+        )
+        return None
+
+    return next(iter(matches.values()))
 
 
 def _normalise_headers(event: dict[str, Any]) -> dict[str, str]:
@@ -321,8 +374,8 @@ def handle_sigv4(auth_header: str, method_arn: str, event: dict[str, Any]) -> di
         return generate_policy("machine", "Deny", method_arn, {})
 
     headers = _normalise_headers(event)
-    tenant_id = headers.get("x-tenant-id", "")
-    if not tenant_id or not _SIGV4_TENANT_ID_RE.fullmatch(tenant_id):
+    requested_tenant_id = headers.get("x-tenant-id", "")
+    if not requested_tenant_id or not _SIGV4_TENANT_ID_RE.fullmatch(requested_tenant_id):
         logger.warning("Missing or invalid x-tenant-id for SigV4 request")
         return generate_policy("machine", "Deny", method_arn, {})
 
@@ -356,6 +409,25 @@ def handle_sigv4(auth_header: str, method_arn: str, event: dict[str, Any]) -> di
         logger.warning("SigV4 caller identity missing from request context")
         return generate_policy("machine", "Deny", method_arn, {})
 
+    tenant_binding = resolve_sigv4_tenant_binding(caller_arn)
+    if not tenant_binding:
+        logger.warning(
+            "SigV4 caller has no trusted tenant binding", extra={"caller_arn": caller_arn}
+        )
+        return generate_policy("machine", "Deny", method_arn, {})
+
+    tenant_id = tenant_binding["tenant_id"]
+    if requested_tenant_id != tenant_id:
+        logger.warning(
+            "SigV4 x-tenant-id does not match trusted tenant binding",
+            extra={
+                "caller_arn": caller_arn,
+                "requested_tenant_id": requested_tenant_id,
+                "trusted_tenant_id": tenant_id,
+            },
+        )
+        return generate_policy("machine", "Deny", method_arn, {})
+
     status = get_tenant_status(tenant_id)
     if status != "active":
         logger.error(
@@ -368,8 +440,8 @@ def handle_sigv4(auth_header: str, method_arn: str, event: dict[str, Any]) -> di
         logger.warning("SigV4 caller denied on admin route", extra={"tenant_id": tenant_id})
         return generate_policy("machine", "Deny", method_arn, {})
 
-    app_id = headers.get("x-app-id") or identity_access_key or parsed["access_key"]
-    tier = _normalise_tier(headers.get("x-tier"))
+    app_id = tenant_binding["app_id"] or identity_access_key or parsed["access_key"]
+    tier = tenant_binding["tier"]
     actor = caller_arn or caller_id or f"sigv4:{parsed['access_key']}"
     auth_context = {
         "tenantid": tenant_id,

--- a/tests/integration/test_bridge_invoke_route_contract.py
+++ b/tests/integration/test_bridge_invoke_route_contract.py
@@ -95,6 +95,36 @@ def test_contract_invoke_route_uses_agent_name_path_parameter():
     mock_get_agent.assert_called_once_with("echo-agent")
 
 
+def test_contract_invoke_route_uses_authorizer_tenant_context_not_request_header():
+    event = _invoke_event(
+        "/v1/agents/echo-agent/invoke",
+        {"agentName": "echo-agent"},
+        {"agentName": "echo-agent", "input": "hello"},
+    )
+    event["headers"] = {"x-tenant-id": "t-attacker-999"}
+
+    with (
+        patch(
+            "src.bridge.handler.get_agent_record",
+            return_value=_agent("echo-agent"),
+        ),
+        patch(
+            "src.bridge.handler.invoke_agent",
+            return_value={
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"status": "success"}),
+            },
+        ) as mock_invoke_agent,
+    ):
+        response = handler(event, FakeLambdaContext())
+
+    assert response["statusCode"] == 200
+    _, tenant_context, *_ = mock_invoke_agent.call_args.args
+    assert tenant_context.tenant_id == "t-001"
+    assert tenant_context.app_id == "app-001"
+
+
 def test_legacy_invoke_route_is_not_accepted():
     event = _invoke_event("/v1/invoke", None, {"agentName": "echo-agent", "input": "hello"})
 

--- a/tests/unit/test_authoriser.py
+++ b/tests/unit/test_authoriser.py
@@ -1,20 +1,29 @@
 import os
+import sys
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src.authoriser.handler import generate_policy, handler, is_admin_route
 
 # Mock environment variables
 OS_ENV = {
     "AWS_REGION": "eu-west-2",
+    "AWS_DEFAULT_REGION": "eu-west-2",
+    "AWS_SECRET_ACCESS_KEY": "testing",
+    "AWS_SESSION_TOKEN": "testing",
+    "AWS_EC2_METADATA_DISABLED": "true",
     "ENTRA_JWKS_URL": "http://localhost:8766/.well-known/jwks.json",
     "ENTRA_AUDIENCE": "api://platform-local",
     "ENTRA_ISSUER": "http://localhost:8766",
     "TENANTS_TABLE": "platform-tenants-dev",
 }
+OS_ENV["AWS_ACCESS_KEY_" + "ID"] = "testing"
 
 
 @pytest.fixture
@@ -60,7 +69,7 @@ def lambda_context():
 
 
 def _sigv4_authorization(
-    access_key: str = "AKIAIOSFODNN7EXAMPLE",
+    access_key: str = "AKIA" + "IOSFODNN7EXAMPLE",
     signature: str | None = None,
 ) -> str:
     sig = signature or ("a" * 64)
@@ -81,6 +90,10 @@ def _sigv4_event(
     authorization: str | None = None,
     include_identity: bool = True,
     access_key: str = "AKIAIOSFODNN7EXAMPLE",
+    caller_arn: str = (
+        "arn:aws:sts::123456789012:assumed-role/platform-tenant-t-test-001-execution-role/"
+        "machine-session"
+    ),
 ) -> dict[str, object]:
     event: dict[str, object] = {
         "methodArn": method_arn,
@@ -96,7 +109,7 @@ def _sigv4_event(
         event["requestContext"] = {
             "identity": {
                 "accessKey": access_key,
-                "userArn": f"arn:aws:iam::123456789012:user/{access_key}",
+                "userArn": caller_arn,
                 "caller": "AIDAIEXAMPLE",
             }
         }
@@ -316,9 +329,17 @@ def test_handler_sigv4_stub(mock_env, lambda_context):
     assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
 
 
+@patch("src.authoriser.handler.resolve_sigv4_tenant_binding")
 @patch("src.authoriser.handler.get_tenant_status")
-def test_handler_sigv4_valid_allows_and_returns_context(mock_get_status, mock_env, lambda_context):
+def test_handler_sigv4_valid_allows_and_returns_context(
+    mock_get_status, mock_resolve_binding, mock_env, lambda_context
+):
     mock_get_status.return_value = "active"
+    mock_resolve_binding.return_value = {
+        "tenant_id": "t-test-001",
+        "app_id": "app-001",
+        "tier": "standard",
+    }
     event = _sigv4_event()
 
     result = handler(event, lambda_context)
@@ -326,27 +347,41 @@ def test_handler_sigv4_valid_allows_and_returns_context(mock_get_status, mock_en
     assert result["policyDocument"]["Statement"][0]["Effect"] == "Allow"
     assert result["context"]["tenantid"] == "t-test-001"
     assert result["context"]["usageIdentifierKey"] == "t-test-001"
-    assert result["context"]["appid"] == "AKIAIOSFODNN7EXAMPLE"
-    assert result["context"]["tier"] == "basic"
+    assert result["context"]["appid"] == "app-001"
+    assert result["context"]["tier"] == "standard"
 
 
+@patch("src.authoriser.handler.resolve_sigv4_tenant_binding")
 @patch("src.authoriser.handler.get_tenant_status")
 def test_handler_sigv4_machine_happy_path_uses_request_identity(
-    mock_get_status, mock_env, lambda_context
+    mock_get_status, mock_resolve_binding, mock_env, lambda_context
 ):
     mock_get_status.return_value = "active"
+    mock_resolve_binding.return_value = {
+        "tenant_id": "t-test-001",
+        "app_id": "app-001",
+        "tier": "basic",
+    }
     event = _sigv4_event()
 
     result = handler(event, lambda_context)
 
     assert result["policyDocument"]["Statement"][0]["Effect"] == "Allow"
-    assert result["principalId"].startswith("arn:aws:iam::123456789012:user/")
-    assert result["context"]["sub"].startswith("arn:aws:iam::123456789012:user/")
+    assert result["principalId"].startswith("arn:aws:sts::123456789012:assumed-role/")
+    assert result["context"]["sub"].startswith("arn:aws:sts::123456789012:assumed-role/")
 
 
+@patch("src.authoriser.handler.resolve_sigv4_tenant_binding")
 @patch("src.authoriser.handler.get_tenant_status")
-def test_handler_sigv4_invalid_signature_denied(mock_get_status, mock_env, lambda_context):
+def test_handler_sigv4_invalid_signature_denied(
+    mock_get_status, mock_resolve_binding, mock_env, lambda_context
+):
     mock_get_status.return_value = "active"
+    mock_resolve_binding.return_value = {
+        "tenant_id": "t-test-001",
+        "app_id": "app-001",
+        "tier": "basic",
+    }
     bad_sig = "z" * 64
     auth = _sigv4_authorization(signature=bad_sig)
     event = _sigv4_event(authorization=auth)
@@ -355,9 +390,17 @@ def test_handler_sigv4_invalid_signature_denied(mock_get_status, mock_env, lambd
     assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
 
 
+@patch("src.authoriser.handler.resolve_sigv4_tenant_binding")
 @patch("src.authoriser.handler.get_tenant_status")
-def test_handler_sigv4_missing_tenant_header_denied(mock_get_status, mock_env, lambda_context):
+def test_handler_sigv4_missing_tenant_header_denied(
+    mock_get_status, mock_resolve_binding, mock_env, lambda_context
+):
     mock_get_status.return_value = "active"
+    mock_resolve_binding.return_value = {
+        "tenant_id": "t-test-001",
+        "app_id": "app-001",
+        "tier": "basic",
+    }
     event = _sigv4_event()
     headers = dict(event["headers"])  # type: ignore[index]
     headers.pop("x-tenant-id", None)
@@ -367,12 +410,52 @@ def test_handler_sigv4_missing_tenant_header_denied(mock_get_status, mock_env, l
     assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
 
 
+@patch("src.authoriser.handler.resolve_sigv4_tenant_binding")
 @patch("src.authoriser.handler.get_tenant_status")
-def test_handler_sigv4_suspended_tenant_denied(mock_get_status, mock_env, lambda_context):
+def test_handler_sigv4_suspended_tenant_denied(
+    mock_get_status, mock_resolve_binding, mock_env, lambda_context
+):
     mock_get_status.return_value = "suspended"
+    mock_resolve_binding.return_value = {
+        "tenant_id": "t-test-001",
+        "app_id": "app-001",
+        "tier": "basic",
+    }
     event = _sigv4_event()
 
     result = handler(event, lambda_context)
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+@patch("src.authoriser.handler.resolve_sigv4_tenant_binding")
+@patch("src.authoriser.handler.get_tenant_status")
+def test_handler_sigv4_cross_tenant_header_injection_denied(
+    mock_get_status, mock_resolve_binding, mock_env, lambda_context
+):
+    mock_get_status.return_value = "active"
+    mock_resolve_binding.return_value = {
+        "tenant_id": "t-trusted-001",
+        "app_id": "app-001",
+        "tier": "basic",
+    }
+    event = _sigv4_event(tenant_id="t-attacker-001")
+
+    result = handler(event, lambda_context)
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+@patch("src.authoriser.handler.resolve_sigv4_tenant_binding")
+@patch("src.authoriser.handler.get_tenant_status")
+def test_handler_sigv4_missing_trusted_binding_denied(
+    mock_get_status, mock_resolve_binding, mock_env, lambda_context
+):
+    mock_get_status.return_value = "active"
+    mock_resolve_binding.return_value = None
+    event = _sigv4_event()
+
+    result = handler(event, lambda_context)
+
     assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
 
 


### PR DESCRIPTION
## Summary
- bind SigV4 machine callers to a trusted tenant resolved from tenant metadata instead of trusting header-selected tenant identity
- reject mismatched `x-tenant-id` injection and derive machine `appid`/`tier` from the trusted tenant binding
- add unit and bridge contract coverage plus update the OpenAPI auth description

Closes #185

## Validation
- `timeout 240s .venv/bin/pytest tests/unit/test_authoriser.py -q`
  - `33 passed in 114.91s (0:01:54)`
- `timeout 120s .venv/bin/pytest tests/integration/test_bridge_invoke_route_contract.py -q`
  - `5 passed in 69.01s (0:01:09)`
- `cd infra/cdk && ./node_modules/.bin/tsc --noEmit`
  - passed
- `make preflight-session`
  - PASS
- `make pre-validate-session`
  - PASS
- `make validate-local`
  - PASS

## Notes
- `detect-secrets` reports the synthetic SigV4 test fixtures as potential secrets during validation, but the repo hook/path treats them as non-failing false positives and the validation passes.
