### PR TITLE
Restrict tenant invite roles to tenant-scoped access

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1295,6 +1295,7 @@ components:
           format: email
         role:
           type: string
+          enum: [Agent.Invoke]
           default: Agent.Invoke
         displayName:
           type: string

--- a/spa/src/api/contracts.ts
+++ b/spa/src/api/contracts.ts
@@ -48,6 +48,19 @@ export type TenantDto = {
   updatedAt?: string | null;
 };
 
+export type SessionSummaryDto = {
+  sessionId: string;
+  agentName: string;
+  startedAt: string;
+  lastActivityAt: string;
+  status: "active" | "completed" | "expired" | "failed";
+};
+
+export type SessionsListResponseDto = {
+  items: SessionSummaryDto[];
+  nextToken?: string | null;
+};
+
 export type TenantUpdateRequestDto = {
   displayName?: string;
   tier?: "basic" | "standard" | "premium";

--- a/spa/src/pages/TenantMembersPage.test.tsx
+++ b/spa/src/pages/TenantMembersPage.test.tsx
@@ -49,7 +49,7 @@ describe("TenantMembersPage", () => {
       invite: {
         inviteId: "invite-1",
         email: "new.user@example.com",
-        role: "Platform.Operator",
+        role: "Agent.Invoke",
         status: "pending",
         expiresAt: "2026-03-31T00:00:00Z",
       },
@@ -60,9 +60,6 @@ describe("TenantMembersPage", () => {
     fireEvent.change(screen.getByLabelText("Email Address"), {
       target: { value: "new.user@example.com" },
     });
-    fireEvent.change(screen.getByLabelText("Role"), {
-      target: { value: "Platform.Operator" },
-    });
     fireEvent.click(screen.getByRole("button", { name: "Send Invite" }));
 
     await waitFor(() => {
@@ -71,7 +68,7 @@ describe("TenantMembersPage", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: "new.user@example.com",
-          role: "Platform.Operator",
+          role: "Agent.Invoke",
         }),
       });
     });
@@ -79,6 +76,14 @@ describe("TenantMembersPage", () => {
     expect(client.request).not.toHaveBeenCalledWith("/v1/tenants/tenant-acme/users/invites");
     expect(screen.getByText("Invite sent to new.user@example.com.")).toBeInTheDocument();
     expect(screen.getByText("new.user@example.com")).toBeInTheDocument();
-    expect(screen.getByText("Platform.Operator")).toBeInTheDocument();
+    expect(screen.getAllByText("Agent.Invoke")).not.toHaveLength(0);
+  });
+
+  it("does not offer platform roles in the invite form", () => {
+    render(<TenantMembersPage />);
+
+    expect(screen.getByText("Agent.Invoke (tenant-scoped access)")).toBeInTheDocument();
+    expect(screen.queryByText("Platform.Operator (Admin Access)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Role")).not.toBeInTheDocument();
   });
 });

--- a/spa/src/pages/TenantMembersPage.tsx
+++ b/spa/src/pages/TenantMembersPage.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
 
+const TENANT_INVITE_ROLE = "Agent.Invoke";
+
 type Invite = {
     inviteId: string;
     email: string;
@@ -26,7 +28,6 @@ export const TenantMembersPage: React.FC = () => {
 
     const [invites, setInvites] = useState<Invite[]>([]);
     const [inviteEmail, setInviteEmail] = useState("");
-    const [inviteRole, setInviteRole] = useState("Agent.Invoke");
     const [submitting, setSubmitting] = useState(false);
     const [inviteMessage, setInviteMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null);
 
@@ -40,7 +41,7 @@ export const TenantMembersPage: React.FC = () => {
             const response = await client.request<{ invite: Invite }>(`/v1/tenants/${tenantId}/users/invite`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+                body: JSON.stringify({ email: inviteEmail.trim(), role: TENANT_INVITE_ROLE }),
             });
             setInviteMessage({ type: 'success', text: `Invite sent to ${response.invite.email}.` });
             setInviteEmail("");
@@ -119,15 +120,10 @@ export const TenantMembersPage: React.FC = () => {
                             />
                         </div>
                         <div>
-                            <label className="block text-sm font-medium text-gray-700">Role</label>
-                            <select
-                                value={inviteRole}
-                                onChange={e => setInviteRole(e.target.value)}
-                                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                            >
-                                <option value="Agent.Invoke">Agent.Invoke (Basic Access)</option>
-                                <option value="Platform.Operator">Platform.Operator (Admin Access)</option>
-                            </select>
+                            <span className="block text-sm font-medium text-gray-700">Access Level</span>
+                            <p className="mt-1 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+                                {TENANT_INVITE_ROLE} (tenant-scoped access)
+                            </p>
                         </div>
                         <div className="pt-2">
                             <button

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -42,6 +42,7 @@ _FAILOVER_LOCK_NAME_ENV = "FAILOVER_LOCK_NAME"
 _DELETE_RETENTION_DAYS = 30
 _ADMIN_ROLES = {"Platform.Admin"}
 _SELF_SERVICE_ADMIN_ROLES = {"Platform.Admin", "Platform.Operator", "SelfService.Admin"}
+_ALLOWED_TENANT_INVITE_ROLES = {"Agent.Invoke"}
 _INVITE_EXPIRY_DAYS = 7
 _AUDIT_EXPORT_PREFIX = "audit-exports"
 _AUDIT_EXPORT_URL_EXPIRY_SECONDS = 3600
@@ -535,6 +536,14 @@ def _is_self_service_admin(caller: CallerIdentity) -> bool:
 
 def _can_manage_tenant_self_service(caller: CallerIdentity, tenant_id: str) -> bool:
     return _is_self_service_admin(caller)
+
+
+def _normalize_tenant_invite_role(value: Any) -> str:
+    role = _str_or_none(value) or "Agent.Invoke"
+    if role not in _ALLOWED_TENANT_INVITE_ROLES:
+        allowed = ", ".join(sorted(_ALLOWED_TENANT_INVITE_ROLES))
+        raise ValueError(f"role must be one of: {allowed}")
+    return role
 
 
 def _ddb_value(value: Any) -> Any:
@@ -1039,7 +1048,7 @@ def _handle_invite_user(
     if email is None or "@" not in email:
         raise ValueError("email is required and must be a valid email address")
 
-    role = _str_or_none(body.get("role")) or "Agent.Invoke"
+    role = _normalize_tenant_invite_role(body.get("role"))
     display_name = _str_or_none(body.get("displayName"))
     app_id = _str_or_none(existing.get("appId"))
 

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -1542,6 +1542,60 @@ def test_invite_user_for_own_tenant_succeeds_for_platform_operator(
     assert detail["tenantId"] == "t-invite"
 
 
+@pytest.mark.parametrize(
+    "role",
+    ["Platform.Operator", "Platform.Admin", "Unknown.Role", "agent.invoke"],
+)
+def test_invite_user_rejects_non_tenant_scoped_roles(fake_state: dict[str, Any], role: str) -> None:
+    fake_state["db"].items[("TENANT#t-invite-role", "METADATA")] = {
+        "PK": "TENANT#t-invite-role",
+        "SK": "METADATA",
+        "tenantId": "t-invite-role",
+        "appId": "app-invite-role",
+        "status": "active",
+    }
+    event = _event(
+        method="POST",
+        tenant_id="t-invite-role",
+        caller_tenant_id="t-invite-role",
+        roles=["Platform.Operator"],
+        app_id="app-invite-role",
+        body={"email": "new.user@example.com", "role": role},
+    )
+    event["path"] = "/v1/tenants/t-invite-role/users/invite"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+    error = _body(response)["error"]
+    assert error["code"] == "BAD_REQUEST"
+    assert error["message"] == "role must be one of: Agent.Invoke"
+
+
+def test_invite_user_defaults_role_to_agent_invoke(fake_state: dict[str, Any]) -> None:
+    fake_state["db"].items[("TENANT#t-invite-default", "METADATA")] = {
+        "PK": "TENANT#t-invite-default",
+        "SK": "METADATA",
+        "tenantId": "t-invite-default",
+        "appId": "app-invite-default",
+        "status": "active",
+    }
+    event = _event(
+        method="POST",
+        tenant_id="t-invite-default",
+        caller_tenant_id="t-invite-default",
+        roles=["Platform.Operator"],
+        app_id="app-invite-default",
+        body={"email": "new.user@example.com"},
+    )
+    event["path"] = "/v1/tenants/t-invite-default/users/invite"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 202
+    assert _body(response)["invite"]["role"] == "Agent.Invoke"
+
+
 def test_invite_user_canonicalizes_mixed_case_path_tenant_id(fake_state: dict[str, Any]) -> None:
     fake_state["db"].items[("TENANT#tenant-invite-001", "METADATA")] = {
         "PK": "TENANT#tenant-invite-001",


### PR DESCRIPTION
Closes #203

## Summary
- restrict tenant-managed invite roles to `Agent.Invoke` at the API boundary
- remove platform-role invite options from the tenant members SPA
- restore the missing SPA `SessionsListResponseDto` contract type so validation passes

## Validation
- `make preflight-session`
- `make pre-validate-session`
- `uv run pytest tests/unit/test_tenant_api_handler.py -q -k invite`
- `cd spa && ./node_modules/.bin/tsc --noEmit`