### PR TITLE
Fix SessionsPage unauthenticated loading state

### DIFF
--- a/spa/src/pages/SessionsPage.test.tsx
+++ b/spa/src/pages/SessionsPage.test.tsx
@@ -78,7 +78,10 @@ describe("SessionsPage", () => {
     render(<SessionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Loading sessions...")).toBeInTheDocument();
+      expect(screen.getByText("Authentication Required")).toBeInTheDocument();
+      expect(
+        screen.getByText("Sign in with your Entra account to view active runtime sessions for this tenant."),
+      ).toBeInTheDocument();
     });
     expect(request).not.toHaveBeenCalled();
   });

--- a/spa/src/pages/SessionsPage.tsx
+++ b/spa/src/pages/SessionsPage.tsx
@@ -21,11 +21,21 @@ export const SessionsPage: React.FC = () => {
     const [sessions, setSessions] = useState<SessionRow[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const { getAccessToken, isAuthenticated } = useAuth();
+    const { getAccessToken, isAuthenticated, isLoading: authLoading } = useAuth();
 
     useEffect(() => {
+        if (authLoading) {
+            return;
+        }
+
+        if (!isAuthenticated) {
+            setSessions([]);
+            setError(null);
+            setLoading(false);
+            return;
+        }
+
         const fetchSessions = async () => {
-            if (!isAuthenticated) return;
             try {
                 const client = getApiClient(getAccessToken);
                 const data = await client.request<SessionsListResponseDto>("/v1/sessions");
@@ -38,9 +48,17 @@ export const SessionsPage: React.FC = () => {
             }
         };
         fetchSessions();
-    }, [getAccessToken, isAuthenticated]);
+    }, [authLoading, getAccessToken, isAuthenticated]);
 
-    if (loading) return <Loading message="Retrieving active sessions..." className="h-[400px]" />;
+    if (loading || authLoading) return <Loading message="Retrieving active sessions..." className="h-[400px]" />;
+
+    if (!isAuthenticated) {
+        return (
+            <PageBanner title="Authentication Required" severity="warning">
+                Sign in with your Entra account to view active runtime sessions for this tenant.
+            </PageBanner>
+        );
+    }
     
     if (error) {
         return (


### PR DESCRIPTION
## Summary
- stop `SessionsPage` from staying in a loading state once auth resolution determines the user is unauthenticated
- render a clear authentication-required banner instead of leaving the spinner on screen indefinitely
- update the page test to assert the corrected unauthenticated behavior

## Validation
- `make preflight-session` ✅ PASS
- `make pre-validate-session` ✅ PASS
- `make worktree-push-issue` ✅ PASS (includes enforced fast pre-push validation)

## Issue
- Closes #200
