### PR TITLE
Fix TenantMembersPage invite route usage

### DIFF
--- a/spa/src/pages/TenantMembersPage.test.tsx
+++ b/spa/src/pages/TenantMembersPage.test.tsx
@@ -1,0 +1,84 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getApiClient } from "../api/client";
+import { useAuth } from "../auth/useAuth";
+import { createApiClientMock, createAuthContextValue } from "../test/mockFactories";
+import { TenantMembersPage } from "./TenantMembersPage";
+
+vi.mock("../auth/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../api/client", () => ({
+  getApiClient: vi.fn(),
+}));
+
+describe("TenantMembersPage", () => {
+  const client = createApiClientMock();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.request.mockReset();
+    vi.mocked(getApiClient).mockReturnValue(client as never);
+    vi.mocked(useAuth).mockReturnValue(
+      createAuthContextValue({
+        isAuthenticated: true,
+        account: {
+          idTokenClaims: {
+            tenantid: "tenant-acme",
+          },
+        } as never,
+      }) as never,
+    );
+  });
+
+  it("does not call the undeployed invite listing route on load", () => {
+    render(<TenantMembersPage />);
+
+    expect(client.request).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Pending invites sent from this page will appear here."),
+    ).toBeInTheDocument();
+  });
+
+  it("submits invites through the documented route and renders the returned invite", async () => {
+    client.request.mockResolvedValue({
+      invite: {
+        inviteId: "invite-1",
+        email: "new.user@example.com",
+        role: "Platform.Operator",
+        status: "pending",
+        expiresAt: "2026-03-31T00:00:00Z",
+      },
+    });
+
+    render(<TenantMembersPage />);
+
+    fireEvent.change(screen.getByLabelText("Email Address"), {
+      target: { value: "new.user@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Role"), {
+      target: { value: "Platform.Operator" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send Invite" }));
+
+    await waitFor(() => {
+      expect(client.request).toHaveBeenCalledWith("/v1/tenants/tenant-acme/users/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "new.user@example.com",
+          role: "Platform.Operator",
+        }),
+      });
+    });
+
+    expect(client.request).not.toHaveBeenCalledWith("/v1/tenants/tenant-acme/users/invites");
+    expect(screen.getByText("Invite sent to new.user@example.com.")).toBeInTheDocument();
+    expect(screen.getByText("new.user@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Platform.Operator")).toBeInTheDocument();
+  });
+});

--- a/spa/src/pages/TenantMembersPage.tsx
+++ b/spa/src/pages/TenantMembersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
 
@@ -25,32 +25,10 @@ export const TenantMembersPage: React.FC = () => {
     const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
 
     const [invites, setInvites] = useState<Invite[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
     const [inviteEmail, setInviteEmail] = useState("");
     const [inviteRole, setInviteRole] = useState("Agent.Invoke");
     const [submitting, setSubmitting] = useState(false);
     const [inviteMessage, setInviteMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null);
-
-    useEffect(() => {
-        if (!isAuthenticated || !tenantId) {
-            setLoading(false);
-            return;
-        }
-
-        const run = async () => {
-            try {
-                const client = getApiClient(getAccessToken);
-                const data = await client.request<{ items: Invite[] }>(`/v1/tenants/${tenantId}/users/invites`);
-                setInvites(data.items);
-            } catch (err) {
-                setError(err instanceof Error ? err.message : "Failed to load invites.");
-            } finally {
-                setLoading(false);
-            }
-        };
-        void run();
-    }, [getAccessToken, isAuthenticated, tenantId]);
 
     const onInviteSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -74,8 +52,7 @@ export const TenantMembersPage: React.FC = () => {
         }
     };
 
-    if (loading) return <div className="p-8">Loading members...</div>;
-    if (error) return <div className="p-8 text-red-600">Error: {error}</div>;
+    if (!isAuthenticated) return <div className="p-8">Loading members...</div>;
 
     return (
         <div className="space-y-6">
@@ -91,7 +68,9 @@ export const TenantMembersPage: React.FC = () => {
                     </div>
                     <div className="overflow-x-auto">
                         {invites.length === 0 ? (
-                            <div className="p-8 text-center text-gray-500 text-sm">No pending invites.</div>
+                            <div className="p-8 text-center text-gray-500 text-sm">
+                                Pending invites sent from this page will appear here.
+                            </div>
                         ) : (
                             <table className="min-w-full divide-y divide-gray-200">
                                 <thead className="bg-gray-50 text-xs font-medium text-gray-500 uppercase tracking-wider">


### PR DESCRIPTION
## Summary
- stop `TenantMembersPage` from calling the undeployed `GET /v1/tenants/{tenantId}/users/invites` route on load
- keep the invite table local to invites created via the documented `POST /v1/tenants/{tenantId}/users/invite` route
- add a focused page test covering the corrected frontend behavior

Closes #201

## Validation Evidence
- `make preflight-session` — PASS
- `make pre-validate-session` — PASS
- `make worktree-push-issue` — PASS
  - `ruff check .` — PASS
  - `ruff format --check .` — PASS
  - `pyright --project ../../pyrightconfig.json` — `0 errors, 0 warnings, 0 informations`
  - `pytest tests/unit/test_openapi_contract_routes.py` — `5 passed`
  - `detect-secrets` push scan — PASS

## Notes
- Added `spa/src/pages/TenantMembersPage.test.tsx` to cover the route usage regression.
