### PR TITLE
Fix InvokePage unauthenticated loading state

### DIFF
--- a/ai-context/CLAUDE.md
+++ b/ai-context/CLAUDE.md
@@ -343,7 +343,7 @@ git worktree prune
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationships, 192 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2050 symbols, 6290 relationships, 165 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -359,7 +359,7 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt193/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -398,10 +398,10 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/wt193/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt193/clusters` | All functional areas |
-| `gitnexus://repo/wt193/processes` | All execution flows |
-| `gitnexus://repo/wt193/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 
@@ -410,6 +410,24 @@ Before completing any code modification task, verify:
 2. No HIGH/CRITICAL risk warnings were ignored
 3. `gitnexus_detect_changes()` confirms changes match expected scope
 4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After every local `git commit` and after every merge into your working branch, the GitNexus index becomes stale. Re-run analyze to update it immediately:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+This is mandatory. Do not assume a local hook or client automation exists; if you make a commit or complete a merge, run the appropriate `gitnexus analyze` command yourself before continuing.
 
 ## CLI
 

--- a/spa/src/pages/InvokePage.test.tsx
+++ b/spa/src/pages/InvokePage.test.tsx
@@ -203,7 +203,7 @@ describe("InvokePage", () => {
         expect(pageText).toContain("Async invoke response missing jobId");
     });
 
-    it("does not fetch agent details when unauthenticated", async () => {
+    it("shows an authentication-required banner when unauthenticated", async () => {
         useAuthMock.mockReturnValue(createAuthContextValue({
             isAuthenticated: false,
             getAccessToken: getAccessTokenMock,
@@ -217,7 +217,9 @@ describe("InvokePage", () => {
         await flushMicrotasks();
 
         expect(requestMock).not.toHaveBeenCalled();
-        expect(JSON.stringify(renderer!.toJSON())).toContain("Loading...");
+        const pageText = JSON.stringify(renderer!.toJSON());
+        expect(pageText).toContain("Authentication Required");
+        expect(pageText).toContain("Sign in again");
     });
 
     it("shows fetch error when initial agent lookup fails", async () => {

--- a/spa/src/pages/InvokePage.tsx
+++ b/spa/src/pages/InvokePage.tsx
@@ -52,9 +52,16 @@ export const InvokePage: React.FC = () => {
 
     const invocationMode = agent?.invocation_mode ?? "sync";
 
+    if (!isAuthenticated) {
+        return (
+            <PageBanner title="Authentication Required" severity="warning">
+                Your session is no longer authenticated. Sign in again to load this agent and continue.
+            </PageBanner>
+        );
+    }
+
     useEffect(() => {
         const fetchAgent = async () => {
-            if (!isAuthenticated) return;
             try {
                 const client = getApiClient(getAccessToken);
                 const data = await client.request<Agent>(`/v1/agents/${agentName}`);
@@ -64,7 +71,7 @@ export const InvokePage: React.FC = () => {
             }
         };
         void fetchAgent();
-    }, [agentName, getAccessToken, isAuthenticated]);
+    }, [agentName, getAccessToken]);
 
     const handleInvoke = async (e: React.FormEvent) => {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- stop `InvokePage` from rendering a perpetual loading state when the user is unauthenticated
- show an explicit authentication-required banner instead of falling through to the agent-loading spinner
- update the page test to assert the corrected unauthenticated behavior
- resync `ai-context/CLAUDE.md` with canonical `CLAUDE.md` so repo validation passes

Closes #205.

## Validation
- `make preflight-session`
- `make validate-local`
- `make pre-validate-session`
- `make worktree-push-issue`
- `npx gitnexus analyze`
- `gitnexus impact InvokePage upstream`: LOW risk, 0 direct callers, 0 affected processes
- `gitnexus detect_changes`: low risk, no affected processes
