### PR TITLE
Fix agent deployment false success on runtime update failure

### DIFF
--- a/ai-context/AGENTS.md
+++ b/ai-context/AGENTS.md
@@ -109,7 +109,7 @@ ADR-013: Entra group-to-role claim for RBAC
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationships, 192 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2553 symbols, 8100 relationships, 207 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -125,7 +125,7 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt193/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -164,10 +164,10 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/wt193/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt193/clusters` | All functional areas |
-| `gitnexus://repo/wt193/processes` | All execution flows |
-| `gitnexus://repo/wt193/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/ai-context/CLAUDE.md
+++ b/ai-context/CLAUDE.md
@@ -343,7 +343,7 @@ git worktree prune
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationships, 192 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2553 symbols, 8100 relationships, 207 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -359,7 +359,7 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt193/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -398,10 +398,10 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/wt193/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt193/clusters` | All functional areas |
-| `gitnexus://repo/wt193/processes` | All execution flows |
-| `gitnexus://repo/wt193/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/scripts/deploy_agent.py
+++ b/scripts/deploy_agent.py
@@ -47,6 +47,23 @@ def get_ssm_param(ssm, name: str) -> str | None:
         raise
 
 
+def update_agentcore_runtime(
+    acore, agent_name: str, bucket: str, deps_key: str, script_key: str
+) -> str:
+    response = acore.update_agent_code(
+        agentName=agent_name,
+        code={
+            "s3Bucket": bucket,
+            "depsKey": deps_key,
+            "scriptKey": script_key,
+        },
+    )
+    runtime_arn = str(response.get("agentArn", "")).strip()
+    if not runtime_arn:
+        raise RuntimeError("AgentCore update_agent_code did not return agentArn")
+    return runtime_arn
+
+
 def deploy_agent(agent_name: str, env: str) -> bool:
     aws_region = require_aws_region()
 
@@ -89,43 +106,20 @@ def deploy_agent(agent_name: str, env: str) -> bool:
         Overwrite=True,
     )
 
-    # In mock/test environment, we also ensure runtime-arn exists for tests
-    try:
-        ssm.get_parameter(Name=f"/platform/agents/{env}/{agent_name}/runtime-arn")
-    except ClientError:
-        ssm.put_parameter(
-            Name=f"/platform/agents/{env}/{agent_name}/runtime-arn",
-            Value=f"arn:aws:bedrock:eu-west-2:123456789012:runtime/{agent_name}",
-            Type="String",
-        )
-
-    # Call AgentCore Runtime API
-    # Assuming bedrock-agentcore is a custom boto3 client or similar
     try:
         acore = boto3.client("bedrock-agentcore", region_name=aws_region)
         logger.info(f"Updating AgentCore Runtime for '{agent_name}'")
-        response = acore.update_agent_code(
-            agentName=agent_name,
-            code={
-                "s3Bucket": bucket,
-                "depsKey": deps_key,
-                "scriptKey": script_key,
-            },
-        )
-        runtime_arn = response.get("agentArn")
-        if runtime_arn:
-            ssm.put_parameter(
-                Name=f"/platform/agents/{env}/{agent_name}/runtime-arn",
-                Value=runtime_arn,
-                Type="String",
-                Overwrite=True,
-            )
+        runtime_arn = update_agentcore_runtime(acore, agent_name, bucket, deps_key, script_key)
     except Exception as e:
-        logger.warning(f"Failed to call AgentCore Runtime API (might be expected in mock env): {e}")
-        # In mock environment or during early phase, we might not have the actual API
-        # but we want the script to succeed if the artifacts are uploaded.
-        if os.environ.get("CI"):
-            logger.info("Continuing anyway because CI is set")
+        logger.error("Failed to update AgentCore Runtime for '%s': %s", agent_name, e)
+        return False
+
+    ssm.put_parameter(
+        Name=f"/platform/agents/{env}/{agent_name}/runtime-arn",
+        Value=runtime_arn,
+        Type="String",
+        Overwrite=True,
+    )
 
     logger.info(f"Agent '{agent_name}' deployed successfully to {env}")
     return True

--- a/tests/unit/test_agent_scripts.py
+++ b/tests/unit/test_agent_scripts.py
@@ -2,11 +2,13 @@
 
 import importlib.util
 import sys
+import types
 import zipfile
 from pathlib import Path
 from typing import Any
 
 import boto3
+import pytest
 from moto import mock_aws
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,6 +33,28 @@ deploy_agent = _load_module("deploy_agent")
 register_agent = _load_module("register_agent")
 
 _REGION = "eu-west-2"
+
+
+class _FakeAgentCoreClient:
+    def __init__(self, *, response: dict[str, Any] | None = None, error: Exception | None = None):
+        self._response = response or {}
+        self._error = error
+
+    def update_agent_code(self, **_: Any) -> dict[str, Any]:
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+
+def _patch_deploy_agentcore(monkeypatch, fake_client: _FakeAgentCoreClient) -> None:
+    real_client = boto3.client
+
+    def _client(service_name: str, *args: Any, **kwargs: Any) -> Any:
+        if service_name == "bedrock-agentcore":
+            return fake_client
+        return real_client(service_name, *args, **kwargs)
+
+    monkeypatch.setattr(deploy_agent, "boto3", types.SimpleNamespace(client=_client))
 
 
 # ---------------------------------------------------------------------------
@@ -69,12 +93,9 @@ def test_package_agent_creates_zip(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@mock_aws
-def test_deploy_agent_zip(tmp_path, monkeypatch):
+def _prepare_deploy_agent_fixture(tmp_path, monkeypatch) -> tuple[str, str, str]:
     monkeypatch.setenv("AWS_REGION", _REGION)
-    monkeypatch.setenv("CI", "true")
 
-    # Monkeypatch REPO_ROOT and BUILD_DIR
     monkeypatch.setattr(deploy_agent, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(deploy_agent, "BUILD_DIR", tmp_path / ".build")
 
@@ -113,19 +134,54 @@ version = "1.2.3"
 type = "zip"
 """)
 
-    deploy_agent.deploy_agent(agent_name, env)
+    return agent_name, env, bucket_name
 
-    # Verify S3 upload
+
+@mock_aws
+def test_deploy_agent_zip_stores_runtime_arn_on_success(tmp_path, monkeypatch):
+    agent_name, env, bucket_name = _prepare_deploy_agent_fixture(tmp_path, monkeypatch)
+    _patch_deploy_agentcore(
+        monkeypatch,
+        _FakeAgentCoreClient(
+            response={
+                "agentArn": "arn:aws:bedrock-agentcore:eu-west-2:210987654321:runtime/echo-agent"
+            }
+        ),
+    )
+
+    assert deploy_agent.deploy_agent(agent_name, env) is True
+
+    s3 = boto3.client("s3", region_name=_REGION)
     response = s3.list_objects_v2(Bucket=bucket_name)
     keys = [obj["Key"] for obj in response.get("Contents", [])]
     expected_script_key = f"scripts/{agent_name}/1.2.3.zip"
     assert expected_script_key in keys
 
-    # Verify SSM parameters (environment-scoped)
+    ssm = boto3.client("ssm", region_name=_REGION)
     s3_key_param = ssm.get_parameter(Name=f"/platform/agents/{env}/{agent_name}/script-s3-key")
     assert s3_key_param["Parameter"]["Value"] == expected_script_key
-    # runtime-arn might not be written if acore.update_agent_code fails (it fails in mock)
-    # But let's check if it was intended.
+    runtime_arn_param = ssm.get_parameter(Name=f"/platform/agents/{env}/{agent_name}/runtime-arn")
+    assert (
+        runtime_arn_param["Parameter"]["Value"]
+        == "arn:aws:bedrock-agentcore:eu-west-2:210987654321:runtime/echo-agent"
+    )
+
+
+@mock_aws
+def test_deploy_agent_returns_false_when_runtime_update_fails(tmp_path, monkeypatch):
+    agent_name, env, _ = _prepare_deploy_agent_fixture(tmp_path, monkeypatch)
+    _patch_deploy_agentcore(
+        monkeypatch,
+        _FakeAgentCoreClient(error=RuntimeError("runtime update failed")),
+    )
+
+    assert deploy_agent.deploy_agent(agent_name, env) is False
+
+    ssm = boto3.client("ssm", region_name=_REGION)
+    s3_key_param = ssm.get_parameter(Name=f"/platform/agents/{env}/{agent_name}/script-s3-key")
+    assert s3_key_param["Parameter"]["Value"] == f"scripts/{agent_name}/1.2.3.zip"
+    with pytest.raises(ssm.exceptions.ParameterNotFound):
+        ssm.get_parameter(Name=f"/platform/agents/{env}/{agent_name}/runtime-arn")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #227

## Summary
- remove fake runtime ARN seeding from `scripts/deploy_agent.py`
- fail deployment when the AgentCore runtime update fails or returns no `agentArn`
- update unit coverage to assert success stores the returned ARN and failure leaves `runtime-arn` unset
- sync required `ai-context` rule mirrors so repo validation passes

## Validation
- `uv run pytest tests/unit/test_agent_scripts.py -q`
- `uv run ruff check scripts/deploy_agent.py tests/unit/test_agent_scripts.py`
- `make validate-local`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`
