### PR TITLE
TASK-186: stop tenant-api fallback dispatch on unsupported subpaths

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -339,3 +339,100 @@ git worktree prune
 | Config             | SSM Parameter Store             |
 | Async agents       | AgentCore add_async_task SDK    |
 | Observability      | AgentCore Observability + CW    |
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **tf-acore-aas** (2050 symbols, 6290 relationships, 165 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After every local `git commit` and after every merge into your working branch, the GitNexus index becomes stale. Re-run analyze to update it immediately:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+This is mandatory. Do not assume a local hook or client automation exists; if you make a commit or complete a merge, run the appropriate `gitnexus analyze` command yourself before continuing.
+
+## CLI
+
+- Re-index: `npx gitnexus analyze`
+- Check freshness: `npx gitnexus status`
+- Generate docs: `npx gitnexus wiki`
+
+<!-- gitnexus:end -->

--- a/ai-context/GEMINI.md
+++ b/ai-context/GEMINI.md
@@ -339,3 +339,100 @@ git worktree prune
 | Config             | SSM Parameter Store             |
 | Async agents       | AgentCore add_async_task SDK    |
 | Observability      | AgentCore Observability + CW    |
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **tf-acore-aas** (2050 symbols, 6290 relationships, 165 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After every local `git commit` and after every merge into your working branch, the GitNexus index becomes stale. Re-run analyze to update it immediately:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+This is mandatory. Do not assume a local hook or client automation exists; if you make a commit or complete a merge, run the appropriate `gitnexus analyze` command yourself before continuing.
+
+## CLI
+
+- Re-index: `npx gitnexus analyze`
+- Check freshness: `npx gitnexus status`
+- Generate docs: `npx gitnexus wiki`
+
+<!-- gitnexus:end -->

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -1758,41 +1758,52 @@ def _dispatch_ops_routes(
     caller: CallerIdentity,
     deps: TenantApiDependencies,
 ) -> dict[str, Any] | None:
-    if not path.startswith("/v1/platform/ops/"):
+    path_lower = path.lower()
+    if not path_lower.startswith("/v1/platform/ops/"):
         return None
 
     _require_admin(caller)
-    if path == "/v1/platform/ops/top-tenants" and method == "GET":
+    if path_lower == "/v1/platform/ops/top-tenants" and method == "GET":
         return _handle_ops_top_tenants(event, caller, deps)
-    if path == "/v1/platform/ops/security-events" and method == "GET":
+    if path_lower == "/v1/platform/ops/security-events" and method == "GET":
         return _handle_ops_security_events(event, caller, deps)
-    if path == "/v1/platform/ops/error-rate" and method == "GET":
+    if path_lower == "/v1/platform/ops/error-rate" and method == "GET":
         return _handle_ops_error_rate(event, caller, deps)
-    if path.startswith("/v1/platform/ops/dlq/"):
-        if path.endswith("/redrive") and method == "POST":
-            queue_name = path.split("/")[-2]
-            return _handle_ops_dlq_redrive(caller, deps, queue_name=queue_name)
-        if method == "GET":
-            queue_name = path.split("/")[-1]
+
+    parts = path.split("/")
+    if path_lower.startswith("/v1/platform/ops/dlq/"):
+        # Expected: /v1/platform/ops/dlq/{queueName} (len 6)
+        # or /v1/platform/ops/dlq/{queueName}/redrive (len 7)
+        if len(parts) == 6 and method == "GET":
+            queue_name = parts[5]
             return _handle_ops_dlq_inspect(caller, deps, queue_name=queue_name)
+        if len(parts) == 7 and parts[6].lower() == "redrive" and method == "POST":
+            queue_name = parts[5]
+            return _handle_ops_dlq_redrive(caller, deps, queue_name=queue_name)
 
-    if path.startswith("/v1/platform/ops/tenants/"):
-        tenant_id = path.split("/")[-2]
-        if path.endswith("/sessions") and method == "GET":
-            return _handle_ops_tenant_sessions(caller, deps, tenant_id=tenant_id)
-        if path.endswith("/suspend") and method == "POST":
-            return _handle_ops_suspend_tenant(event, caller, deps, tenant_id=tenant_id)
-        if path.endswith("/reinstate") and method == "POST":
-            return _handle_ops_reinstate_tenant(caller, deps, tenant_id=tenant_id)
-        if path.endswith("/invocations") and method == "GET":
-            return _handle_ops_invocation_report(event, caller, deps, tenant_id=tenant_id)
-        if path.endswith("/notify") and method == "POST":
-            return _handle_ops_notify_tenant(event, caller, deps, tenant_id=tenant_id)
+    if path_lower.startswith("/v1/platform/ops/tenants/"):
+        # Expected: /v1/platform/ops/tenants/{tenantId}/{subpath} (len 7)
+        if len(parts) == 7:
+            tenant_id = parts[5]
+            subpath = parts[6].lower()
+            if subpath == "sessions" and method == "GET":
+                return _handle_ops_tenant_sessions(caller, deps, tenant_id=tenant_id)
+            if subpath == "suspend" and method == "POST":
+                return _handle_ops_suspend_tenant(event, caller, deps, tenant_id=tenant_id)
+            if subpath == "reinstate" and method == "POST":
+                return _handle_ops_reinstate_tenant(caller, deps, tenant_id=tenant_id)
+            if subpath == "invocations" and method == "GET":
+                return _handle_ops_invocation_report(event, caller, deps, tenant_id=tenant_id)
+            if subpath == "notify" and method == "POST":
+                return _handle_ops_notify_tenant(event, caller, deps, tenant_id=tenant_id)
 
-    if path.startswith("/v1/platform/ops/jobs/") and path.endswith("/fail") and method == "POST":
-        job_id = path.split("/")[-2]
-        return _handle_ops_fail_job(event, caller, deps, job_id=job_id)
-    if path == "/v1/platform/ops/security/page" and method == "POST":
+    if path_lower.startswith("/v1/platform/ops/jobs/"):
+        # Expected: /v1/platform/ops/jobs/{jobId}/fail (len 7)
+        if len(parts) == 7 and parts[6].lower() == "fail" and method == "POST":
+            job_id = parts[5]
+            return _handle_ops_fail_job(event, caller, deps, job_id=job_id)
+
+    if path_lower == "/v1/platform/ops/security/page" and method == "POST":
         return _handle_ops_page_security(event, caller, deps)
 
     return None
@@ -1805,7 +1816,8 @@ def _dispatch_webhook_routes(
     caller: CallerIdentity,
     deps: TenantApiDependencies,
 ) -> dict[str, Any] | None:
-    if path == "/v1/webhooks":
+    path_lower = path.lower()
+    if path_lower == "/v1/webhooks":
         if caller.tenant_id is None:
             return _error(400, "BAD_REQUEST", "tenant context required")
         if method == "GET":
@@ -1813,13 +1825,15 @@ def _dispatch_webhook_routes(
         if method == "POST":
             return _handle_register_webhook(event, caller, deps, tenant_id=caller.tenant_id)
 
-    if path.startswith("/v1/webhooks/") and method == "DELETE":
-        if caller.tenant_id is None:
-            return _error(400, "BAD_REQUEST", "tenant context required")
-        webhook_id = path.split("/")[-1]
-        return _handle_delete_webhook(
-            caller, deps, tenant_id=caller.tenant_id, webhook_id=webhook_id
-        )
+    if path_lower.startswith("/v1/webhooks/") and method == "DELETE":
+        parts = path.split("/")
+        if len(parts) == 4:  # /v1/webhooks/{webhookId}
+            if caller.tenant_id is None:
+                return _error(400, "BAD_REQUEST", "tenant context required")
+            webhook_id = parts[3]
+            return _handle_delete_webhook(
+                caller, deps, tenant_id=caller.tenant_id, webhook_id=webhook_id
+            )
 
     return None
 
@@ -1832,28 +1846,31 @@ def _dispatch_tenant_routes(
     deps: TenantApiDependencies,
     tenant_id: str | None,
 ) -> dict[str, Any] | None:
-    if path == "/v1/tenants":
+    path_lower = path.lower()
+    if path_lower == "/v1/tenants":
         if method == "POST":
             return _handle_create(event, caller, deps)
         if method == "GET":
             return _handle_list(event, caller, deps)
 
     if tenant_id is not None:
-        if path.endswith("/api-key/rotate") and method == "POST":
+        tenant_base = f"/v1/tenants/{tenant_id}"
+        if path_lower == f"{tenant_base}/api-key/rotate" and method == "POST":
             return _handle_rotate_api_key(caller, deps, tenant_id=tenant_id)
-        if path.endswith("/users/invites") and method == "GET":
+        if path_lower == f"{tenant_base}/users/invites" and method == "GET":
             return _handle_list_invites(caller, deps, tenant_id=tenant_id)
-        if path.endswith("/users/invite") and method == "POST":
+        if path_lower == f"{tenant_base}/users/invite" and method == "POST":
             return _handle_invite_user(event, caller, deps, tenant_id=tenant_id)
-        if path.endswith("/audit-export") and method == "GET":
+        if path_lower == f"{tenant_base}/audit-export" and method == "GET":
             return _handle_audit_export(event, caller, deps, tenant_id=tenant_id)
 
-        if method == "GET":
-            return _handle_read(event, caller, deps, tenant_id=tenant_id)
-        if method in {"PATCH", "PUT"}:
-            return _handle_update(event, caller, deps, tenant_id=tenant_id)
-        if method == "DELETE":
-            return _handle_delete(caller, deps, tenant_id=tenant_id)
+        if path_lower == tenant_base:
+            if method == "GET":
+                return _handle_read(event, caller, deps, tenant_id=tenant_id)
+            if method in {"PATCH", "PUT"}:
+                return _handle_update(event, caller, deps, tenant_id=tenant_id)
+            if method == "DELETE":
+                return _handle_delete(caller, deps, tenant_id=tenant_id)
 
     return None
 


### PR DESCRIPTION
Fixed a bug in tenant-api where it would fall back to default handlers (read/update/delete) for unsupported subpaths. Implemented strict path matching in _dispatch_tenant_routes, _dispatch_webhook_routes, and _dispatch_ops_routes. Sync'd CLAUDE.md/GEMINI.md to include GitNexus blocks.