### PR TITLE
fix: align InvokePage with deployed agent detail contract

### DIFF
--- a/spa/src/api/contracts.ts
+++ b/spa/src/api/contracts.ts
@@ -12,6 +12,17 @@ export type AgentsListResponseDto = {
   items: AgentSummaryDto[];
 };
 
+export type AgentDetailVersionDto = {
+  version: string;
+  deployedAt: string;
+  invocationMode?: "sync" | "streaming" | "async";
+  streamingEnabled?: boolean;
+};
+
+export type AgentDetailDto = AgentSummaryDto & {
+  versions?: AgentDetailVersionDto[];
+};
+
 export type AgentCatalogueItem = {
   agentName: string;
   version: string;
@@ -105,6 +116,19 @@ export type TenantsListResponseDto = {
   nextToken?: string | null;
 };
 
+export type SessionDto = {
+  sessionId: string;
+  agentName: string;
+  startedAt: string;
+  lastActivityAt: string;
+  status: "active" | "completed" | "expired";
+};
+
+export type SessionsListResponseDto = {
+  items: SessionDto[];
+  nextToken?: string | null;
+};
+
 export type TenantAdminRow = {
   tenantId: string;
   displayName: string;
@@ -186,6 +210,20 @@ export const SPA_OPENAPI_CONTRACTS: OpenApiContractExpectation[] = [
       "tierMinimum",
       "invocationMode",
       "streamingEnabled",
+    ],
+  },
+  {
+    name: "agentDetail",
+    path: "/v1/agents/{agentName}",
+    method: "get",
+    statusCode: "200",
+    requiredFields: [
+      "agentName",
+      "latestVersion",
+      "tierMinimum",
+      "invocationMode",
+      "streamingEnabled",
+      "versions",
     ],
   },
   {

--- a/spa/src/api/openapiContract.test.ts
+++ b/spa/src/api/openapiContract.test.ts
@@ -16,6 +16,7 @@ type OpenApiDoc = {
 
 type OpenApiSchema = {
   $ref?: string;
+  allOf?: OpenApiSchema[];
   type?: string;
   items?: OpenApiSchema;
   properties?: Record<string, OpenApiSchema>;
@@ -45,23 +46,61 @@ function resolveSchema(schema: OpenApiSchema | undefined, doc: OpenApiDoc): Open
   if (!schema || typeof schema !== "object") {
     return schema;
   }
-  if (!schema.$ref) {
-    return schema;
+
+  if (schema.$ref) {
+    const pointer = String(schema.$ref).replace(/^#\//, "").split("/");
+    let resolved: unknown = doc;
+    for (const segment of pointer) {
+      if (!resolved || typeof resolved !== "object") {
+        resolved = undefined;
+        break;
+      }
+      resolved = (resolved as Record<string, unknown>)[segment];
+    }
+    if (!resolved) {
+      throw new Error(`Unresolvable OpenAPI reference: ${schema.$ref}`);
+    }
+    return resolveSchema(resolved as OpenApiSchema, doc);
   }
 
-  const pointer = String(schema.$ref).replace(/^#\//, "").split("/");
-  let resolved: unknown = doc;
-  for (const segment of pointer) {
-    if (!resolved || typeof resolved !== "object") {
-      resolved = undefined;
-      break;
-    }
-    resolved = (resolved as Record<string, unknown>)[segment];
+  if (schema.allOf?.length) {
+    return schema.allOf.reduce<OpenApiSchema>(
+      (merged, part) => {
+        const resolvedPart = resolveSchema(part, doc);
+        if (!resolvedPart) {
+          return merged;
+        }
+
+        return {
+          ...merged,
+          ...resolvedPart,
+          properties: {
+            ...merged.properties,
+            ...resolvedPart.properties,
+          },
+        };
+      },
+      { properties: {} },
+    );
   }
-  if (!resolved) {
-    throw new Error(`Unresolvable OpenAPI reference: ${schema.$ref}`);
+
+  if (schema.items) {
+    return {
+      ...schema,
+      items: resolveSchema(schema.items, doc),
+    };
   }
-  return resolveSchema(resolved as OpenApiSchema, doc);
+
+  if (schema.properties) {
+    return {
+      ...schema,
+      properties: Object.fromEntries(
+        Object.entries(schema.properties).map(([key, value]) => [key, resolveSchema(value, doc) ?? value]),
+      ),
+    };
+  }
+
+  return schema;
 }
 
 describe("SPA/OpenAPI contract drift", () => {

--- a/spa/src/pages/InvokePage.test.tsx
+++ b/spa/src/pages/InvokePage.test.tsx
@@ -117,6 +117,24 @@ describe("InvokePage", () => {
         expect(getInvokeBody()).toEqual({ input: "ping" });
     });
 
+    it("renders agent metadata from the deployed camelCase detail contract", async () => {
+        requestMock.mockResolvedValueOnce(buildAgent("sync"));
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        await act(async () => {
+            renderer = TestRenderer.create(<InvokePage />);
+        });
+
+        await flushMicrotasks();
+
+        const pageText = JSON.stringify(renderer!.toJSON());
+        expect(pageText).toContain("Invoke: ");
+        expect(pageText).toContain("echo-agent");
+        expect(pageText).toContain("sync mode");
+        expect(pageText).toContain("Tier: ");
+        expect(pageText).toContain("basic+");
+    });
+
     it("uses streaming invoke path with contract-compatible payload", async () => {
         requestMock.mockResolvedValueOnce(buildAgent("streaming"));
         streamMock.mockReturnValue(

--- a/spa/src/pages/InvokePage.tsx
+++ b/spa/src/pages/InvokePage.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
 import { getApiClient } from "../api/client";
+import type { AgentDetailDto } from "../api/contracts";
 import { useAuth } from "../auth/useAuth";
-import { Agent, AgentInvokeResponse } from "../types";
+import { AgentInvokeResponse } from "../types";
 import { useJobPolling } from "../hooks/useJobPolling";
 import { useSessionKeepalive } from "../hooks/useSessionKeepalive";
 import {
@@ -37,7 +38,7 @@ export const InvokePage: React.FC = () => {
     const { agentName } = useParams<{ agentName: string }>();
     const { getAccessToken, isAuthenticated } = useAuth();
     
-    const [agent, setAgent] = useState<Agent | null>(null);
+    const [agent, setAgent] = useState<AgentDetailDto | null>(null);
     const [prompt, setPrompt] = useState("");
     const [loading, setLoading] = useState(false);
     const [result, setResult] = useState<string | null>(null);
@@ -50,14 +51,14 @@ export const InvokePage: React.FC = () => {
     // Maintain session continuity with keepalive pings
     useSessionKeepalive(sessionId, agentName || null);
 
-    const invocationMode = agent?.invocation_mode ?? "sync";
+    const invocationMode = agent?.invocationMode ?? "sync";
 
     useEffect(() => {
         const fetchAgent = async () => {
             if (!isAuthenticated) return;
             try {
                 const client = getApiClient(getAccessToken);
-                const data = await client.request<Agent>(`/v1/agents/${agentName}`);
+                const data = await client.request<AgentDetailDto>(`/v1/agents/${agentName}`);
                 setAgent(data);
             } catch (err: unknown) {
                 setError(formatApiErrorMessage(err));
@@ -143,14 +144,14 @@ export const InvokePage: React.FC = () => {
                                 <Bot className="h-7 w-7" />
                             </div>
                             <div>
-                                <CardTitle className="text-xl font-bold text-white">Invoke: {agent?.agent_name}</CardTitle>
+                                <CardTitle className="text-xl font-bold text-white">Invoke: {agent?.agentName}</CardTitle>
                                 <CardDescription className="text-slate-400 font-mono text-xs">
-                                    Agent ARN: platform::agent::{agentName} v{agent?.version}
+                                    Agent ARN: platform::agent::{agentName} v{agent?.latestVersion}
                                 </CardDescription>
                             </div>
                         </div>
                         <Badge variant="outline" className="h-6 border-cyan-500/30 text-cyan-400 bg-cyan-500/5">
-                            {agent?.invocation_mode} mode
+                            {agent?.invocationMode} mode
                         </Badge>
                     </CardHeader>
 
@@ -268,11 +269,11 @@ export const InvokePage: React.FC = () => {
                       </div>
                       <div className="flex items-center gap-3 text-xs text-slate-300">
                          <Zap className="h-4 w-4 text-cyan-400 shrink-0" />
-                         <span>Mode: {agent?.invocation_mode}</span>
+                         <span>Mode: {agent?.invocationMode}</span>
                       </div>
                       <div className="flex items-center gap-3 text-xs text-slate-300">
                          <Shield className="h-4 w-4 text-cyan-400 shrink-0" />
-                         <span>Tier: {agent?.tier_minimum}+</span>
+                         <span>Tier: {agent?.tierMinimum}+</span>
                       </div>
                    </div>
                 </div>

--- a/spa/src/test/testData.ts
+++ b/spa/src/test/testData.ts
@@ -1,11 +1,12 @@
 import type {
+  AgentDetailDto,
   AgentsListResponseDto,
   HealthResponseDto,
   PlatformQuotaResponseDto,
   SessionsListResponseDto,
   TenantsListResponseDto,
 } from "../api/contracts";
-import type { AgentInvokeResponse, Agent } from "../types";
+import type { AgentInvokeResponse } from "../types";
 
 export const catalogueSingleAgent: AgentsListResponseDto = {
   items: [
@@ -122,16 +123,23 @@ export const quotaRows: PlatformQuotaResponseDto = {
   ],
 };
 
-export function buildAgent(invocationMode: Agent["invocation_mode"]): Agent {
+export function buildAgent(invocationMode: AgentDetailDto["invocationMode"]): AgentDetailDto {
   return {
-    agent_name: "echo-agent",
-    version: "1.0.0",
-    owner_team: "platform",
-    tier_minimum: "basic",
-    deployed_at: "2026-03-08T00:00:00Z",
-    invocation_mode: invocationMode,
-    streaming_enabled: invocationMode === "streaming",
-    estimated_duration_seconds: 5,
+    agentName: "echo-agent",
+    latestVersion: "1.0.0",
+    ownerTeam: "platform",
+    tierMinimum: "basic",
+    invocationMode: invocationMode,
+    streamingEnabled: invocationMode === "streaming",
+    estimatedDurationSeconds: 5,
+    versions: [
+      {
+        version: "1.0.0",
+        deployedAt: "2026-03-08T00:00:00Z",
+        invocationMode,
+        streamingEnabled: invocationMode === "streaming",
+      },
+    ],
   };
 }
 

--- a/spa/src/types.ts
+++ b/spa/src/types.ts
@@ -5,17 +5,6 @@ export type InvocationStatus = "success" | "error" | "timeout" | "throttled";
 export type JobStatus = "pending" | "running" | "completed" | "failed";
 export type SessionStatus = "active" | "completed" | "expired";
 
-export interface Agent {
-    agent_name: string;
-    version: string;
-    owner_team: string;
-    tier_minimum: TenantTier;
-    deployed_at: string;
-    invocation_mode: InvocationMode;
-    streaming_enabled: boolean;
-    estimated_duration_seconds?: number;
-}
-
 export interface Invocation {
     invocation_id: string;
     tenant_id: string;


### PR DESCRIPTION
## Summary
- align  with the deployed camelCase  contract
- update invoke fixtures/tests to use the real field names
- extend the SPA/OpenAPI drift check to cover  and resolve 

## Validation
- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt202'
uv run python scripts/worktree_issues.py preflight
Preflight context:
  repo:     /mnt/c/Users/julia/worktrees/wt202
  path:     /mnt/c/Users/julia/worktrees/wt202
  worktree: /mnt/c/Users/julia/worktrees/wt202
  primary:  /mnt/c/Users/julia/tf-acore-aas
  branch:   wt/task/202-align-invokepage-agent-typing-and-rendering-with-the-deploye
Preflight result: PASS
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt202'
- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt202'
uv run python scripts/worktree_issues.py pre-validate \
	
make[2]: Entering directory '/mnt/c/Users/julia/worktrees/wt202'
==> Running pre-push validation (no cdk synth)
uv run ruff check .
All checks passed!
uv run ruff format --check .
83 files already formatted
cd infra/cdk && npx --no-install pyright --project ../../pyrightconfig.json
0 errors, 0 warnings, 0 informations
uv run pytest tests/unit/test_openapi_contract_routes.py
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/c/Users/julia/worktrees/wt202
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0
collected 5 items

tests/unit/test_openapi_contract_routes.py .....                         [100%]

============================== 5 passed in 7.39s ===============================
==> validate-cdk-ts: skipped (no CDK/TS files in commits-to-push)
==> detect-secrets (files in commits-to-push)
==> detect-secrets: no commits-to-push files detected; falling back to changed-files scan
==> detect-secrets (changed files only)
==> detect-secrets: no changed files to scan
==> Pre-push validation passed
make[2]: Leaving directory '/mnt/c/Users/julia/worktrees/wt202'
Running pre-push validation in /mnt/c/Users/julia/worktrees/wt202 (make validate-pre-push)
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt202'
- targeted TypeScript parse: 
- 

Closes #202