### PR TITLE
Fix recursive auth dependency in SPA BFF token refresh fallback

### DIFF
--- a/spa/src/api/client.test.ts
+++ b/spa/src/api/client.test.ts
@@ -77,6 +77,29 @@ describe("ApiClient", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("calls BFF token refresh with an explicit assertion token and no auth recursion", async () => {
+    const tokenProvider = vi.fn<AccessTokenProvider>().mockResolvedValue("unused");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(createResponse(200, { accessToken: "fresh-token" }));
+
+    const client = new ApiClient({
+      baseUrl: "https://api.example.com",
+      getAccessToken: tokenProvider,
+      fetchImpl,
+    });
+
+    const response = await client.bffTokenRefresh(
+      { scopes: ["api://platform-dev/Agent.Invoke"] },
+      { accessToken: "assertion-token" },
+    );
+
+    expect(response).toEqual({ accessToken: "fresh-token" });
+    expect(tokenProvider).not.toHaveBeenCalled();
+    const requestHeaders = new Headers(fetchImpl.mock.calls[0][1]?.headers);
+    expect(requestHeaders.get("Authorization")).toBe("Bearer assertion-token");
+  });
+
   it("streams SSE chunks via Fetch + ReadableStream", async () => {
     const tokenProvider = vi.fn<AccessTokenProvider>().mockResolvedValue("stream-token");
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(

--- a/spa/src/api/client.ts
+++ b/spa/src/api/client.ts
@@ -19,6 +19,10 @@ export type ApiClientOptions = {
   fetchImpl?: typeof fetch;
 };
 
+export type BffAuthOptions = {
+  accessToken: string;
+};
+
 export type SseEvent = {
   event: string;
   data: string;
@@ -61,12 +65,22 @@ export class ApiClient {
     return this.requestWithAuth(path, init, false);
   }
 
-  async bffTokenRefresh(request: BffTokenRefreshRequestDto): Promise<BffTokenRefreshResponseDto> {
-    return this.request<BffTokenRefreshResponseDto>("/v1/bff/token-refresh", {
+  async bffTokenRefresh(
+    request: BffTokenRefreshRequestDto,
+    auth: BffAuthOptions,
+  ): Promise<BffTokenRefreshResponseDto> {
+    const response = await this.fetchImpl(this.resolveUrl("/v1/bff/token-refresh"), {
       method: "POST",
       body: JSON.stringify(request),
-      headers: { "Content-Type": "application/json" },
+      headers: mergeHeaders(
+        { "Content-Type": "application/json" },
+        { Authorization: `Bearer ${auth.accessToken}` },
+      ),
     });
+    if (!response.ok) {
+      throw await toApiError(response);
+    }
+    return parseJsonResponse<BffTokenRefreshResponseDto>(response);
   }
 
   async bffSessionKeepalive(

--- a/spa/src/auth/AuthProvider.test.ts
+++ b/spa/src/auth/AuthProvider.test.ts
@@ -42,7 +42,10 @@ describe("acquireTokenWithBffFallback", () => {
   });
 
   it("falls back to BFF when MSAL silent fails but BFF succeeds", async () => {
-    const acquireTokenSilent = vi.fn().mockRejectedValue(new Error("silent-fail"));
+    const acquireTokenSilent = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("silent-fail"))
+      .mockResolvedValueOnce({ accessToken: "assertion-token" });
     const acquireTokenPopup = vi.fn();
     const bffTokenRefresh = vi.fn().mockResolvedValue({ accessToken: "bff-token" });
     vi.mocked(getApiClient).mockReturnValue({ bffTokenRefresh } as never);
@@ -58,18 +61,19 @@ describe("acquireTokenWithBffFallback", () => {
     });
 
     expect(token).toBe("bff-token");
-    expect(acquireTokenSilent).toHaveBeenCalledTimes(1);
-    expect(bffTokenRefresh).toHaveBeenCalledWith({ scopes: ["api://platform-dev/Agent.Invoke"] });
+    expect(acquireTokenSilent).toHaveBeenCalledTimes(2);
+    expect(bffTokenRefresh).toHaveBeenCalledWith(
+      { scopes: ["api://platform-dev/Agent.Invoke"] },
+      { accessToken: "assertion-token" },
+    );
     expect(acquireTokenPopup).not.toHaveBeenCalled();
   });
 
-  it("falls back to acquireTokenPopup when interaction is required and BFF fails", async () => {
+  it("returns the interactive MSAL token when silent refresh requires interaction", async () => {
     const acquireTokenSilent = vi
       .fn()
       .mockRejectedValue(new InteractionRequiredAuthError("interaction_required", "login"));
     const acquireTokenPopup = vi.fn().mockResolvedValue({ accessToken: "popup-token" });
-    const bffTokenRefresh = vi.fn().mockRejectedValue(new Error("bff-fail"));
-    vi.mocked(getApiClient).mockReturnValue({ bffTokenRefresh } as never);
 
     const token = await acquireTokenWithBffFallback({
       client: {
@@ -88,7 +92,7 @@ describe("acquireTokenWithBffFallback", () => {
       scopes: ["api://platform-dev/Agent.Invoke"],
       forceRefresh: true,
     });
-    expect(bffTokenRefresh).toHaveBeenCalledTimes(1);
+    expect(getApiClient).not.toHaveBeenCalled();
     expect(acquireTokenPopup).toHaveBeenCalledWith({
       account,
       scopes: ["api://platform-dev/Agent.Invoke"],

--- a/spa/src/auth/AuthProvider.tsx
+++ b/spa/src/auth/AuthProvider.tsx
@@ -53,10 +53,15 @@ type TokenAcquisitionParams = {
   allowBffFallback?: boolean;
 };
 
-export async function acquireTokenWithBffFallback(
-  params: TokenAcquisitionParams,
-): Promise<string> {
-  const { client, account, scopes, forceRefresh = false, allowBffFallback = true } = params;
+type TokenAcquisitionResult = {
+  accessToken: string;
+  usedInteractivePrompt: boolean;
+};
+
+async function acquireAccessTokenWithoutBffFallback(
+  params: Omit<TokenAcquisitionParams, "allowBffFallback">,
+): Promise<TokenAcquisitionResult> {
+  const { client, account, scopes, forceRefresh = false } = params;
 
   try {
     const result = await client.acquireTokenSilent({
@@ -64,20 +69,11 @@ export async function acquireTokenWithBffFallback(
       scopes,
       forceRefresh,
     });
-    return result.accessToken;
+    return {
+      accessToken: result.accessToken,
+      usedInteractivePrompt: false,
+    };
   } catch (error) {
-    if (allowBffFallback) {
-      console.warn("[Auth] MSAL silent refresh failed, attempting BFF OBO fallback", error);
-      try {
-        const apiClient = getApiClient();
-        const bffResult = await apiClient.bffTokenRefresh({ scopes });
-        console.info("[Auth] Successfully refreshed token via BFF OBO");
-        return bffResult.accessToken;
-      } catch (bffError) {
-        console.error("[Auth] BFF OBO fallback failed", bffError);
-      }
-    }
-
     if (error instanceof InteractionRequiredAuthError) {
       console.warn("[Auth] Interaction required - MSAL popup may be shown");
       const popupRequest: PopupRequest = {
@@ -85,7 +81,63 @@ export async function acquireTokenWithBffFallback(
         scopes,
       };
       const result = await client.acquireTokenPopup(popupRequest);
-      return result.accessToken;
+      return {
+        accessToken: result.accessToken,
+        usedInteractivePrompt: true,
+      };
+    }
+    throw error;
+  }
+}
+
+export async function acquireTokenWithBffFallback(
+  params: TokenAcquisitionParams,
+): Promise<string> {
+  const { client, account, scopes, forceRefresh = false, allowBffFallback = true } = params;
+
+  try {
+    const token = await acquireAccessTokenWithoutBffFallback({
+      client,
+      account,
+      scopes,
+      forceRefresh,
+    });
+    return token.accessToken;
+  } catch (error) {
+    if (allowBffFallback) {
+      console.warn("[Auth] MSAL silent refresh failed, attempting BFF OBO fallback", error);
+      let assertionToken: TokenAcquisitionResult | null = null;
+      try {
+        assertionToken = await acquireAccessTokenWithoutBffFallback({
+          client,
+          account,
+          scopes,
+          forceRefresh,
+        });
+        const apiClient = getApiClient();
+        const bffResult = await apiClient.bffTokenRefresh(
+          { scopes },
+          { accessToken: assertionToken.accessToken },
+        );
+        console.info("[Auth] Successfully refreshed token via BFF OBO");
+        return bffResult.accessToken;
+      } catch (bffError) {
+        console.error("[Auth] BFF OBO fallback failed", bffError);
+        if (assertionToken?.usedInteractivePrompt) {
+          console.info("[Auth] Using interactive MSAL token after BFF OBO fallback failure");
+          return assertionToken.accessToken;
+        }
+      }
+    }
+
+    if (error instanceof InteractionRequiredAuthError) {
+      const token = await acquireAccessTokenWithoutBffFallback({
+        client,
+        account,
+        scopes,
+        forceRefresh,
+      });
+      return token.accessToken;
     }
     throw error;
   }
@@ -200,12 +252,37 @@ export function AuthProvider({ children, client = msalInstance }: AuthProviderPr
 
   const refreshAccessTokenViaBff = useCallback(
     async (scopes?: string[]) => {
+      let activeAccount = account ?? resolveAccount(client);
+      if (!activeAccount) {
+        await login();
+        activeAccount = resolveAccount(client);
+      }
+
+      if (!activeAccount) {
+        throw new Error("Unable to resolve active account after login");
+      }
+
       const requestedScopes = scopes?.length ? scopes : defaultScopes;
+      const assertionToken = await acquireAccessTokenWithoutBffFallback({
+        client,
+        account: activeAccount,
+        scopes: requestedScopes,
+      });
       const apiClient = getApiClient();
-      const bffResult = await apiClient.bffTokenRefresh({ scopes: requestedScopes });
-      return bffResult.accessToken;
+      try {
+        const bffResult = await apiClient.bffTokenRefresh(
+          { scopes: requestedScopes },
+          { accessToken: assertionToken.accessToken },
+        );
+        return bffResult.accessToken;
+      } catch (error) {
+        if (assertionToken.usedInteractivePrompt) {
+          return assertionToken.accessToken;
+        }
+        throw error;
+      }
     },
-    [],
+    [account, client, login],
   );
 
   const value = useMemo<AuthContextValue>(

--- a/spa/src/hooks/useBffTokenRefresh.ts
+++ b/spa/src/hooks/useBffTokenRefresh.ts
@@ -1,18 +1,19 @@
 import { useCallback } from "react";
-import { getApiClient } from "../api/client";
 import { defaultScopes } from "../auth/msalConfig";
+import { useAuth } from "../auth/useAuth";
 
 export function useBffTokenRefresh() {
+  const { refreshAccessTokenViaBff } = useAuth();
+
   const refresh = useCallback(async (scopes: string[] = defaultScopes) => {
     try {
-      const client = getApiClient();
-      const response = await client.bffTokenRefresh({ scopes });
-      return response;
+      const accessToken = await refreshAccessTokenViaBff(scopes);
+      return { accessToken };
     } catch (err) {
       console.error("[BFF] Token refresh failed:", err);
       throw err;
     }
-  }, []);
+  }, [refreshAccessTokenViaBff]);
 
   return { refresh };
 }

--- a/spa/src/test/testData.ts
+++ b/spa/src/test/testData.ts
@@ -2,10 +2,19 @@ import type {
   AgentsListResponseDto,
   HealthResponseDto,
   PlatformQuotaResponseDto,
-  SessionsListResponseDto,
   TenantsListResponseDto,
 } from "../api/contracts";
 import type { AgentInvokeResponse, Agent } from "../types";
+
+type SessionsListResponseDto = {
+  items: Array<{
+    sessionId: string;
+    agentName: string;
+    startedAt: string;
+    lastActivityAt: string;
+    status: string;
+  }>;
+};
 
 export const catalogueSingleAgent: AgentsListResponseDto = {
   items: [


### PR DESCRIPTION
Closes #204.

## Summary
- move BFF token refresh onto a dedicated transport path that accepts an explicit bearer token instead of re-entering the generic auth-attaching API client flow
- update AuthProvider fallback logic to acquire assertion tokens without BFF recursion and to reuse an interactive MSAL token when BFF refresh is unavailable
- align SPA tests with the new non-recursive path and fix the stale `SessionsListResponseDto` fixture type blocking TypeScript validation

## Validation
- `make preflight-session`
- `make pre-validate-session`
- `npm exec -- vite build` in `spa/`
- `npm exec -- vitest run src/api/client.test.ts --environment jsdom --pool forks --no-file-parallelism --reporter=basic`
- `npm exec -- vitest run src/auth/AuthProvider.test.ts --environment node --pool forks --no-file-parallelism --reporter=basic`

## Evidence
- `make preflight-session`: PASS
- `make pre-validate-session`: PASS
- `vite build`: PASS
- `src/api/client.test.ts`: 5 passed
- `src/auth/AuthProvider.test.ts`: 4 passed
