### PR TITLE
Fix billing fallback pricing failures

### DIFF
--- a/ai-context/AGENTS.md
+++ b/ai-context/AGENTS.md
@@ -109,7 +109,7 @@ ADR-013: Entra group-to-role claim for RBAC
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationships, 192 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2553 symbols, 8100 relationships, 207 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -125,7 +125,7 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt193/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -164,10 +164,10 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/wt193/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt193/clusters` | All functional areas |
-| `gitnexus://repo/wt193/processes` | All execution flows |
-| `gitnexus://repo/wt193/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/ai-context/CLAUDE.md
+++ b/ai-context/CLAUDE.md
@@ -343,7 +343,7 @@ git worktree prune
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationships, 192 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2553 symbols, 8100 relationships, 207 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -359,7 +359,7 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt193/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -398,10 +398,10 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/wt193/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt193/clusters` | All functional areas |
-| `gitnexus://repo/wt193/processes` | All execution flows |
-| `gitnexus://repo/wt193/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -24,8 +24,6 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Key
 from data_access.client import TenantScopedDynamoDB
 from data_access.models import (
-    BillingSummaryRecord,
-    InvocationStatus,
     TenantContext,
     TenantStatus,
     TenantTier,
@@ -44,25 +42,51 @@ _events = boto3.client("events", region_name=os.environ["AWS_REGION"])
 _dynamodb = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"])
 
 
+class PricingResolutionError(RuntimeError):
+    """Raised when billing pricing configuration is unavailable or invalid."""
+
+
 def _get_pricing(tier: str) -> dict[str, float]:
     """Fetch pricing for a tier from SSM."""
     path = f"/platform/billing/pricing/{tier}"
     try:
         response = _ssm.get_parameter(Name=path)
         value = response.get("Parameter", {}).get("Value")
-        if not value:
-            raise ValueError(f"Empty or missing Value in SSM parameter {path}")
-        return json.loads(value)
-    except Exception as e:
-        logger.error(f"Failed to fetch pricing for tier={tier}: {e}")
-        # Default fallback pricing (conservative)
-        return {"input_1k": 0.01, "output_1k": 0.03}
+    except Exception as exc:
+        raise PricingResolutionError(f"Failed to fetch pricing parameter {path} from SSM") from exc
+
+    if not value:
+        raise PricingResolutionError(f"Pricing parameter {path} is empty or missing a value")
+
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise PricingResolutionError(f"Pricing parameter {path} contains malformed JSON") from exc
+
+    if not isinstance(parsed, dict):
+        raise PricingResolutionError(
+            f"Pricing parameter {path} must be a JSON object, got {type(parsed).__name__}"
+        )
+
+    pricing: dict[str, float] = {}
+    for field in ("input_1k", "output_1k"):
+        raw_value = parsed.get(field)
+        if raw_value is None:
+            raise PricingResolutionError(f"Pricing parameter {path} is missing {field}")
+        try:
+            pricing[field] = float(raw_value)
+        except (TypeError, ValueError) as exc:
+            raise PricingResolutionError(
+                f"Pricing parameter {path} has non-numeric {field}: {raw_value!r}"
+            ) from exc
+
+    return pricing
 
 
 def _calculate_cost(input_tokens: int, output_tokens: int, pricing: dict[str, float]) -> float:
     """Calculate cost in USD."""
-    input_cost = (input_tokens / 1000.0) * pricing.get("input_1k", 0.0)
-    output_cost = (output_tokens / 1000.0) * pricing.get("output_1k", 0.0)
+    input_cost = (input_tokens / 1000.0) * pricing["input_1k"]
+    output_cost = (output_tokens / 1000.0) * pricing["output_1k"]
     return input_cost + output_cost
 
 
@@ -85,6 +109,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
     tier = tenant["tier"]
     budget = float(tenant.get("monthly_budget_usd", 0.0))
     app_id = tenant.get("app_id", "unknown")
+    pricing_path = f"/platform/billing/pricing/{tier}"
 
     # Day window
     start_time = date_to_process.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
@@ -116,7 +141,14 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
     day_output = sum(int(inv.get("output_tokens", 0)) for inv in result.items)
 
     # 2. Apply pricing
-    pricing = _get_pricing(tier)
+    try:
+        pricing = _get_pricing(tier)
+    except PricingResolutionError as exc:
+        logger.exception(
+            "Billing pricing resolution failed",
+            extra={"pricing_path": pricing_path, "tier": tier},
+        )
+        raise PricingResolutionError(f"Unable to price tenant {tenant_id}") from exc
     day_cost = _calculate_cost(day_input, day_output, pricing)
 
     # 3. Update monthly summary
@@ -215,13 +247,14 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
         try:
             _process_tenant(tenant, date_to_process)
             processed += 1
-        except Exception as e:
-            logger.exception(f"Failed to process tenant {tenant.get('tenant_id')}: {e}")
+        except Exception as exc:
+            logger.exception(f"Failed to process tenant {tenant.get('tenant_id')}: {exc}")
             errors += 1
 
+    status = "success" if errors == 0 else "partial_failure"
     logger.info(f"Billing pipeline complete. Processed={processed}, Errors={errors}")
     return {
-        "status": "success",
+        "status": status,
         "processed": processed,
         "errors": errors,
         "date": date_to_process.date().isoformat(),

--- a/tests/unit/test_billing_handler.py
+++ b/tests/unit/test_billing_handler.py
@@ -41,6 +41,7 @@ os.environ["TENANTS_TABLE_NAME"] = "platform-tenants"
 os.environ["INVOCATIONS_TABLE_NAME"] = "platform-invocations"
 os.environ["EVENT_BUS_NAME"] = "default"
 
+from src.billing import handler as billing_handler
 from src.billing.handler import lambda_handler
 
 # Constants for test
@@ -218,3 +219,87 @@ def test_incremental_update(mock_aws_clients: Any) -> None:
     assert summary["total_output_tokens"] == 3000
     # New cost: 1.5 + (1*0.1 + 1*0.2) = 1.5 + 0.3 = 1.8
     assert float(summary["total_cost_usd"]) == 1.8
+
+
+def test_missing_pricing_parameter_fails_tenant_and_records_error(mock_aws_clients: Any) -> None:
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    ssm = boto3.client("ssm", region_name="eu-west-2")
+    _seed_tenant(ddb)
+
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    ts = yesterday.replace(hour=12).isoformat()
+    _seed_invocation(ddb, timestamp=ts, input_tokens=1000, output_tokens=1000)
+
+    ssm.delete_parameter(Name=f"/platform/billing/pricing/{TIER}")
+
+    result = lambda_handler({"date": yesterday.date().isoformat()}, MagicMock())
+
+    assert result["processed"] == 0
+    assert result["errors"] == 1
+    assert result["status"] == "partial_failure"
+
+    year_month = yesterday.strftime("%Y-%m")
+    table = ddb.Table("platform-tenants")
+    resp = table.get_item(Key={"PK": f"TENANT#{TENANT_ID}", "SK": f"BILLING#{year_month}"})
+    assert "Item" not in resp
+
+
+def test_malformed_pricing_parameter_fails_clearly(
+    mock_aws_clients: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    ssm = boto3.client("ssm", region_name="eu-west-2")
+    _seed_tenant(ddb)
+
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    ts = yesterday.replace(hour=12).isoformat()
+    _seed_invocation(ddb, timestamp=ts, input_tokens=1000, output_tokens=1000)
+
+    ssm.put_parameter(
+        Name=f"/platform/billing/pricing/{TIER}",
+        Value="{not-json",
+        Type="String",
+        Overwrite=True,
+    )
+
+    logger_exception = MagicMock()
+    monkeypatch.setattr(billing_handler.logger, "exception", logger_exception)
+
+    result = lambda_handler({"date": yesterday.date().isoformat()}, MagicMock())
+
+    assert result["processed"] == 0
+    assert result["errors"] == 1
+    logger_exception.assert_any_call(
+        "Billing pricing resolution failed",
+        extra={"pricing_path": f"/platform/billing/pricing/{TIER}", "tier": TIER},
+    )
+
+
+def test_pricing_lookup_failure_is_reported_in_pipeline_logs(
+    mock_aws_clients: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    ssm = boto3.client("ssm", region_name="eu-west-2")
+    _seed_tenant(ddb)
+
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    ts = yesterday.replace(hour=12).isoformat()
+    _seed_invocation(ddb, timestamp=ts, input_tokens=1000, output_tokens=1000)
+
+    ssm.delete_parameter(Name=f"/platform/billing/pricing/{TIER}")
+
+    logger_exception = MagicMock()
+    monkeypatch.setattr(billing_handler.logger, "exception", logger_exception)
+
+    result = lambda_handler({"date": yesterday.date().isoformat()}, MagicMock())
+
+    assert result == {
+        "status": "partial_failure",
+        "processed": 0,
+        "errors": 1,
+        "date": yesterday.date().isoformat(),
+    }
+    logger_exception.assert_any_call(
+        "Billing pricing resolution failed",
+        extra={"pricing_path": f"/platform/billing/pricing/{TIER}", "tier": TIER},
+    )


### PR DESCRIPTION
## Summary
- fail billing pricing resolution instead of applying hidden fallback rates
- return `partial_failure` when any tenant cannot be billed correctly
- add regression coverage for missing and malformed pricing config
- sync `ai-context` policy mirrors required by repo validation

Closes #226

## Validation
- `./.venv/bin/python -m pytest tests/unit/test_billing_handler.py -q -p no:cacheprovider`
  - `6 passed in 202.61s (0:03:22)`
- `make validate-local`
  - passed
- `make preflight-session`
  - passed
- `make pre-validate-session`
  - passed
- `make worktree-push-issue`
  - passed and pushed branch

## Notes
- GitNexus MCP impact/detect-changes calls were unavailable in this environment because the transport closed while the worktree-local analyzer state was unstable. I used manual scope verification instead: `src/billing/handler.py`, `tests/unit/test_billing_handler.py`, and the required `ai-context` mirrors only.
