### PR TITLE
Fix split-accounts AWS account ID validation

### DIFF
--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -46,6 +46,7 @@ _AUDIT_EXPORT_PAGE_SIZE = 200
 _TENANT_ID_MIN_LENGTH = 3
 _TENANT_ID_MAX_LENGTH = 32
 _TENANT_ID_PATTERN = re.compile(r"^[a-z](?:[a-z0-9-]{1,30}[a-z0-9])$")
+_AWS_ACCOUNT_ID_PATTERN = re.compile(r"^[0-9]{12}$")
 _RESERVED_TENANT_IDS = frozenset({"admin", "root", "system", "stub"})
 _DEFAULT_OPS_LOCKS_TABLE = "platform-ops-locks"
 _DEFAULT_RUNTIME_REGION_PARAM = "/platform/config/runtime-region"
@@ -221,6 +222,15 @@ def _canonical_tenant_id(value: Any) -> str:
     if not _TENANT_ID_PATTERN.fullmatch(normalized):
         raise ValueError("tenantId must match ^[a-z](?:[a-z0-9-]{1,30}[a-z0-9])$")
     return normalized
+
+
+def _require_aws_account_id(value: Any, *, field: str) -> str:
+    account_id = _str_or_none(value)
+    if account_id is None:
+        raise ValueError(f"{field} is required")
+    if not _AWS_ACCOUNT_ID_PATTERN.fullmatch(account_id):
+        raise ValueError(f"{field} must match ^[0-9]{{12}}$")
+    return account_id
 
 
 def _parse_utc_timestamp(value: Any, *, field: str) -> datetime:
@@ -1475,10 +1485,10 @@ def _handle_platform_split_accounts(
 
     body = _require_json_body(event)
     tier = _normalize_tier(body.get("tier"))
-    target_account_id = _str_or_none(body.get("targetAccountId"))
-
-    if not target_account_id:
-        raise ValueError("targetAccountId is required")
+    target_account_id = _require_aws_account_id(
+        body.get("targetAccountId"),
+        field="targetAccountId",
+    )
 
     # In a real implementation, this would trigger an Step Function or async job
     # to move tenants of the specified tier to a new account.

--- a/tests/unit/test_openapi_contract_routes.py
+++ b/tests/unit/test_openapi_contract_routes.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.tenant_api import handler as tenant_api_handler
 
 
 def _load_openapi() -> dict:
@@ -67,3 +72,20 @@ def test_openapi_bff_token_refresh_contract_restricts_to_platform_scopes() -> No
     assert "sessionId" not in properties
     scope_items = properties.get("scopes", {}).get("items", {})
     assert scope_items.get("pattern") == "^api://[A-Za-z0-9-]+/[A-Za-z][A-Za-z0-9._-]{0,127}$"
+
+
+def test_openapi_split_accounts_target_account_id_pattern_matches_runtime_validator() -> None:
+    spec = _load_openapi()
+    schema = (
+        spec.get("paths", {})
+        .get("/v1/platform/quota/split-accounts", {})
+        .get("post", {})
+        .get("requestBody", {})
+        .get("content", {})
+        .get("application/json", {})
+        .get("schema", {})
+    )
+    target_account_schema = schema.get("properties", {}).get("targetAccountId", {})
+
+    assert target_account_schema.get("pattern") == "^[0-9]{12}$"
+    assert tenant_api_handler._AWS_ACCOUNT_ID_PATTERN.pattern == "^[0-9]{12}$"

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -1076,6 +1076,25 @@ def test_platform_split_accounts_requires_platform_admin(fake_state: dict[str, A
     assert response["statusCode"] == 403
 
 
+@pytest.mark.parametrize("target_account_id", ["12345678901", "1234567890123", "12345abc9012"])
+def test_platform_split_accounts_rejects_invalid_target_account_id(
+    fake_state: dict[str, Any],
+    target_account_id: str,
+) -> None:
+    event = _event(
+        method="POST",
+        body={"tier": "premium", "targetAccountId": target_account_id},
+    )
+    event["path"] = "/v1/platform/quota/split-accounts"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+    error = _body(response)["error"]
+    assert error["code"] == "BAD_REQUEST"
+    assert error["message"] == "targetAccountId must match ^[0-9]{12}$"
+
+
 def test_parse_roles_accepts_json_encoded_array() -> None:
     parsed = tenant_api_handler._parse_roles('["Platform.Admin","Platform.Operator"]')
     assert parsed == frozenset({"Platform.Admin", "Platform.Operator"})


### PR DESCRIPTION
## Summary
- enforce the documented 12-digit AWS account ID validation for `POST /v1/platform/quota/split-accounts`
- return the existing stable `BAD_REQUEST` response shape for malformed `targetAccountId` values
- add deny-path tests plus an OpenAPI/runtime contract assertion to keep the regex aligned

Closes #195

## Validation
- `pytest -q tests/unit/test_tenant_api_handler.py tests/unit/test_openapi_contract_routes.py`
- `make preflight-session`
- `make pre-validate-session`
- `make validate-local`

## Notes
- `gitnexus impact`, `gitnexus cypher`, and `gitnexus detect_changes` all timed out in this environment; direct static callsite analysis showed `_handle_platform_split_accounts` is only dispatched via `_dispatch_platform_routes` in `src/tenant_api/handler.py`.
