### PR TITLE
Fix hardcoded eu-west-2 Lambda fallbacks

### DIFF
--- a/src/authoriser/handler.py
+++ b/src/authoriser/handler.py
@@ -40,6 +40,10 @@ _SIGV4_ACCESS_KEY_RE = re.compile(r"^[A-Z0-9]{16,128}$")
 _SIGV4_TENANT_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]{0,127}$")
 
 
+def _aws_region() -> str:
+    return os.environ["AWS_REGION"]
+
+
 def get_jwk_client() -> PyJWKClient | None:
     """Lazy initialization of PyJWKClient."""
     global _jwk_client
@@ -53,8 +57,7 @@ def get_dynamodb():
     """Lazy initialization of boto3 resource."""
     global _dynamodb_resource
     if _dynamodb_resource is None:
-        region = os.environ.get("AWS_REGION", "eu-west-2")
-        _dynamodb_resource = boto3.resource("dynamodb", region_name=region)
+        _dynamodb_resource = boto3.resource("dynamodb", region_name=_aws_region())
     return _dynamodb_resource
 
 

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -97,27 +97,28 @@ _config_cache: dict[str, Any] = {}
 _config_cache_expiry: float = 0
 
 
+def _aws_region() -> str:
+    return os.environ["AWS_REGION"]
+
+
 def get_ssm():
     global _ssm_client
     if _ssm_client is None:
-        region = os.environ.get("AWS_REGION", "eu-west-2")
-        _ssm_client = boto3.client("ssm", region_name=region)
+        _ssm_client = boto3.client("ssm", region_name=_aws_region())
     return _ssm_client
 
 
 def get_sts():
     global _sts_client
     if _sts_client is None:
-        region = os.environ.get("AWS_REGION", "eu-west-2")
-        _sts_client = boto3.client("sts", region_name=region)
+        _sts_client = boto3.client("sts", region_name=_aws_region())
     return _sts_client
 
 
 def get_dynamodb():
     global _dynamodb_resource
     if _dynamodb_resource is None:
-        region = os.environ.get("AWS_REGION", "eu-west-2")
-        _dynamodb_resource = boto3.resource("dynamodb", region_name=region)
+        _dynamodb_resource = boto3.resource("dynamodb", region_name=_aws_region())
     return _dynamodb_resource
 
 

--- a/tests/unit/test_authoriser.py
+++ b/tests/unit/test_authoriser.py
@@ -457,6 +457,16 @@ def test_get_dynamodb_logic(mock_env):
         assert db is not None
 
 
+def test_get_dynamodb_requires_aws_region(mock_env, monkeypatch):
+    from src.authoriser.handler import get_dynamodb
+
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch("src.authoriser.handler._dynamodb_resource", None):
+        with pytest.raises(KeyError, match="AWS_REGION"):
+            get_dynamodb()
+
+
 def test_get_tenant_status_no_table(mock_env):
     from src.authoriser.handler import get_tenant_status
 

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -748,6 +748,24 @@ def test_get_job_status_hides_other_tenants_job(setup_data):
     assert body["error"]["code"] == "NOT_FOUND"
 
 
+def test_client_initializers_require_aws_region(monkeypatch):
+    import src.bridge.handler as bridge_module
+
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with (
+        patch("src.bridge.handler._ssm_client", None),
+        patch("src.bridge.handler._sts_client", None),
+        patch("src.bridge.handler._dynamodb_resource", None),
+    ):
+        with pytest.raises(KeyError, match="AWS_REGION"):
+            bridge_module.get_ssm()
+        with pytest.raises(KeyError, match="AWS_REGION"):
+            bridge_module.get_sts()
+        with pytest.raises(KeyError, match="AWS_REGION"):
+            bridge_module.get_dynamodb()
+
+
 def test_register_and_delete_webhook(setup_data):
     ddb = boto3.resource("dynamodb", region_name="eu-west-2")
     jobs_table = ddb.Table("platform-jobs")


### PR DESCRIPTION
## Summary
- require `AWS_REGION` for bridge and authoriser boto3 client initialization instead of silently defaulting to `eu-west-2`
- add focused regression tests covering missing-`AWS_REGION` behavior in both handlers
- keep scope limited to Lambda application code for issue #188

## Validation
- `make preflight-session` PASS
- `make pre-validate-session` PASS
- pre-push hook PASS during `git push -u origin wt/task/188-remove-hardcoded-eu-west-2-runtime-fallbacks-from-lambda-cod`
- `npx gitnexus analyze` run after commit per repo policy

## Notes
- `detect-secrets` emitted the existing false positive on `tests/unit/test_authoriser.py:63` and still passed
- GitNexus MCP transport was unavailable for `impact` and `detect_changes`, so local caller analysis was used for blast-radius confirmation

Closes #188
