### PR TITLE
Fix ops failover CLI to match platform API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,18 +375,15 @@ infra-rollback-lambda:
 	@test -n "$(FUNCTION)" || (echo "ERROR: FUNCTION required" && exit 1)
 	uv run python scripts/rollback_lambda.py $(FUNCTION) $(ENV)
 
-## infra-set-runtime-region: Update active runtime region (use with failover lock)
+## infra-set-runtime-region: Update active runtime region via Admin REST API (requires failover lock)
 ## Usage: make infra-set-runtime-region REGION=eu-central-1 ENV=prod
 infra-set-runtime-region:
 	@test -n "$(REGION)" || (echo "ERROR: REGION required" && exit 1)
-	@test -n "$$AWS_REGION" || (echo "ERROR: AWS_REGION environment variable not set" && exit 1)
-	aws ssm put-parameter \
-		--region $$AWS_REGION \
-		--name /platform/config/runtime-region \
-		--value $(REGION) \
-		--type String \
-		--overwrite
-	@echo "==> Runtime region set to $(REGION) (via SSM in $$AWS_REGION)"
+	uv run python scripts/ops.py set-runtime-region \
+		--region $(REGION) \
+		$(if $(LOCK_ID),--lock-id "$(LOCK_ID)",) \
+		--env $(ENV)
+	@echo "==> Runtime region set to $(REGION) via POST /v1/platform/failover"
 	@echo "    Allow 90 seconds for all bridge Lambda instances to pick up the change"
 
 ## failover-lock-acquire: Acquire distributed lock before region failover

--- a/docs/operations/RUNBOOK-001-runtime-region-failover.md
+++ b/docs/operations/RUNBOOK-001-runtime-region-failover.md
@@ -19,7 +19,7 @@ make ops-service-health ENV=prod
 ### 2. Acquire distributed lock
 ```bash
 make failover-lock-acquire ENV=prod
-# IMPORTANT: must succeed before touching SSM
+# IMPORTANT: must succeed before calling the failover API
 # If lock already held: another operator is acting — coordinate before proceeding
 # Expected output: Lock acquired: platform-runtime-failover
 ```
@@ -27,7 +27,8 @@ make failover-lock-acquire ENV=prod
 ### 3. Switch runtime region
 ```bash
 make infra-set-runtime-region REGION=eu-central-1 ENV=prod
-# Updates SSM /platform/config/runtime-region
+# Calls POST /v1/platform/failover
+# Uses the saved lock token from step 2 unless LOCK_ID is passed explicitly
 # Bridge Lambda caches this for 60s — allow 90s for all instances to pick up
 # Expected output: Runtime region updated to eu-central-1
 ```

--- a/scripts/ops.py
+++ b/scripts/ops.py
@@ -21,6 +21,7 @@ from urllib.request import Request, urlopen
 DEFAULT_ENV = "dev"
 DEFAULT_TIMEOUT_SECONDS = 30
 DEFAULT_TOKEN_TTL_SECONDS = 3600
+DEFAULT_FAILOVER_LOCK_TOKEN_PATH = ".build/failover-lock-token.json"
 _TOKEN_ENV_NAMES = ("OPS_ACCESS_TOKEN", "PLATFORM_ACCESS_TOKEN", "BEARER_TOKEN")
 
 
@@ -36,6 +37,11 @@ class ApiOperation:
 class ApiResponse:
     status_code: int
     payload: Any
+
+
+@dataclass(frozen=True)
+class FailoverLockToken:
+    lock_id: str
 
 
 class OpsCliError(RuntimeError):
@@ -97,6 +103,29 @@ def _load_credentials_store(path: Path) -> dict[str, Any]:
     if not isinstance(profiles, dict):
         parsed["profiles"] = {}
     return parsed
+
+
+def _failover_lock_token_path() -> Path:
+    override = os.environ.get("FAILOVER_LOCK_TOKEN_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _repo_root() / DEFAULT_FAILOVER_LOCK_TOKEN_PATH
+
+
+def _load_failover_lock_token() -> FailoverLockToken | None:
+    path = _failover_lock_token_path()
+    if not path.exists():
+        return None
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        return None
+
+    lock_id = str(raw.get("lockId", "")).strip()
+    if not lock_id:
+        return None
+
+    return FailoverLockToken(lock_id=lock_id)
 
 
 def _save_credentials_store(path: Path, store: dict[str, Any]) -> None:
@@ -348,15 +377,20 @@ def _command_to_operation(args: argparse.Namespace) -> ApiOperation:
             path="/v1/platform/ops/error-rate",
             query={"minutes": str(args.minutes)},
         )
-    if args.command == "failover-lock-acquire":
-        return ApiOperation(method="POST", path="/v1/platform/failover/lock/acquire")
-    if args.command == "failover-lock-release":
-        return ApiOperation(method="POST", path="/v1/platform/failover/lock/release")
     if args.command == "set-runtime-region":
+        lock_id = args.lock_id
+        if not lock_id:
+            token = _load_failover_lock_token()
+            if token is not None:
+                lock_id = token.lock_id
+        if not lock_id:
+            raise OpsCliError(
+                "Failover lock id required. Acquire the lock first or pass --lock-id."
+            )
         return ApiOperation(
             method="POST",
             path="/v1/platform/failover",
-            body={"runtimeRegion": args.region},
+            body={"targetRegion": args.region, "lockId": lock_id},
         )
     if args.command == "notify-tenant":
         tenant = quote(args.tenant, safe="")
@@ -474,24 +508,17 @@ def build_parser() -> argparse.ArgumentParser:
     _add_api_common_arguments(error_rate)
     error_rate.add_argument("--minutes", type=int, default=5)
 
-    failover_lock_acquire = subparsers.add_parser(
-        "failover-lock-acquire",
-        help="Acquire failover lock.",
-    )
-    _add_api_common_arguments(failover_lock_acquire)
-
-    failover_lock_release = subparsers.add_parser(
-        "failover-lock-release",
-        help="Release failover lock.",
-    )
-    _add_api_common_arguments(failover_lock_release)
-
     set_runtime_region = subparsers.add_parser(
         "set-runtime-region",
-        help="Set active runtime region.",
+        help="Trigger runtime region failover via the Admin API.",
     )
     _add_api_common_arguments(set_runtime_region)
     set_runtime_region.add_argument("--region", required=True)
+    set_runtime_region.add_argument(
+        "--lock-id",
+        default=None,
+        help="Failover lock id. Defaults to the saved token from failover-lock-acquire.",
+    )
 
     notify_tenant = subparsers.add_parser("notify-tenant", help="Notify tenant owner.")
     _add_api_common_arguments(notify_tenant)

--- a/tests/unit/test_ops_script.py
+++ b/tests/unit/test_ops_script.py
@@ -11,6 +11,8 @@ from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request
 
+import pytest
+
 
 def _load_ops_module() -> Any:
     repo_root = Path(__file__).resolve().parents[2]
@@ -71,6 +73,16 @@ def _write_creds(path: Path, *, env_name: str, token: str, api_base_url: str) ->
         },
     }
     path.write_text(json.dumps(store), encoding="utf-8")
+
+
+def _write_failover_lock_token(path: Path, *, lock_id: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "lockId": lock_id,
+        "tableName": "platform-ops-locks",
+        "lockName": "platform-runtime-failover",
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def test_parse_args_top_tenants_defaults() -> None:
@@ -186,6 +198,102 @@ def test_update_tenant_budget_uses_patch_and_json_body(monkeypatch, tmp_path: Pa
     assert seen["body"] == {"monthlyBudgetUsd": 5000.0}
     assert seen["content_type"] == "application/json"
     assert seen["timeout"] == 12
+
+
+def test_set_runtime_region_uses_failover_api_contract(monkeypatch, tmp_path: Path) -> None:
+    creds_path = tmp_path / ".platform" / "credentials"
+    token_path = tmp_path / ".build" / "failover-lock-token.json"
+    monkeypatch.setenv("PLATFORM_CREDENTIALS_PATH", str(creds_path))
+    monkeypatch.setenv("FAILOVER_LOCK_TOKEN_PATH", str(token_path))
+    _write_creds(
+        creds_path,
+        env_name="prod",
+        token="failover-token",
+        api_base_url="https://ops.example.com",
+    )
+    _write_failover_lock_token(token_path, lock_id="lock-123")
+
+    seen: dict[str, Any] = {}
+
+    def _fake_urlopen(request: Request, timeout: int) -> _FakeResponse:
+        seen["url"] = request.full_url
+        seen["method"] = request.get_method()
+        seen["body"] = json.loads(request.data.decode("utf-8"))
+        seen["timeout"] = timeout
+        return _FakeResponse(status=200, payload={"status": "completed"})
+
+    monkeypatch.setattr(ops, "urlopen", _fake_urlopen)
+
+    rc = ops.main(["set-runtime-region", "--env", "prod", "--region", "eu-central-1"])
+
+    assert rc == 0
+    assert seen["method"] == "POST"
+    assert seen["url"] == "https://ops.example.com/v1/platform/failover"
+    assert seen["body"] == {"targetRegion": "eu-central-1", "lockId": "lock-123"}
+    assert seen["timeout"] == 30
+
+
+def test_set_runtime_region_accepts_explicit_lock_id(monkeypatch, tmp_path: Path) -> None:
+    creds_path = tmp_path / ".platform" / "credentials"
+    monkeypatch.setenv("PLATFORM_CREDENTIALS_PATH", str(creds_path))
+    _write_creds(
+        creds_path,
+        env_name="prod",
+        token="failover-token",
+        api_base_url="https://ops.example.com",
+    )
+
+    seen: dict[str, Any] = {}
+
+    def _fake_urlopen(request: Request, timeout: int) -> _FakeResponse:
+        del timeout
+        seen["body"] = json.loads(request.data.decode("utf-8"))
+        return _FakeResponse(status=200, payload={"status": "completed"})
+
+    monkeypatch.setattr(ops, "urlopen", _fake_urlopen)
+
+    rc = ops.main(
+        [
+            "set-runtime-region",
+            "--env",
+            "prod",
+            "--region",
+            "eu-central-1",
+            "--lock-id",
+            "lock-explicit",
+        ]
+    )
+
+    assert rc == 0
+    assert seen["body"] == {"targetRegion": "eu-central-1", "lockId": "lock-explicit"}
+
+
+def test_set_runtime_region_requires_lock_id_when_no_saved_token(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    creds_path = tmp_path / ".platform" / "credentials"
+    token_path = tmp_path / ".build" / "failover-lock-token.json"
+    monkeypatch.setenv("PLATFORM_CREDENTIALS_PATH", str(creds_path))
+    monkeypatch.setenv("FAILOVER_LOCK_TOKEN_PATH", str(token_path))
+    _write_creds(
+        creds_path,
+        env_name="prod",
+        token="failover-token",
+        api_base_url="https://ops.example.com",
+    )
+
+    rc = ops.main(["set-runtime-region", "--env", "prod", "--region", "eu-central-1"])
+
+    assert rc == 2
+    assert "Failover lock id required" in capsys.readouterr().err
+
+
+def test_parse_args_rejects_removed_failover_lock_api_commands() -> None:
+    with pytest.raises(SystemExit):
+        ops.parse_args(["failover-lock-acquire"])
+
+    with pytest.raises(SystemExit):
+        ops.parse_args(["failover-lock-release"])
 
 
 def test_api_error_returns_nonzero_and_prints_error(monkeypatch, tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- align `scripts/ops.py set-runtime-region` with the real `POST /v1/platform/failover` contract
- stop exposing nonexistent failover lock API commands from the ops CLI parser
- route `make infra-set-runtime-region` through the Admin API and update the failover runbook

## Validation
- `python -m py_compile scripts/ops.py`
- `pytest -q tests/unit/test_ops_script.py`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #198
