### PR TITLE
TASK-229: Make register-agent persist the deployed script object key

### DIFF
--- a/scripts/register_agent.py
+++ b/scripts/register_agent.py
@@ -65,15 +65,15 @@ def register_agent(agent_name: str, env: str) -> bool:
     ssm = boto3.client("ssm", region_name=aws_region)
     layer_hash = get_ssm_param(ssm, f"/platform/layers/{env}/{agent_name}/hash")
     layer_s3_key = get_ssm_param(ssm, f"/platform/layers/{env}/{agent_name}/s3-key")
+    script_s3_key = get_ssm_param(ssm, f"/platform/agents/{env}/{agent_name}/script-s3-key")
 
-    if not layer_hash or not layer_s3_key:
+    if not layer_hash or not layer_s3_key or not script_s3_key:
         logger.error(
-            f"Layer metadata not found for agent '{agent_name}' in env '{env}'. "
-            "Run build_layer first."
+            f"Deployment metadata not found for agent '{agent_name}' in env '{env}'. "
+            "Run build_layer and deploy_agent first."
         )
         return False
 
-    script_s3_key = f"agents/{agent_name}/code.zip"
     deployed_at = datetime.datetime.now(datetime.UTC).isoformat()
 
     # Get Runtime ARN from SSM if it exists (set by infra or previous deployment)

--- a/tests/unit/test_agent_scripts.py
+++ b/tests/unit/test_agent_scripts.py
@@ -181,6 +181,11 @@ invocation_mode = "sync"
     ssm.put_parameter(
         Name=f"/platform/layers/{env}/{agent_name}/s3-key", Value="layers/key.zip", Type="String"
     )
+    ssm.put_parameter(
+        Name=f"/platform/agents/{env}/{agent_name}/script-s3-key",
+        Value="scripts/custom-key.zip",
+        Type="String",
+    )
 
     register_agent.register_agent(agent_name, env)
 
@@ -192,6 +197,7 @@ invocation_mode = "sync"
     assert item["agent_name"] == agent_name
     assert item["version"] == "1.2.3"
     assert item["layer_hash"] == "hash123"
+    assert item["script_s3_key"] == "scripts/custom-key.zip"
 
     # Verify SSM latest-version (environment-scoped)
     param_name = f"/platform/agents/{env}/{agent_name}/latest-version"


### PR DESCRIPTION
This PR fixes register_agent.py to retrieve the script_s3_key from SSM instead of using a hardcoded value, ensuring it correctly persists the versioned script object key uploaded during deployment.