### PR TITLE
Fix dev invoke CLI stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ make worktree-push-issue      # push with preflight + pre-validate enforced
 
 ```bash
 make agent-push AGENT=my-agent ENV=dev    # push agent, fast path when deps are unchanged
-make agent-invoke AGENT=my-agent PROMPT="hello"
+make agent-invoke AGENT=my-agent TENANT=t-test-001 PROMPT="hello"
 make agent-test AGENT=my-agent
 ```
 

--- a/docs/development/AGENT-DEVELOPER-GUIDE.md
+++ b/docs/development/AGENT-DEVELOPER-GUIDE.md
@@ -19,7 +19,7 @@ vim agents/my-agent/pyproject.toml
 # Develop locally
 make dev                                    # Start local environment
 make agent-push AGENT=my-agent ENV=dev      # Deploy to local mock Runtime
-make agent-invoke AGENT=my-agent PROMPT="hello"
+make agent-invoke AGENT=my-agent TENANT=t-test-001 PROMPT="hello"
 
 # Run tests
 make agent-test AGENT=my-agent

--- a/docs/development/LOCAL-SETUP.md
+++ b/docs/development/LOCAL-SETUP.md
@@ -60,7 +60,7 @@ After `make dev`, two test tenants are available. Their JWTs are in `.env.test`:
 | PREMIUM_TENANT_JWT    | t-test-002 | premium  |
 | ADMIN_JWT             | admin-001  | Platform.Admin |
 
-Use these in `make agent-invoke --tenant t-test-001` or in your tests via conftest.py.
+Use these with `make agent-invoke AGENT=echo-agent TENANT=t-test-001` or in your tests via `conftest.py`.
 
 ## Running Tests
 

--- a/docs/operations/RUNBOOK-008-developer-onboarding.md
+++ b/docs/operations/RUNBOOK-008-developer-onboarding.md
@@ -40,7 +40,7 @@ cp -r agents/echo-agent agents/my-first-agent
 # Edit pyproject.toml: change name, version, owner_team
 # Edit handler.py: change the response
 make agent-push AGENT=my-first-agent ENV=dev
-make agent-invoke AGENT=my-first-agent PROMPT="hello world"
+make agent-invoke AGENT=my-first-agent TENANT=t-test-001 PROMPT="hello world"
 ```
 
 ## Success Criteria

--- a/scripts/dev-invoke.py
+++ b/scripts/dev-invoke.py
@@ -1,19 +1,294 @@
-"""
-dev-invoke.py — Invoke an agent in the local development environment.
+"""Developer CLI for invoking the contracted agent REST route."""
 
-Sends a request to the local mock AgentCore Runtime (docker-compose).
-Reads tenant JWT from .env.test.
+from __future__ import annotations
 
-Usage:
-    uv run python scripts/dev-invoke.py \\
-        --agent <agent_name> \\
-        --tenant <tenant_id> \\
-        --jwt <jwt_token> \\
-        --prompt "Hello" \\
-        --mode sync|streaming|async \\
-        [--env dev]
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
 
-Called by: make dev-invoke, make agent-invoke
+DEFAULT_API_BASE_URL = "http://localhost:8080"
+DEFAULT_ENV = "local"
+DEFAULT_TIMEOUT_SECONDS = 30
+DEFAULT_CREDENTIALS_PATH = Path.home() / ".platform" / "credentials"
+_TOKEN_ENV_NAMES = ("DEV_INVOKE_JWT", "PLATFORM_ACCESS_TOKEN", "BEARER_TOKEN")
 
-Implemented in TASK-015.
-"""
+
+class DevInvokeError(RuntimeError):
+    """Domain error for CLI usage and request failures."""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, raw = stripped.split("=", 1)
+        key = key.strip()
+        value = raw.strip().strip('"').strip("'")
+        if key:
+            values[key] = value
+    return values
+
+
+def _load_dotenv_values() -> dict[str, str]:
+    values: dict[str, str] = {}
+    for filename in (".env.local", ".env", ".env.test"):
+        values.update(_load_env_file(_repo_root() / filename))
+    return values
+
+
+def _load_credentials_store(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": 1, "profiles": {}}
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise DevInvokeError(f"Invalid credentials file format: {path}")
+    profiles = parsed.get("profiles")
+    if not isinstance(profiles, dict):
+        parsed["profiles"] = {}
+    return parsed
+
+
+def _credentials_path() -> Path:
+    override = os.environ.get("PLATFORM_CREDENTIALS_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_CREDENTIALS_PATH
+
+
+def _profile_for_env(store: dict[str, Any], env_name: str) -> dict[str, Any]:
+    profiles = store.get("profiles", {})
+    if not isinstance(profiles, dict):
+        return {}
+    profile = profiles.get(env_name, {})
+    return profile if isinstance(profile, dict) else {}
+
+
+def _resolve_api_base_url(explicit: str | None, env_name: str) -> str:
+    if explicit and explicit.strip():
+        return explicit.strip()
+
+    for key in ("API_BASE_URL", "VITE_API_BASE_URL"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+
+    dotenv_values = _load_dotenv_values()
+    for key in ("API_BASE_URL", "VITE_API_BASE_URL"):
+        value = dotenv_values.get(key, "").strip()
+        if value:
+            return value
+
+    if env_name == DEFAULT_ENV:
+        return DEFAULT_API_BASE_URL
+
+    profile = _profile_for_env(_load_credentials_store(_credentials_path()), env_name)
+    stored = str(profile.get("apiBaseUrl", "")).strip()
+    if stored:
+        return stored
+
+    raise DevInvokeError(
+        "API base URL not set. Use --api-base-url, API_BASE_URL, or VITE_API_BASE_URL."
+    )
+
+
+def _tenant_token_from_env_test(tenant_id: str, dotenv_values: dict[str, str]) -> str | None:
+    mappings = (
+        ("BASIC_TENANT_ID", "BASIC_TENANT_JWT"),
+        ("PREMIUM_TENANT_ID", "PREMIUM_TENANT_JWT"),
+        ("ADMIN_TENANT_ID", "ADMIN_JWT"),
+    )
+    for tenant_key, token_key in mappings:
+        if dotenv_values.get(tenant_key, "").strip() == tenant_id:
+            token = dotenv_values.get(token_key, "").strip()
+            return token or None
+
+    if tenant_id == "admin-001":
+        token = dotenv_values.get("ADMIN_JWT", "").strip()
+        return token or None
+    return None
+
+
+def _resolve_token(explicit: str | None, tenant_id: str, env_name: str) -> str:
+    if explicit and explicit.strip():
+        return explicit.strip()
+
+    for env_key in _TOKEN_ENV_NAMES:
+        candidate = os.environ.get(env_key, "").strip()
+        if candidate:
+            return candidate
+
+    dotenv_values = _load_dotenv_values()
+    tenant_token = _tenant_token_from_env_test(tenant_id, dotenv_values)
+    if tenant_token:
+        return tenant_token
+
+    profile = _profile_for_env(_load_credentials_store(_credentials_path()), env_name)
+    stored = str(profile.get("accessToken", "")).strip()
+    if stored:
+        return stored
+
+    raise DevInvokeError(
+        "Bearer token not set. Use --jwt, DEV_INVOKE_JWT, .env.test, or stored credentials."
+    )
+
+
+def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {"input": args.prompt}
+    if args.session_id:
+        payload["sessionId"] = args.session_id
+    if args.webhook_id:
+        payload["webhookId"] = args.webhook_id
+    return payload
+
+
+def build_request(
+    *,
+    api_base_url: str,
+    token: str,
+    args: argparse.Namespace,
+) -> Request:
+    route = f"/v1/agents/{args.agent}/invoke"
+    url = urljoin(api_base_url.rstrip("/") + "/", route.lstrip("/"))
+    payload = json.dumps(_build_payload(args)).encode("utf-8")
+    request = Request(url=url, data=payload, method="POST")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Content-Type", "application/json")
+    accept = "text/event-stream" if args.mode == "streaming" else "application/json"
+    request.add_header("Accept", accept)
+    request.add_header("x-tenant-id", args.tenant)
+    return request
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Invoke an agent via the contracted REST route.")
+    parser.add_argument("--agent", required=True, help="Agent name registered in the platform")
+    parser.add_argument("--tenant", required=True, help="Tenant ID for the request context")
+    parser.add_argument(
+        "--jwt",
+        "--token",
+        dest="token",
+        help="Bearer token to send in the Authorization header",
+    )
+    parser.add_argument("--prompt", default="Hello", help="Input prompt/body for the invocation")
+    parser.add_argument(
+        "--mode",
+        choices=("sync", "streaming", "async"),
+        default="sync",
+        help="Client expectation for response handling; the server still decides actual mode",
+    )
+    parser.add_argument("--env", default=DEFAULT_ENV, help="Profile/environment name")
+    parser.add_argument("--api-base-url", help="Override the API base URL")
+    parser.add_argument("--session-id", help="Optional existing session identifier")
+    parser.add_argument("--webhook-id", help="Optional webhook registration identifier")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="HTTP timeout in seconds",
+    )
+    return parser.parse_args(argv)
+
+
+def _decode_json(raw: bytes) -> Any:
+    text = raw.decode("utf-8", errors="replace").strip()
+    if not text:
+        return None
+    return json.loads(text)
+
+
+def _print_json(payload: Any) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _print_streaming_response(raw: bytes) -> None:
+    events: list[str] = []
+    for line in raw.decode("utf-8", errors="replace").splitlines():
+        if not line.startswith("data: "):
+            continue
+        data = line[6:]
+        if data == "[DONE]":
+            break
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError:
+            events.append(data)
+            continue
+        if payload.get("type") == "text":
+            events.append(str(payload.get("content", "")))
+    print("".join(events))
+
+
+def _handle_success_response(*, content_type: str, body: bytes) -> None:
+    if "text/event-stream" in content_type:
+        _print_streaming_response(body)
+        return
+
+    payload = _decode_json(body)
+    _print_json(payload)
+
+
+def _handle_http_error(exc: HTTPError) -> None:
+    body = exc.read()
+    try:
+        payload = _decode_json(body)
+    except json.JSONDecodeError:
+        payload = body.decode("utf-8", errors="replace")
+    print(
+        f"Invoke failed with HTTP {exc.code}",
+        file=sys.stderr,
+    )
+    if payload is not None:
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True)
+            if not isinstance(payload, str)
+            else payload
+        )
+        print(rendered, file=sys.stderr)
+
+
+def run(args: argparse.Namespace) -> int:
+    api_base_url = _resolve_api_base_url(args.api_base_url, args.env)
+    token = _resolve_token(args.token, args.tenant, args.env)
+    request = build_request(api_base_url=api_base_url, token=token, args=args)
+
+    try:
+        with urlopen(request, timeout=args.timeout_seconds) as response:
+            body = response.read()
+            content_type = response.headers.get("Content-Type", "application/json")
+    except HTTPError as exc:
+        _handle_http_error(exc)
+        return 1
+    except URLError as exc:
+        print(f"Invoke failed: {exc.reason}", file=sys.stderr)
+        return 1
+
+    _handle_success_response(content_type=content_type, body=body)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        return run(args)
+    except DevInvokeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_dev_invoke.py
+++ b/tests/unit/test_dev_invoke.py
@@ -1,0 +1,206 @@
+"""Unit tests for scripts/dev-invoke.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.request import Request
+
+
+def _load_dev_invoke_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "dev_invoke_script",
+        repo_root / "scripts" / "dev-invoke.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+dev_invoke = _load_dev_invoke_module()
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status: int,
+        payload: Any,
+        content_type: str = "application/json",
+    ) -> None:
+        self.status = status
+        self._payload = payload
+        self.headers = {"Content-Type": content_type}
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: Any) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        if isinstance(self._payload, bytes):
+            return self._payload
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_parse_args_matches_makefile_contract() -> None:
+    args = dev_invoke.parse_args(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-test-001",
+            "--jwt",
+            "jwt-token",
+            "--prompt",
+            "Hello from local environment",
+            "--mode",
+            "sync",
+        ]
+    )
+
+    assert args.agent == "echo-agent"
+    assert args.tenant == "t-test-001"
+    assert args.token == "jwt-token"
+    assert args.prompt == "Hello from local environment"
+    assert args.mode == "sync"
+    assert args.env == "local"
+
+
+def test_build_request_includes_contract_headers_and_payload() -> None:
+    args = dev_invoke.parse_args(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-test-001",
+            "--prompt",
+            "Hello",
+            "--mode",
+            "streaming",
+            "--session-id",
+            "session-123",
+            "--webhook-id",
+            "wh-123",
+        ]
+    )
+
+    request = dev_invoke.build_request(
+        api_base_url="http://localhost:8080",
+        token="jwt-token",
+        args=args,
+    )
+
+    assert request.full_url == "http://localhost:8080/v1/agents/echo-agent/invoke"
+    assert request.get_method() == "POST"
+    assert request.get_header("Authorization") == "Bearer jwt-token"
+    assert request.get_header("Accept") == "text/event-stream"
+    headers = {key.lower(): value for key, value in request.header_items()}
+    assert headers["x-tenant-id"] == "t-test-001"
+    assert json.loads(request.data.decode("utf-8")) == {
+        "input": "Hello",
+        "sessionId": "session-123",
+        "webhookId": "wh-123",
+    }
+
+
+def test_resolve_token_uses_env_test_fixture_for_known_tenant(monkeypatch, tmp_path: Path) -> None:
+    env_test = tmp_path / ".env.test"
+    env_test.write_text(
+        "\n".join(
+            [
+                "BASIC_TENANT_ID=t-test-001",
+                "BASIC_TENANT_JWT=fixture-basic-token",  # pragma: allowlist secret
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dev_invoke, "_repo_root", lambda: tmp_path)
+
+    token = dev_invoke._resolve_token(None, "t-test-001", "local")
+
+    assert token == "fixture-basic-token"
+
+
+def test_main_documented_dev_invoke_path_uses_local_defaults(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    env_test = tmp_path / ".env.test"
+    env_test.write_text(
+        "\n".join(
+            [
+                "BASIC_TENANT_ID=t-test-001",
+                "BASIC_TENANT_JWT=fixture-basic-token",  # pragma: allowlist secret
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dev_invoke, "_repo_root", lambda: tmp_path)
+
+    seen: dict[str, Any] = {}
+
+    def _fake_urlopen(request: Request, timeout: int) -> _FakeResponse:
+        seen["url"] = request.full_url
+        seen["auth"] = request.get_header("Authorization")
+        seen["accept"] = request.get_header("Accept")
+        seen["timeout"] = timeout
+        seen["body"] = json.loads(request.data.decode("utf-8"))
+        return _FakeResponse(
+            status=200,
+            payload={"status": "success", "output": "Echo: Hello from local environment"},
+        )
+
+    monkeypatch.setattr(dev_invoke, "urlopen", _fake_urlopen)
+
+    rc = dev_invoke.main(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-test-001",
+            "--prompt",
+            "Hello from local environment",
+            "--mode",
+            "sync",
+        ]
+    )
+
+    assert rc == 0
+    assert seen["url"] == "http://localhost:8080/v1/agents/echo-agent/invoke"
+    assert seen["auth"] == "Bearer fixture-basic-token"
+    assert seen["accept"] == "application/json"
+    assert seen["timeout"] == dev_invoke.DEFAULT_TIMEOUT_SECONDS
+    assert seen["body"] == {"input": "Hello from local environment"}
+    captured = capsys.readouterr()
+    assert "Echo: Hello from local environment" in captured.out
+
+
+def test_main_fails_cleanly_when_token_cannot_be_resolved(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.setattr(dev_invoke, "_repo_root", lambda: tmp_path)
+    monkeypatch.setenv("PLATFORM_CREDENTIALS_PATH", str(tmp_path / "missing-creds.json"))
+
+    rc = dev_invoke.main(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-missing",
+            "--prompt",
+            "hello",
+        ]
+    )
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Bearer token not set" in captured.err


### PR DESCRIPTION
Closes #234

## Summary
- replace the `scripts/dev-invoke.py` stub with a real REST invoke CLI
- resolve API base URL and bearer token from CLI args, env, `.env.test`, or stored credentials
- align local developer docs/examples with the actual `agent-invoke` contract

## Validation
- `PYTHONPATH=. uv run pytest tests/unit/test_dev_invoke.py -v --tb=short`
- `uv run ruff check scripts/dev-invoke.py tests/unit/test_dev_invoke.py README.md docs/development/LOCAL-SETUP.md docs/operations/RUNBOOK-008-developer-onboarding.md docs/development/AGENT-DEVELOPER-GUIDE.md`
- `make preflight-session`
- `make pre-validate-session`
- `make validate-local`

## Notes
- `--mode` is retained for CLI compatibility and streaming response handling, but the platform still treats the agent registry as the source of truth for invocation mode.
