### PR TITLE
fix: expand SPA OpenAPI contract coverage for UI routes

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -276,7 +276,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Tenant"
+                $ref: "#/components/schemas/TenantReadResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -486,6 +486,28 @@ paths:
           $ref: "#/components/responses/InternalServerError"
 
   /v1/webhooks:
+    get:
+      tags: [Webhooks]
+      operationId: listWebhooks
+      summary: List registered webhooks
+      description: >
+        Lists webhook callback registrations visible to the current tenant self-service
+        admin caller.
+      responses:
+        "200":
+          description: Webhook registrations
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     post:
       tags: [Webhooks]
       operationId: registerWebhook
@@ -595,6 +617,96 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "409":
           $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/platform/ops/top-tenants:
+    get:
+      tags: [Platform]
+      operationId: getTopTenants
+      summary: Get top tenants by token volume
+      description: >
+        Returns the highest-volume tenants for platform operator monitoring.
+      x-required-roles:
+        - Platform.Admin
+        - Platform.Operator
+      parameters:
+        - in: query
+          name: n
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+      responses:
+        "200":
+          description: Top tenant list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TopTenantsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/platform/ops/security-events:
+    get:
+      tags: [Platform]
+      operationId: getSecurityEvents
+      summary: Get recent security events
+      description: >
+        Returns recent platform security events for operator review.
+      x-required-roles:
+        - Platform.Admin
+        - Platform.Operator
+      responses:
+        "200":
+          description: Security event list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SecurityEventsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/platform/ops/error-rate:
+    get:
+      tags: [Platform]
+      operationId: getPlatformErrorRate
+      summary: Get recent platform error rate
+      description: >
+        Returns platform error-rate telemetry for a recent rolling period.
+      x-required-roles:
+        - Platform.Admin
+        - Platform.Operator
+      parameters:
+        - in: query
+          name: minutes
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1440
+            default: 5
+      responses:
+        "200":
+          description: Platform error rate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorRateResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -976,12 +1088,14 @@ components:
 
     HealthResponse:
       type: object
-      required: [status, timestamp, version]
+      required: [status, timestamp, version, runtimeRegion]
       properties:
         status:
           type: string
           enum: [ok, degraded, fail]
         version:
+          type: string
+        runtimeRegion:
           type: string
         timestamp:
           $ref: "#/components/schemas/UtcTimestamp"
@@ -1193,6 +1307,30 @@ components:
         monthlyBudgetUsd:
           type: [number, "null"]
           minimum: 0
+
+    TenantUsageSummary:
+      type: object
+      properties:
+        requestsToday:
+          type: integer
+          minimum: 0
+        budgetRemainingUsd:
+          type: number
+          minimum: 0
+        usageIdentifierKey:
+          type: string
+
+    TenantReadResponse:
+      type: object
+      required: [tenant]
+      properties:
+        tenant:
+          allOf:
+            - $ref: "#/components/schemas/Tenant"
+            - type: object
+              properties:
+                usage:
+                  $ref: "#/components/schemas/TenantUsageSummary"
 
     TenantCreateRequest:
       type: object
@@ -1416,6 +1554,84 @@ components:
         signatureAlgorithm:
           type: string
           example: HMAC-SHA256
+
+    WebhookListItem:
+      allOf:
+        - $ref: "#/components/schemas/WebhookRegistrationResponse"
+        - type: object
+          properties:
+            status:
+              type: string
+            description:
+              type: [string, "null"]
+            updatedAt:
+              oneOf:
+                - $ref: "#/components/schemas/UtcTimestamp"
+                - type: "null"
+
+    WebhookListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/WebhookListItem"
+
+    TopTenant:
+      type: object
+      required: [tenantId, tokens]
+      properties:
+        tenantId:
+          type: string
+        tokens:
+          type: integer
+          minimum: 0
+
+    TopTenantsResponse:
+      type: object
+      required: [tenants]
+      properties:
+        tenants:
+          type: array
+          items:
+            $ref: "#/components/schemas/TopTenant"
+
+    SecurityEvent:
+      type: object
+      required: [timestamp, type, tenantId, details]
+      properties:
+        timestamp:
+          $ref: "#/components/schemas/UtcTimestamp"
+        type:
+          type: string
+        tenantId:
+          type: string
+        details:
+          type: string
+
+    SecurityEventsResponse:
+      type: object
+      required: [events]
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/SecurityEvent"
+
+    ErrorRateResponse:
+      type: object
+      required: [errorRate, periodMinutes, threshold]
+      properties:
+        errorRate:
+          type: number
+          minimum: 0
+        periodMinutes:
+          type: integer
+          minimum: 1
+        threshold:
+          type: number
+          minimum: 0
 
     BffTokenRefreshRequest:
       type: object

--- a/spa/src/api/contracts.ts
+++ b/spa/src/api/contracts.ts
@@ -57,6 +57,17 @@ export type TenantDto = {
   accountId?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
+  usage?: TenantUsageDto | null;
+};
+
+export type TenantUsageDto = {
+  requestsToday?: number;
+  budgetRemainingUsd?: number;
+  usageIdentifierKey?: string;
+};
+
+export type TenantReadResponseDto = {
+  tenant: TenantDto;
 };
 
 export type TenantUpdateRequestDto = {
@@ -72,6 +83,13 @@ export type AuditExportResponseDto = {
   tenantId: string;
   downloadUrl: string;
   expiresAt: string;
+};
+
+export type TenantApiKeyRotateResponseDto = {
+  tenantId: string;
+  apiKeySecretArn: string;
+  rotatedAt: string;
+  versionId?: string | null;
 };
 
 export type TopTenantsResponseDto = {
@@ -127,6 +145,41 @@ export type SessionDto = {
 export type SessionsListResponseDto = {
   items: SessionDto[];
   nextToken?: string | null;
+};
+
+export type WebhookEventDto = "job.completed" | "job.failed";
+
+export type WebhookRegistrationResponseDto = {
+  webhookId: string;
+  callbackUrl: string;
+  events: WebhookEventDto[];
+  createdAt: string;
+  signatureHeader: string;
+  signatureAlgorithm?: string;
+};
+
+export type WebhookListItemDto = WebhookRegistrationResponseDto & {
+  status?: string;
+  description?: string;
+  updatedAt?: string;
+};
+
+export type WebhooksListResponseDto = {
+  items: WebhookListItemDto[];
+};
+
+export type TenantUserInviteDto = {
+  inviteId: string;
+  tenantId: string;
+  email: string;
+  role: string;
+  status: "pending";
+  expiresAt: string;
+  displayName?: string | null;
+};
+
+export type TenantUserInviteAcceptedResponseDto = {
+  invite: TenantUserInviteDto;
 };
 
 export type TenantAdminRow = {
@@ -194,7 +247,7 @@ export type OpenApiContractExpectation = {
   method: "get" | "post" | "patch" | "delete";
   statusCode: string;
   collectionProperty?: string;
-  requiredFields: string[];
+  requiredFieldPaths: string[];
 };
 
 export const SPA_OPENAPI_CONTRACTS: OpenApiContractExpectation[] = [
@@ -204,7 +257,7 @@ export const SPA_OPENAPI_CONTRACTS: OpenApiContractExpectation[] = [
     method: "get",
     statusCode: "200",
     collectionProperty: "items",
-    requiredFields: [
+    requiredFieldPaths: [
       "agentName",
       "latestVersion",
       "tierMinimum",
@@ -217,7 +270,7 @@ export const SPA_OPENAPI_CONTRACTS: OpenApiContractExpectation[] = [
     path: "/v1/agents/{agentName}",
     method: "get",
     statusCode: "200",
-    requiredFields: [
+    requiredFieldPaths: [
       "agentName",
       "latestVersion",
       "tierMinimum",
@@ -232,7 +285,90 @@ export const SPA_OPENAPI_CONTRACTS: OpenApiContractExpectation[] = [
     method: "get",
     statusCode: "200",
     collectionProperty: "items",
-    requiredFields: ["tenantId", "displayName", "tier", "status"],
+    requiredFieldPaths: ["tenantId", "displayName", "tier", "status"],
+  },
+  {
+    name: "tenantDetail",
+    path: "/v1/tenants/{tenantId}",
+    method: "get",
+    statusCode: "200",
+    requiredFieldPaths: [
+      "tenant.tenantId",
+      "tenant.displayName",
+      "tenant.tier",
+      "tenant.status",
+      "tenant.ownerEmail",
+      "tenant.ownerTeam",
+      "tenant.createdAt",
+      "tenant.updatedAt",
+      "tenant.apiKeySecretArn",
+      "tenant.usage.requestsToday",
+      "tenant.usage.budgetRemainingUsd",
+    ],
+  },
+  {
+    name: "tenantAuditExport",
+    path: "/v1/tenants/{tenantId}/audit-export",
+    method: "get",
+    statusCode: "200",
+    requiredFieldPaths: ["tenantId", "downloadUrl", "expiresAt"],
+  },
+  {
+    name: "tenantApiKeyRotate",
+    path: "/v1/tenants/{tenantId}/api-key/rotate",
+    method: "post",
+    statusCode: "200",
+    requiredFieldPaths: ["tenantId", "apiKeySecretArn", "rotatedAt"],
+  },
+  {
+    name: "tenantInvite",
+    path: "/v1/tenants/{tenantId}/users/invite",
+    method: "post",
+    statusCode: "202",
+    requiredFieldPaths: [
+      "invite.inviteId",
+      "invite.tenantId",
+      "invite.email",
+      "invite.role",
+      "invite.status",
+      "invite.expiresAt",
+    ],
+  },
+  {
+    name: "webhookList",
+    path: "/v1/webhooks",
+    method: "get",
+    statusCode: "200",
+    collectionProperty: "items",
+    requiredFieldPaths: [
+      "webhookId",
+      "callbackUrl",
+      "events",
+      "status",
+      "description",
+      "createdAt",
+      "signatureHeader",
+    ],
+  },
+  {
+    name: "webhookRegister",
+    path: "/v1/webhooks",
+    method: "post",
+    statusCode: "201",
+    requiredFieldPaths: [
+      "webhookId",
+      "callbackUrl",
+      "events",
+      "createdAt",
+      "signatureHeader",
+    ],
+  },
+  {
+    name: "jobStatus",
+    path: "/v1/jobs/{jobId}",
+    method: "get",
+    statusCode: "200",
+    requiredFieldPaths: ["jobId", "tenantId", "agentName", "status", "createdAt"],
   },
   {
     name: "quota",
@@ -240,27 +376,57 @@ export const SPA_OPENAPI_CONTRACTS: OpenApiContractExpectation[] = [
     method: "get",
     statusCode: "200",
     collectionProperty: "utilisation",
-    requiredFields: ["region", "quotaName", "currentValue", "limit", "utilisationPercentage"],
+    requiredFieldPaths: ["region", "quotaName", "currentValue", "limit", "utilisationPercentage"],
+  },
+  {
+    name: "topTenants",
+    path: "/v1/platform/ops/top-tenants",
+    method: "get",
+    statusCode: "200",
+    collectionProperty: "tenants",
+    requiredFieldPaths: ["tenantId", "tokens"],
+  },
+  {
+    name: "securityEvents",
+    path: "/v1/platform/ops/security-events",
+    method: "get",
+    statusCode: "200",
+    collectionProperty: "events",
+    requiredFieldPaths: ["timestamp", "type", "tenantId", "details"],
+  },
+  {
+    name: "errorRate",
+    path: "/v1/platform/ops/error-rate",
+    method: "get",
+    statusCode: "200",
+    requiredFieldPaths: ["errorRate", "periodMinutes", "threshold"],
+  },
+  {
+    name: "platformFailover",
+    path: "/v1/platform/failover",
+    method: "post",
+    statusCode: "200",
+    requiredFieldPaths: ["status", "region", "previousRegion", "lockId", "changed"],
   },
   {
     name: "health",
     path: "/v1/health",
     method: "get",
     statusCode: "200",
-    requiredFields: ["status", "version", "timestamp"],
+    requiredFieldPaths: ["status", "version", "runtimeRegion", "timestamp"],
   },
   {
     name: "bffTokenRefresh",
     path: "/v1/bff/token-refresh",
     method: "post",
     statusCode: "200",
-    requiredFields: ["accessToken", "tokenType", "expiresAt"],
+    requiredFieldPaths: ["accessToken", "tokenType", "expiresAt"],
   },
   {
     name: "bffSessionKeepalive",
     path: "/v1/bff/session-keepalive",
     method: "post",
     statusCode: "202",
-    requiredFields: ["sessionId", "status", "expiresAt"],
+    requiredFieldPaths: ["sessionId", "status", "expiresAt"],
   },
 ];

--- a/spa/src/api/openapiContract.test.ts
+++ b/spa/src/api/openapiContract.test.ts
@@ -35,6 +35,11 @@ type OpenApiOperation = {
   >;
 };
 
+type SourceRouteReference = {
+  filePath: string;
+  route: string;
+};
+
 function loadOpenApiDoc(): OpenApiDoc {
   const currentFile = fileURLToPath(import.meta.url);
   const specPath = path.resolve(path.dirname(currentFile), "../../../docs/openapi.yaml");
@@ -103,6 +108,74 @@ function resolveSchema(schema: OpenApiSchema | undefined, doc: OpenApiDoc): Open
   return schema;
 }
 
+function resolveSchemaPath(
+  schema: OpenApiSchema | undefined,
+  doc: OpenApiDoc,
+  fieldPath: string,
+): OpenApiSchema | undefined {
+  let current = resolveSchema(schema, doc);
+  for (const segment of fieldPath.split(".")) {
+    current = resolveSchema(current?.properties?.[segment], doc);
+  }
+  return current;
+}
+
+function collectSpaRouteReferences(): SourceRouteReference[] {
+  const currentFile = fileURLToPath(import.meta.url);
+  const spaSrcRoot = path.resolve(path.dirname(currentFile), "..");
+  const targetFiles = [
+    path.join(spaSrcRoot, "api", "client.ts"),
+    path.join(spaSrcRoot, "hooks", "useJobPolling.ts"),
+    ...walkFiles(path.join(spaSrcRoot, "pages")),
+  ];
+
+  const routePattern = /(["'`])((?:\/v1\/)[^"'`\n]+)\1/g;
+  const references: SourceRouteReference[] = [];
+
+  for (const filePath of targetFiles) {
+    if (filePath.endsWith(".test.ts") || filePath.endsWith(".test.tsx")) {
+      continue;
+    }
+
+    const source = fs.readFileSync(filePath, "utf8");
+    for (const match of source.matchAll(routePattern)) {
+      references.push({
+        filePath,
+        route: normalizeRoutePath(match[2]),
+      });
+    }
+  }
+
+  return references;
+}
+
+function walkFiles(root: string): string[] {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function normalizeRoutePath(route: string): string {
+  return route
+    .split("?")[0]
+    .replace(/\$\{\s*agentName\s*\}/g, "{agentName}")
+    .replace(/\$\{\s*tenantId\s*\}/g, "{tenantId}")
+    .replace(/\$\{\s*jobId\s*\}/g, "{jobId}")
+    .replace(/\$\{\s*webhookId\s*\}/g, "{webhookId}");
+}
+
 describe("SPA/OpenAPI contract drift", () => {
   it("keeps SPA-consumed endpoints and response fields aligned", () => {
     const doc = loadOpenApiDoc();
@@ -135,22 +208,34 @@ describe("SPA/OpenAPI contract drift", () => {
           collectionSchema?.type === "array"
             ? resolveSchema(collectionSchema.items, doc)
             : collectionSchema;
-        for (const field of contract.requiredFields) {
+        for (const fieldPath of contract.requiredFieldPaths) {
           expect(
-            itemSchema?.properties?.[field],
-            `${contract.name}: missing field ${field} on collection item schema`,
+            resolveSchemaPath(itemSchema, doc, fieldPath),
+            `${contract.name}: missing field ${fieldPath} on collection item schema`,
           ).toBeTruthy();
         }
         continue;
       }
 
       const resolvedRoot = resolveSchema(responseSchema, doc);
-      for (const field of contract.requiredFields) {
+      for (const fieldPath of contract.requiredFieldPaths) {
         expect(
-          resolvedRoot?.properties?.[field],
-          `${contract.name}: missing field ${field} on response schema`,
+          resolveSchemaPath(resolvedRoot, doc, fieldPath),
+          `${contract.name}: missing field ${fieldPath} on response schema`,
         ).toBeTruthy();
       }
+    }
+  });
+
+  it("does not reference undocumented SPA API routes", () => {
+    const doc = loadOpenApiDoc();
+    const references = collectSpaRouteReferences();
+
+    for (const reference of references) {
+      expect(
+        doc.paths?.[reference.route],
+        `${path.basename(reference.filePath)} references undocumented route ${reference.route}`,
+      ).toBeTruthy();
     }
   });
 });

--- a/spa/src/pages/SessionsPage.test.tsx
+++ b/spa/src/pages/SessionsPage.test.tsx
@@ -1,17 +1,11 @@
 /* @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getApiClient } from "../api/client";
 import { useAuth } from "../auth/useAuth";
-import { createApiClientMock, createAuthContextValue } from "../test/mockFactories";
-import { sessionsList } from "../test/testData";
+import { createAuthContextValue } from "../test/mockFactories";
 import { SessionsPage } from "./SessionsPage";
-
-vi.mock("../api/client", () => ({
-  getApiClient: vi.fn(),
-}));
 
 vi.mock("../auth/useAuth", () => ({
   useAuth: vi.fn(),
@@ -25,64 +19,28 @@ describe("SessionsPage", () => {
     }) as never);
   });
 
-  it("renders sessions when API returns items", async () => {
-    const request = vi.fn().mockResolvedValue(sessionsList);
-    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
-      request,
-    }) as never);
-
+  it("renders the undeployed-route placeholder instead of calling the session API", () => {
     render(<SessionsPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("echo-agent")).toBeInTheDocument();
-      expect(screen.getByText("active")).toBeInTheDocument();
-      expect(screen.getByText("research-agent")).toBeInTheDocument();
-      expect(screen.getByText("completed")).toBeInTheDocument();
-    });
-    expect(request).toHaveBeenCalledWith("/v1/sessions");
+    expect(screen.getByText("Session Listing Pending")).toBeInTheDocument();
+    expect(screen.getByText("Session Listing Not Yet Available")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The current tenant API still returns not implemented for session enumeration. Existing sessions remain active, but this page will not call the undeployed route.",
+      ),
+    ).toBeInTheDocument();
   });
 
-  it("renders empty state when no sessions are returned", async () => {
-    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
-      request: vi.fn().mockResolvedValue({ items: [] }),
-    }) as never);
-
-    render(<SessionsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("No active sessions.")).toBeInTheDocument();
-    });
-  });
-
-  it("renders error state when sessions request fails", async () => {
-    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
-      request: vi.fn().mockRejectedValue(new Error("sessions failed")),
-    }) as never);
-
-    render(<SessionsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("sessions failed")).toBeInTheDocument();
-    });
-  });
-
-  it("does not fetch sessions when user is unauthenticated", async () => {
+  it("shows auth guidance when the user is unauthenticated", () => {
     vi.mocked(useAuth).mockReturnValue(createAuthContextValue({
       isAuthenticated: false,
     }) as never);
-    const request = vi.fn();
-    vi.mocked(getApiClient).mockReturnValue(createApiClientMock({
-      request,
-    }) as never);
 
     render(<SessionsPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Authentication Required")).toBeInTheDocument();
-      expect(
-        screen.getByText("Sign in with your Entra account to view active runtime sessions for this tenant."),
-      ).toBeInTheDocument();
-    });
-    expect(request).not.toHaveBeenCalled();
+    expect(screen.getByText("Authentication Required")).toBeInTheDocument();
+    expect(
+      screen.getByText("Sign in with your Entra account to view active runtime sessions for this tenant."),
+    ).toBeInTheDocument();
   });
 });

--- a/spa/src/pages/SessionsPage.tsx
+++ b/spa/src/pages/SessionsPage.tsx
@@ -1,69 +1,19 @@
-import React, { useEffect, useState } from "react";
-import { SessionRow, SessionsListResponseDto, toSessionRow } from "../api/contracts";
-import { getApiClient } from "../api/client";
+import React from "react";
 import { useAuth } from "../auth/useAuth";
-import { Loading } from "../components/ui/loading";
 import { PageBanner } from "../components/PageBanner";
-import { Badge } from "../components/ui/badge";
 import { Typography } from "../components/ui/typography";
 import { EmptyState } from "../components/ui/empty-state";
-import { 
-  Table, 
-  TableBody, 
-  TableCell, 
-  TableHead, 
-  TableHeader, 
-  TableRow 
-} from "../components/ui/table";
-import { Activity, Clock, Terminal, Calendar, Zap } from "lucide-react";
+import { Activity, Zap } from "lucide-react";
 
 export const SessionsPage: React.FC = () => {
-    const [sessions, setSessions] = useState<SessionRow[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const { getAccessToken, isAuthenticated, isLoading: authLoading } = useAuth();
+    const { isAuthenticated, isLoading: authLoading } = useAuth();
 
-    useEffect(() => {
-        if (authLoading) {
-            return;
-        }
-
-        if (!isAuthenticated) {
-            setSessions([]);
-            setError(null);
-            setLoading(false);
-            return;
-        }
-
-        const fetchSessions = async () => {
-            try {
-                const client = getApiClient(getAccessToken);
-                const data = await client.request<SessionsListResponseDto>("/v1/sessions");
-                setSessions((data.items || []).map(toSessionRow));
-            } catch (err: unknown) {
-                console.error("Failed to fetch sessions", err);
-                setError(err instanceof Error ? err.message : "Failed to load active sessions.");
-            } finally {
-                setLoading(false);
-            }
-        };
-        fetchSessions();
-    }, [authLoading, getAccessToken, isAuthenticated]);
-
-    if (loading || authLoading) return <Loading message="Retrieving active sessions..." className="h-[400px]" />;
+    if (authLoading) return null;
 
     if (!isAuthenticated) {
         return (
             <PageBanner title="Authentication Required" severity="warning">
                 Sign in with your Entra account to view active runtime sessions for this tenant.
-            </PageBanner>
-        );
-    }
-    
-    if (error) {
-        return (
-            <PageBanner title="Session Sync Failed" severity="error">
-                {error}
             </PageBanner>
         );
     }
@@ -77,65 +27,15 @@ export const SessionsPage: React.FC = () => {
                 </Typography>
             </div>
 
-            {sessions.length === 0 ? (
-                <EmptyState 
-                    title="No Active Sessions" 
-                    description="You don't have any active agent sessions at the moment. Start an invocation to create a new session."
-                    icon={Activity}
-                />
-            ) : (
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Session Context</TableHead>
-                            <TableHead>Agent</TableHead>
-                            <TableHead className="hidden sm:table-cell">Timeline</TableHead>
-                            <TableHead>Posture</TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {sessions.map((session) => (
-                            <TableRow key={session.sessionId}>
-                                <TableCell>
-                                    <div className="flex flex-col gap-1">
-                                        <span className="font-mono text-xs text-white bg-white/5 px-2 py-0.5 rounded w-fit border border-white/5">
-                                            {session.sessionId.substring(0, 12)}...
-                                        </span>
-                                    </div>
-                                </TableCell>
-                                <TableCell>
-                                    <div className="flex items-center gap-2">
-                                        <div className="h-8 w-8 rounded-lg bg-cyan-500/10 flex items-center justify-center text-cyan-400">
-                                            <Terminal className="h-4 w-4" />
-                                        </div>
-                                        <span className="font-bold text-white text-sm">{session.agentName}</span>
-                                    </div>
-                                </TableCell>
-                                <TableCell className="hidden sm:table-cell">
-                                    <div className="flex flex-col gap-1 text-xs">
-                                        <div className="flex items-center gap-2 text-slate-400">
-                                            <Calendar className="h-3 w-3" />
-                                            <span>Started: {new Date(session.startedAt).toLocaleString()}</span>
-                                        </div>
-                                        <div className="flex items-center gap-2 text-slate-400 font-semibold">
-                                            <Clock className="h-3 w-3" />
-                                            <span>Last: {new Date(session.lastActivityAt).toLocaleString()}</span>
-                                        </div>
-                                    </div>
-                                </TableCell>
-                                <TableCell>
-                                    <Badge 
-                                      variant={session.status === "active" ? "success" : "secondary"}
-                                      className="capitalize tracking-widest text-[10px]"
-                                    >
-                                        {session.status}
-                                    </Badge>
-                                </TableCell>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            )}
+            <PageBanner title="Session Listing Pending" severity="info">
+                Tenant-backed session listing is not deployed yet. Use the invoke flow to maintain an active session, and check back once the northbound route is published.
+            </PageBanner>
+
+            <EmptyState 
+                title="Session Listing Not Yet Available" 
+                description="The current tenant API still returns not implemented for session enumeration. Existing sessions remain active, but this page will not call the undeployed route."
+                icon={Activity}
+            />
 
             <div className="rounded-2xl border border-white/5 bg-slate-900/40 p-6 flex items-start gap-4">
                <div className="h-10 w-10 rounded-full bg-cyan-500/10 flex items-center justify-center text-cyan-400 shrink-0">

--- a/spa/src/pages/TenantApiKeysPage.tsx
+++ b/spa/src/pages/TenantApiKeysPage.tsx
@@ -1,19 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
+import type { TenantApiKeyRotateResponseDto, TenantReadResponseDto } from "../api/contracts";
 import { useAuth } from "../auth/useAuth";
-
-type TenantRecord = {
-    tenantId: string;
-    apiKeySecretArn?: string;
-    updatedAt: string;
-};
-
-type RotateResponse = {
-    tenantId: string;
-    apiKeySecretArn: string;
-    rotatedAt: string;
-    versionId?: string | null;
-};
 
 function resolveTenantId(claims: unknown): string | null {
     if (!claims || typeof claims !== "object") {
@@ -28,7 +16,7 @@ export const TenantApiKeysPage: React.FC = () => {
     const { getAccessToken, account, isAuthenticated } = useAuth();
     const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
 
-    const [tenant, setTenant] = useState<TenantRecord | null>(null);
+    const [tenant, setTenant] = useState<TenantReadResponseDto["tenant"] | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [rotating, setRotating] = useState(false);
@@ -43,7 +31,7 @@ export const TenantApiKeysPage: React.FC = () => {
         const run = async () => {
             try {
                 const client = getApiClient(getAccessToken);
-                const data = await client.request<{ tenant: TenantRecord }>(`/v1/tenants/${tenantId}`);
+                const data = await client.request<TenantReadResponseDto>(`/v1/tenants/${tenantId}`);
                 setTenant(data.tenant);
             } catch (err) {
                 setError(err instanceof Error ? err.message : "Failed to load API key data.");
@@ -60,7 +48,7 @@ export const TenantApiKeysPage: React.FC = () => {
         setRotateMessage(null);
         try {
             const client = getApiClient(getAccessToken);
-            const result = await client.request<RotateResponse>(`/v1/tenants/${tenantId}/api-key/rotate`, {
+            const result = await client.request<TenantApiKeyRotateResponseDto>(`/v1/tenants/${tenantId}/api-key/rotate`, {
                 method: "POST",
             });
             setRotateMessage(`API key rotated successfully at ${new Date(result.rotatedAt).toLocaleString()}.`);

--- a/spa/src/pages/TenantDashboardPage.tsx
+++ b/spa/src/pages/TenantDashboardPage.tsx
@@ -1,20 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
+import type { TenantReadResponseDto } from "../api/contracts";
 import { useAuth } from "../auth/useAuth";
 import { Link } from "react-router-dom";
-
-type TenantUsage = {
-    requestsToday?: number;
-    budgetRemainingUsd?: number;
-};
-
-type TenantRecord = {
-    tenantId: string;
-    displayName: string;
-    tier: string;
-    status: string;
-    usage?: TenantUsage;
-};
 
 function resolveTenantId(claims: unknown): string | null {
     if (!claims || typeof claims !== "object") {
@@ -29,7 +17,7 @@ export const TenantDashboardPage: React.FC = () => {
     const { getAccessToken, account, isAuthenticated } = useAuth();
     const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
 
-    const [tenant, setTenant] = useState<TenantRecord | null>(null);
+    const [tenant, setTenant] = useState<TenantReadResponseDto["tenant"] | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -42,7 +30,7 @@ export const TenantDashboardPage: React.FC = () => {
         const run = async () => {
             try {
                 const client = getApiClient(getAccessToken);
-                const data = await client.request<{ tenant: TenantRecord }>(`/v1/tenants/${tenantId}`);
+                const data = await client.request<TenantReadResponseDto>(`/v1/tenants/${tenantId}`);
                 setTenant(data.tenant);
             } catch (err) {
                 setError(err instanceof Error ? err.message : "Failed to load dashboard.");

--- a/spa/src/pages/TenantMembersPage.tsx
+++ b/spa/src/pages/TenantMembersPage.tsx
@@ -1,15 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
+import type { TenantUserInviteAcceptedResponseDto, TenantUserInviteDto } from "../api/contracts";
 import { useAuth } from "../auth/useAuth";
-
-type Invite = {
-    inviteId: string;
-    email: string;
-    role: string;
-    status: string;
-    expiresAt: string;
-    createdAt?: string;
-};
 
 function resolveTenantId(claims: unknown): string | null {
     if (!claims || typeof claims !== "object") {
@@ -24,7 +16,7 @@ export const TenantMembersPage: React.FC = () => {
     const { getAccessToken, account, isAuthenticated } = useAuth();
     const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
 
-    const [invites, setInvites] = useState<Invite[]>([]);
+    const [invites, setInvites] = useState<TenantUserInviteDto[]>([]);
     const [inviteEmail, setInviteEmail] = useState("");
     const [inviteRole, setInviteRole] = useState("Agent.Invoke");
     const [submitting, setSubmitting] = useState(false);
@@ -37,7 +29,7 @@ export const TenantMembersPage: React.FC = () => {
         setInviteMessage(null);
         try {
             const client = getApiClient(getAccessToken);
-            const response = await client.request<{ invite: Invite }>(`/v1/tenants/${tenantId}/users/invite`, {
+            const response = await client.request<TenantUserInviteAcceptedResponseDto>(`/v1/tenants/${tenantId}/users/invite`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),

--- a/spa/src/pages/TenantSettingsPage.tsx
+++ b/spa/src/pages/TenantSettingsPage.tsx
@@ -1,17 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
+import type { TenantReadResponseDto } from "../api/contracts";
 import { useAuth } from "../auth/useAuth";
-
-type TenantRecord = {
-    tenantId: string;
-    displayName: string;
-    tier: string;
-    status: string;
-    ownerEmail: string;
-    ownerTeam: string;
-    createdAt: string;
-    updatedAt: string;
-};
 
 function resolveTenantId(claims: unknown): string | null {
     if (!claims || typeof claims !== "object") {
@@ -26,7 +16,7 @@ export const TenantSettingsPage: React.FC = () => {
     const { getAccessToken, account, isAuthenticated } = useAuth();
     const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
 
-    const [tenant, setTenant] = useState<TenantRecord | null>(null);
+    const [tenant, setTenant] = useState<TenantReadResponseDto["tenant"] | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -39,7 +29,7 @@ export const TenantSettingsPage: React.FC = () => {
         const run = async () => {
             try {
                 const client = getApiClient(getAccessToken);
-                const data = await client.request<{ tenant: TenantRecord }>(`/v1/tenants/${tenantId}`);
+                const data = await client.request<TenantReadResponseDto>(`/v1/tenants/${tenantId}`);
                 setTenant(data.tenant);
             } catch (err) {
                 setError(err instanceof Error ? err.message : "Failed to load settings.");

--- a/spa/src/pages/TenantWebhooksPage.tsx
+++ b/spa/src/pages/TenantWebhooksPage.tsx
@@ -1,15 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { getApiClient } from "../api/client";
+import type {
+    WebhookListItemDto,
+    WebhookRegistrationResponseDto,
+    WebhooksListResponseDto,
+} from "../api/contracts";
 import { useAuth } from "../auth/useAuth";
-
-type Webhook = {
-    webhookId: string;
-    callbackUrl: string;
-    events: string[];
-    status: string;
-    createdAt: string;
-    description?: string;
-};
 
 function resolveTenantId(claims: unknown): string | null {
     if (!claims || typeof claims !== "object") {
@@ -24,7 +20,7 @@ export const TenantWebhooksPage: React.FC = () => {
     const { getAccessToken, account, isAuthenticated } = useAuth();
     const tenantId = useMemo(() => resolveTenantId(account?.idTokenClaims), [account?.idTokenClaims]);
 
-    const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+    const [webhooks, setWebhooks] = useState<WebhookListItemDto[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [callbackUrl, setCallbackUrl] = useState("");
@@ -42,7 +38,7 @@ export const TenantWebhooksPage: React.FC = () => {
         const run = async () => {
             try {
                 const client = getApiClient(getAccessToken);
-                const data = await client.request<{ items: Webhook[] }>(`/v1/webhooks`);
+                const data = await client.request<WebhooksListResponseDto>(`/v1/webhooks`);
                 setWebhooks(data.items);
             } catch (err) {
                 setError(err instanceof Error ? err.message : "Failed to load webhooks.");
@@ -59,7 +55,7 @@ export const TenantWebhooksPage: React.FC = () => {
         setMessage(null);
         try {
             const client = getApiClient(getAccessToken);
-            const response = await client.request<Webhook>(`/v1/webhooks`, {
+            const response = await client.request<WebhookRegistrationResponseDto>(`/v1/webhooks`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -71,7 +67,14 @@ export const TenantWebhooksPage: React.FC = () => {
             setMessage({ type: 'success', text: "Webhook registered successfully." });
             setCallbackUrl("");
             setDescription("");
-            setWebhooks(prev => [...prev, response]);
+            setWebhooks(prev => [
+                ...prev,
+                {
+                    ...response,
+                    description: description.trim() || undefined,
+                    status: "active",
+                },
+            ]);
         } catch (err) {
             setMessage({ type: 'error', text: err instanceof Error ? err.message : "Failed to register webhook." });
         } finally {


### PR DESCRIPTION
## Summary
- expand SPA/OpenAPI contract coverage to the tenant, webhook, admin ops, jobs, health, and BFF routes the UI actually consumes
- add an automated route inventory check so SPA source files fail when they reference undocumented `/v1/...` routes
- remove the `SessionsPage` call to the intentionally `501` session-listing endpoint and replace it with an explicit placeholder

## Validation
- `make preflight-session`
- `make pre-validate-session`
- `uv run pytest tests/unit/test_openapi_contract_routes.py -q`
- `uv run pytest tests/unit/test_tenant_api_handler.py -q -k 'read_own_tenant_allowed_and_enriched_with_usage or webhook_management_succeeds_for_platform_operator or health_route_returns_openapi_shape'`
- `make issues-audit`

## Notes
- `uv run pytest tests/unit/test_ops_api.py -q` is currently broken in this worktree due an existing fixture mismatch: `TenantApiDependencies.__init__()` now requires `platform_quota_client`. I did not widen scope into that unrelated harness issue.
- I could not run the SPA Vitest suite in this worktree because `npm install` failed with `ENOSPC` while creating `spa/node_modules`.

Closes #206
