### PR TITLE
Restrict BFF token refresh audiences and scopes

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -715,7 +715,8 @@ paths:
       operationId: refreshBffToken
       summary: Refresh SPA scoped token
       description: >
-        Thin BFF endpoint for Entra on-behalf-of token exchange. Does not invoke agents.
+        Thin BFF endpoint for Entra on-behalf-of token exchange using approved platform API
+        delegated scopes only. Does not invoke agents.
       security:
         - BearerAuth: []
       requestBody:
@@ -1446,10 +1447,8 @@ components:
           minItems: 1
           items:
             type: string
-        sessionId:
-          type: [string, "null"]
-        audience:
-          type: [string, "null"]
+            pattern: "^api://[A-Za-z0-9-]+/[A-Za-z][A-Za-z0-9._-]{0,127}$"
+          description: Approved platform delegated scopes only; `/.default` and non-platform audiences are rejected.
 
     BffTokenRefreshResponse:
       type: object

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -268,6 +268,7 @@ export class PlatformStack extends cdk.Stack {
       memorySize: 512,
       environment: {
         POWERTOOLS_SERVICE_NAME: 'bff',
+        ENTRA_AUDIENCE: 'platform-api',
       },
     });
 

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -364,4 +364,16 @@ describe('PlatformStack (TASK-023)', () => {
 
     expect(names.some((name) => name.includes('async-runner'))).toBe(false);
   });
+
+  test('configures the BFF lambda with the approved Entra audience', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'platform-core-dev-bff',
+      Environment: {
+        Variables: Match.objectLike({
+          ENTRA_AUDIENCE: 'platform-api',
+          POWERTOOLS_SERVICE_NAME: 'bff',
+        }),
+      },
+    });
+  });
 });

--- a/spa/src/api/contracts.ts
+++ b/spa/src/api/contracts.ts
@@ -173,7 +173,6 @@ export type HealthResponseDto = {
 
 export type BffTokenRefreshRequestDto = {
   scopes: string[];
-  audience?: string | null;
 };
 
 export type BffTokenRefreshResponseDto = {

--- a/src/bff/handler.py
+++ b/src/bff/handler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -32,9 +33,11 @@ ENTRA_CLIENT_ID = os.environ.get("ENTRA_CLIENT_ID")
 ENTRA_CLIENT_SECRET = os.environ.get("ENTRA_CLIENT_SECRET")
 ENTRA_TENANT_ID = os.environ.get("ENTRA_TENANT_ID", "common")
 ENTRA_TOKEN_ENDPOINT = os.environ.get("ENTRA_TOKEN_ENDPOINT")
+ENTRA_AUDIENCE = os.environ.get("ENTRA_AUDIENCE")
 RUNTIME_PING_URL = os.environ.get("RUNTIME_PING_URL") or os.environ.get("MOCK_RUNTIME_URL")
 RUNTIME_KEEPALIVE_WINDOW_SECONDS = 15 * 60
 RUNTIME_PING_TIMEOUT_SECONDS = 2.0
+_ALLOWED_SCOPE_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._-]{0,127}$")
 
 
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
@@ -98,12 +101,23 @@ def _handle_token_refresh(event: dict[str, Any], *, request_id: str) -> dict[str
         )
 
     audience = _str_or_none(body.get("audience"))
+    if audience is not None:
+        return _error_response(
+            400,
+            "INVALID_REQUEST",
+            "audience is not supported; request only approved platform scopes",
+            request_id,
+        )
+
+    try:
+        approved_scopes = _validate_refresh_scopes(scopes)
+    except ValueError as exc:
+        return _error_response(400, "INVALID_REQUEST", str(exc), request_id)
 
     try:
         token_payload = _exchange_obo_token(
             assertion_token=access_token,
-            scopes=scopes,
-            audience=audience,
+            scopes=approved_scopes,
         )
     except ValueError as exc:
         return _error_response(503, "SERVICE_UNAVAILABLE", str(exc), request_id)
@@ -142,7 +156,7 @@ def _handle_token_refresh(event: dict[str, Any], *, request_id: str) -> dict[str
             request_id,
         )
 
-    scope = _str_or_none(token_payload.get("scope")) or " ".join(scopes)
+    scope = _str_or_none(token_payload.get("scope")) or " ".join(approved_scopes)
 
     return _response(
         200,
@@ -216,22 +230,36 @@ def _exchange_obo_token(
     *,
     assertion_token: str,
     scopes: list[str],
-    audience: str | None,
 ) -> dict[str, Any]:
     endpoint = _entra_token_endpoint()
-    scope_value = " ".join(scopes)
-    if audience and all(not scope.startswith(f"{audience}/") for scope in scopes):
-        scope_value = f"{scope_value} {audience}/.default".strip()
-
     params = {
         "client_id": _required_env_value("ENTRA_CLIENT_ID", ENTRA_CLIENT_ID),
         "client_secret": _required_env_value("ENTRA_CLIENT_SECRET", ENTRA_CLIENT_SECRET),
         "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
         "requested_token_use": "on_behalf_of",
         "assertion": assertion_token,
-        "scope": scope_value,
+        "scope": " ".join(scopes),
     }
     return _http_post_form(endpoint, params)
+
+
+def _validate_refresh_scopes(scopes: list[str]) -> list[str]:
+    approved_audience = _required_env_value("ENTRA_AUDIENCE", ENTRA_AUDIENCE)
+    approved_prefix = f"{approved_audience}/"
+    validated: list[str] = []
+
+    for scope in scopes:
+        if not scope.startswith(approved_prefix):
+            raise ValueError("scopes must target the approved platform audience")
+
+        scope_name = scope.removeprefix(approved_prefix)
+        if scope_name == ".default":
+            raise ValueError("scopes must not request /.default")
+        if not _ALLOWED_SCOPE_NAME_RE.fullmatch(scope_name):
+            raise ValueError(f"scope '{scope}' is not an approved platform scope")
+        validated.append(scope)
+
+    return validated
 
 
 def _ping_runtime_session(*, tenant_id: str, app_id: str, session_id: str, agent_name: str) -> None:

--- a/tests/unit/test_bff_handler.py
+++ b/tests/unit/test_bff_handler.py
@@ -56,6 +56,7 @@ def reset_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(bff_handler, "ENTRA_CLIENT_SECRET", "client-secret")
     monkeypatch.setattr(bff_handler, "ENTRA_TENANT_ID", "tenant-guid")
     monkeypatch.setattr(bff_handler, "ENTRA_TOKEN_ENDPOINT", None)
+    monkeypatch.setattr(bff_handler, "ENTRA_AUDIENCE", "api://platform-dev")
     monkeypatch.setattr(bff_handler, "RUNTIME_PING_URL", "http://localhost:8765")
 
 
@@ -95,68 +96,67 @@ def test_token_refresh_success() -> None:
     exchange.assert_called_once_with(
         assertion_token="incoming-user-token",
         scopes=["api://platform-dev/Agent.Invoke"],
-        audience=None,
     )
 
 
-def test_token_refresh_with_audience_success() -> None:
+def test_token_refresh_rejects_explicit_audience() -> None:
     event = _event(
         path="/v1/bff/token-refresh",
         body={
             "scopes": ["api://platform-dev/Agent.Invoke"],
-            "audience": "https://api.example.com",
+            "audience": "api://platform-dev",
         },
         headers={"Authorization": "Bearer incoming-user-token"},
     )
 
-    with patch.object(
-        bff_handler,
-        "_exchange_obo_token",
-        return_value={
-            "access_token": "new-token-with-aud",
-            "token_type": "Bearer",
-            "expires_in": 3600,
-        },
-    ) as exchange:
-        response = bff_handler.handler(event, FakeContext())
+    response = bff_handler.handler(event, FakeContext())
 
-    assert response["statusCode"] == 200
-    payload = _body(response)
-    assert payload["accessToken"] == "new-token-with-aud"
+    assert response["statusCode"] == 400
+    error = _body(response)["error"]
+    assert error["code"] == "INVALID_REQUEST"
+    assert "audience is not supported" in str(error["message"])
 
-    exchange.assert_called_once_with(
-        assertion_token="incoming-user-token",
-        scopes=["api://platform-dev/Agent.Invoke"],
-        audience="https://api.example.com",
+
+def test_exchange_obo_token_uses_only_approved_scopes() -> None:
+    with patch.object(bff_handler, "_http_post_form") as http_post:
+        bff_handler._exchange_obo_token(
+            assertion_token="some-token",
+            scopes=["api://platform-dev/Agent.Invoke"],
+        )
+
+    http_post.assert_called_once()
+    _, params = http_post.call_args[0]
+    assert params["scope"] == "api://platform-dev/Agent.Invoke"
+
+
+def test_token_refresh_rejects_scope_outside_platform_audience() -> None:
+    event = _event(
+        path="/v1/bff/token-refresh",
+        body={"scopes": ["User.Read"]},
+        headers={"Authorization": "Bearer incoming-user-token"},
     )
 
+    response = bff_handler.handler(event, FakeContext())
 
-def test_exchange_obo_token_adds_default_scope_for_audience() -> None:
-    with patch.object(bff_handler, "_http_post_form") as http_post:
-        bff_handler._exchange_obo_token(
-            assertion_token="some-token",
-            scopes=["user.read"],
-            audience="api://another-app",
-        )
-
-    http_post.assert_called_once()
-    _, params = http_post.call_args[0]
-    # Should include both user.read and api://another-app/.default
-    assert params["scope"] == "user.read api://another-app/.default"
+    assert response["statusCode"] == 400
+    error = _body(response)["error"]
+    assert error["code"] == "INVALID_REQUEST"
+    assert "approved platform audience" in str(error["message"])
 
 
-def test_exchange_obo_token_skips_default_if_already_scoped() -> None:
-    with patch.object(bff_handler, "_http_post_form") as http_post:
-        bff_handler._exchange_obo_token(
-            assertion_token="some-token",
-            scopes=["api://another-app/User.Read"],
-            audience="api://another-app",
-        )
+def test_token_refresh_rejects_default_scope_requests() -> None:
+    event = _event(
+        path="/v1/bff/token-refresh",
+        body={"scopes": ["api://platform-dev/.default"]},
+        headers={"Authorization": "Bearer incoming-user-token"},
+    )
 
-    http_post.assert_called_once()
-    _, params = http_post.call_args[0]
-    # Should NOT add /.default since a scope starting with audience is already there
-    assert params["scope"] == "api://another-app/User.Read"
+    response = bff_handler.handler(event, FakeContext())
+
+    assert response["statusCode"] == 400
+    error = _body(response)["error"]
+    assert error["code"] == "INVALID_REQUEST"
+    assert "/.default" in str(error["message"])
 
 
 def test_token_refresh_requires_authorization_header() -> None:

--- a/tests/unit/test_openapi_contract_routes.py
+++ b/tests/unit/test_openapi_contract_routes.py
@@ -55,3 +55,15 @@ def test_openapi_tenant_id_contract_is_deterministic_and_env_safe() -> None:
     )
     tenant_id_schema = tenant_create_schema.get("tenantId", {})
     assert tenant_id_schema.get("pattern") == "^[a-z](?:[a-z0-9-]{1,30}[a-z0-9])$"
+
+
+def test_openapi_bff_token_refresh_contract_restricts_to_platform_scopes() -> None:
+    spec = _load_openapi()
+    schema = spec.get("components", {}).get("schemas", {}).get("BffTokenRefreshRequest", {})
+    properties = schema.get("properties", {})
+
+    assert schema.get("required") == ["scopes"]
+    assert "audience" not in properties
+    assert "sessionId" not in properties
+    scope_items = properties.get("scopes", {}).get("items", {})
+    assert scope_items.get("pattern") == "^api://[A-Za-z0-9-]+/[A-Za-z][A-Za-z0-9._-]{0,127}$"


### PR DESCRIPTION
Closes #191.

## Summary
- restrict BFF token refresh to approved platform API scopes only
- reject explicit `audience` requests and block `/.default` expansion
- align OpenAPI, SPA request contracts, and CDK env wiring with the tightened policy

## Validation
- `UV_PROJECT_ENVIRONMENT=/tmp/wt191-venv uv run pytest tests/unit/test_bff_handler.py tests/unit/test_openapi_contract_routes.py`
- `VITE_ENTRA_CLIENT_ID=test-client-id VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/test-tenant-id VITE_ENTRA_SCOPES=api://platform-dev/Agent.Invoke VITE_ENTRA_REDIRECT_URI=http://localhost:3000 VITE_ENTRA_POST_LOGOUT_REDIRECT_URI=http://localhost:3000 VITE_API_BASE_URL=https://api.example.test npx vitest run src/api/openapiContract.test.ts src/auth/AuthProvider.test.ts src/api/client.test.ts` in `/tmp/wt191-spa-run/spa`
- `npm test -- --runInBand platform-stack` in `/tmp/wt191-repo/infra/cdk`
- `make preflight-session`
- `make pre-validate-session`

## Notes
- The worktree is on a full `/mnt/c` volume, so transient Python/Node caches were redirected to `/tmp` for validation.
- GitNexus `impact`/`detect_changes` MCP calls were attempted but the transport was unavailable during this task.
