### PR TITLE
fix(issue-235): implement plan-dev CLI

### DIFF
--- a/scripts/plan_dev.py
+++ b/scripts/plan_dev.py
@@ -1,13 +1,213 @@
+#!/usr/bin/env python3
 """
-plan_dev.py — Generate a structured implementation plan for a task.
-
-Reads TASKS.md, ARCHITECTURE.md, and relevant ADRs, then outputs a
-step-by-step plan for the given task description.
+plan_dev.py - Generate a structured implementation plan for a task description.
 
 Usage:
     uv run python scripts/plan_dev.py "Implement the billing metering pipeline"
-
-Called by: make plan-dev TASK="..."
-
-Implemented in TASK-019.
 """
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate a structured implementation plan for a task description."
+    )
+    parser.add_argument("task_description", help='Task description, e.g. "Implement X"')
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def existing_paths(root: Path, candidates: list[str]) -> list[str]:
+    return [candidate for candidate in candidates if (root / candidate).exists()]
+
+
+def infer_paths(task_description: str, root: Path) -> list[str]:
+    lowered = task_description.lower()
+    keyword_hints: list[tuple[tuple[str, ...], list[str]]] = [
+        (
+            ("plan-dev", "plan_dev", "makefile", "workflow", "stub script"),
+            ["scripts/plan_dev.py", "Makefile", "tests/unit/test_plan_dev.py"],
+        ),
+        (
+            ("authoriser", "authorizer", "jwt", "sigv4"),
+            ["src/authoriser/handler.py", "tests/unit/test_authoriser_handler.py"],
+        ),
+        (
+            ("tenant api", "tenant-api", "tenant_api"),
+            ["src/tenant_api/handler.py", "tests/unit/test_tenant_api_handler.py"],
+        ),
+        (
+            ("bridge", "invocation", "streaming", "async"),
+            ["src/bridge/handler.py", "tests/unit/test_bridge_handler.py"],
+        ),
+        (
+            ("cdk", "infrastructure", "stack", "terraform"),
+            ["infra/cdk", "infra/terraform", "docs/ARCHITECTURE.md"],
+        ),
+        (
+            ("spa", "frontend", "react", "portal"),
+            ["spa", "tests", "README.md"],
+        ),
+    ]
+
+    inferred: list[str] = []
+    for keywords, paths in keyword_hints:
+        if any(keyword in lowered for keyword in keywords):
+            inferred.extend(paths)
+
+    if not inferred:
+        inferred.extend(["README.md", "docs/TASKS.md", "tests"])
+
+    unique_paths: list[str] = []
+    seen: set[str] = set()
+    for path in inferred:
+        if path not in seen and (root / path).exists():
+            seen.add(path)
+            unique_paths.append(path)
+    return unique_paths
+
+
+def extract_task_id(task_description: str) -> str | None:
+    match = re.search(r"\bTASK-(\d+)\b", task_description, re.IGNORECASE)
+    if not match:
+        return None
+    return f"TASK-{match.group(1).zfill(3)}"
+
+
+def find_task_snapshot(root: Path, task_id: str | None) -> str | None:
+    if not task_id:
+        return None
+
+    tasks_file = root / "docs" / "TASKS.md"
+    if not tasks_file.exists():
+        return None
+
+    lines = tasks_file.read_text(encoding="utf-8").splitlines()
+    pattern = re.compile(rf"^\[[ ~x!]\] {re.escape(task_id)}\s{{2,}}(.+)")
+
+    for index, line in enumerate(lines):
+        match = pattern.match(line)
+        if not match:
+            continue
+
+        detail_lines = [f"{task_id}: {match.group(1).strip()}"]
+        next_index = index + 1
+        while next_index < len(lines):
+            candidate = lines[next_index]
+            if candidate and not candidate[0].isspace():
+                break
+            if candidate.strip():
+                detail_lines.append(candidate.strip())
+            next_index += 1
+        return "\n".join(detail_lines)
+
+    return None
+
+
+def build_plan(task_description: str, root: Path) -> str:
+    read_first_docs = existing_paths(
+        root,
+        ["AGENTS.md", "CLAUDE.md", "README.md", "docs/ARCHITECTURE.md", "docs/TASKS.md"],
+    )
+    touched_paths = infer_paths(task_description, root)
+    task_id = extract_task_id(task_description)
+    task_snapshot = find_task_snapshot(root, task_id)
+
+    lines = [
+        "# Development Plan",
+        "",
+        f"Task: {task_description}",
+    ]
+
+    if task_snapshot:
+        lines.extend(
+            [
+                "",
+                "Related task snapshot:",
+                task_snapshot,
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "Read-first context:",
+            *[f"- `{path}`" for path in read_first_docs],
+            "",
+            "Likely touched paths:",
+            *[f"- `{path}`" for path in touched_paths],
+            "",
+            "Execution plan:",
+            (
+                "1. Inspect the current implementation, command wiring, and any "
+                "existing tests for this task area."
+            ),
+            (
+                "2. Confirm the required behavior and workflow gates from the "
+                "repo rules and adjacent docs."
+            ),
+            (
+                "3. Implement the smallest scoped change that makes the command "
+                "or feature real instead of implied."
+            ),
+            (
+                "4. Add or update focused regression tests for the interface "
+                "contract and the primary success path."
+            ),
+            (
+                "5. Run targeted checks first, then rerun repo workflow "
+                "validation commands required for issue work."
+            ),
+            "",
+            "Validation checklist:",
+            "- Run the smallest relevant unit tests for the touched files.",
+            "- Run `make preflight-session`.",
+            "- Run `make pre-validate-session` before any push.",
+            "- Run `make issues-audit` and reconcile if needed.",
+            "",
+            "Risks to watch:",
+            (
+                "- Keep changes scoped to the described task; do not widen into "
+                "adjacent workflow refactors."
+            ),
+            (
+                "- Keep repo rules, Make targets, and tests aligned so "
+                "contributors are not sent through dead paths."
+            ),
+            (
+                "- Stop and ask if the change would alter IAM, tenant "
+                "isolation, authoriser validation, or other guarded areas."
+            ),
+        ]
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(build_plan(args.task_description, repo_root()), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_plan_dev.py
+++ b/tests/unit/test_plan_dev.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_plan_dev_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "plan_dev_script", repo_root / "scripts" / "plan_dev.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+plan_dev = _load_plan_dev_module()
+
+
+def test_parse_args_accepts_makefile_contract():
+    args = plan_dev.parse_args(["Implement the billing metering pipeline"])
+    assert args.task_description == "Implement the billing metering pipeline"
+
+
+def test_parse_args_requires_task_description():
+    with pytest.raises(SystemExit):
+        plan_dev.parse_args([])
+
+
+def test_build_plan_returns_structured_output_for_plan_dev_issue():
+    root = Path(__file__).resolve().parents[2]
+    plan = plan_dev.build_plan("Issue 235: implement make plan-dev instead of a stub script", root)
+
+    assert "# Development Plan" in plan
+    assert "Task: Issue 235: implement make plan-dev instead of a stub script" in plan
+    assert "Read-first context:" in plan
+    assert "Likely touched paths:" in plan
+    assert "`scripts/plan_dev.py`" in plan
+    assert "`Makefile`" in plan
+    assert "Execution plan:" in plan
+    assert "Validation checklist:" in plan
+
+
+def test_makefile_plan_dev_target_matches_cli_contract():
+    root = Path(__file__).resolve().parents[2]
+    makefile = (root / "Makefile").read_text(encoding="utf-8")
+
+    assert 'make plan-dev TASK="Implement the billing metering pipeline"' in makefile
+    assert 'uv run python scripts/plan_dev.py "$(TASK)"' in makefile


### PR DESCRIPTION
## Summary
- replace the `scripts/plan_dev.py` docstring stub with a real CLI that emits a structured development plan
- infer likely touched paths from the task description and include repo workflow gates in the generated output
- add focused unit coverage for CLI argument parsing, output contract, and Makefile wiring

## Validation
- `uv run pytest tests/unit/test_plan_dev.py`
- `make plan-dev TASK='Issue 235: implement make plan-dev instead of a stub script'`
- `make preflight-session`
- `make pre-validate-session`
- `make issues-audit`
- `make validate-local`

## Notes
- `make validate-local` passed after installing local CDK dependencies in `infra/cdk/node_modules`
- GitNexus MCP `impact`/`detect_changes` calls timed out in this worktree; fallback inspection confirmed the scoped diff only touches `scripts/plan_dev.py` and `tests/unit/test_plan_dev.py`

Closes #235.
