### PR TITLE
Fix agent catalog pagination across scan pages

### DIFF
--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -935,9 +935,16 @@ def _is_newer_agent_record(candidate: dict[str, Any], current: dict[str, Any]) -
 
 
 def list_agents(tenant_context: TenantContext) -> dict[str, Any]:
-    ddb = get_dynamodb()
-    table = ddb.Table(AGENTS_TABLE)
-    items = table.scan().get("Items", [])
+    db = TenantScopedDynamoDB(tenant_context)
+
+    items: list[dict[str, Any]] = []
+    exclusive_start_key = None
+    while True:
+        page = db.scan(AGENTS_TABLE, exclusive_start_key=exclusive_start_key)
+        items.extend(page.items)
+        exclusive_start_key = page.last_evaluated_key
+        if not exclusive_start_key:
+            break
 
     latest_by_name: dict[str, dict[str, Any]] = {}
     for item in items:

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -189,6 +189,61 @@ def test_list_agents_returns_openapi_shape_and_tier_filtered(setup_data):
     assert body["items"][0]["latestVersion"] == "1.0.0"
 
 
+def test_list_agents_handles_multiple_scan_pages(setup_data):
+    from data_access.models import PaginatedItems
+
+    # Mock TenantScopedDynamoDB.scan to return two pages
+    mock_db = MagicMock()
+    mock_db.scan.side_effect = [
+        PaginatedItems(
+            items=[
+                {
+                    "agent_name": "agent-1",
+                    "version": "1.0.0",
+                    "tier_minimum": "basic",
+                    "deployed_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+            last_evaluated_key={"PK": "AGENT#agent-1", "SK": "VERSION#1.0.0"},
+        ),
+        PaginatedItems(
+            items=[
+                {
+                    "agent_name": "agent-2",
+                    "version": "1.0.0",
+                    "tier_minimum": "basic",
+                    "deployed_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+            last_evaluated_key=None,
+        ),
+    ]
+
+    with patch("src.bridge.handler.TenantScopedDynamoDB", return_value=mock_db):
+        event = {
+            "httpMethod": "GET",
+            "path": "/v1/agents",
+            "pathParameters": {},
+            "requestContext": {
+                "authorizer": {
+                    "tenantid": "t-001",
+                    "appid": "app-001",
+                    "tier": "basic",
+                    "sub": "user-1",
+                }
+            },
+        }
+
+        response = handler(event, FakeLambdaContext())
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+
+        agent_names = [item["agentName"] for item in body["items"]]
+        assert "agent-1" in agent_names
+        assert "agent-2" in agent_names
+        assert mock_db.scan.call_count == 2
+
+
 def test_get_agent_detail_returns_latest_version_and_versions(setup_data):
     ddb = boto3.resource("dynamodb", region_name="eu-west-2")
     table = ddb.Table("platform-agents")


### PR DESCRIPTION
## Summary
- paginate agent catalog scans until DynamoDB returns no last evaluated key
- switch list_agents to TenantScopedDynamoDB scanning rather than a single raw table scan
- add unit coverage for multi-page catalog results

## Validation
- make preflight-session
- make pre-validate-session
- make validate-local

Closes #189