### PR TITLE
fix(issue-228): paginate billing scans and admin totals

### DIFF
--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -96,12 +96,19 @@ def _iso_now() -> str:
 
 def _get_active_tenants() -> list[dict[str, Any]]:
     """Scan platform-tenants for active/suspended tenants."""
-    table = _dynamodb.Table(TENANTS_TABLE)
-    response = table.scan(
-        FilterExpression=Key("SK").eq("METADATA")
-        & (Key("status").eq(TenantStatus.ACTIVE) | Key("status").eq(TenantStatus.SUSPENDED))
+    # System context for admin scan
+    ctx = TenantContext(
+        tenant_id="system",
+        app_id="system",
+        tier=TenantTier.PREMIUM,
+        sub="billing-pipeline",
     )
-    return response.get("Items", [])
+    db = TenantScopedDynamoDB(ctx, dynamodb_resource=_dynamodb)
+    return db.scan_all(
+        TENANTS_TABLE,
+        filter_expression=Key("SK").eq("METADATA")
+        & (Key("status").eq(TenantStatus.ACTIVE) | Key("status").eq(TenantStatus.SUSPENDED)),
+    )
 
 
 def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
@@ -132,13 +139,13 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
 
     # 1. Query invocations for the day
     # SK starts with INV#timestamp
-    result = db.query(
+    invocations = db.query_all(
         INVOCATIONS_TABLE,
         sk_condition=Key("SK").between(f"INV#{start_time}", f"INV#{end_time}"),
     )
 
-    day_input = sum(int(inv.get("input_tokens", 0)) for inv in result.items)
-    day_output = sum(int(inv.get("output_tokens", 0)) for inv in result.items)
+    day_input = sum(int(inv.get("input_tokens", 0)) for inv in invocations)
+    day_output = sum(int(inv.get("output_tokens", 0)) for inv in invocations)
 
     # 2. Apply pricing
     try:

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -931,15 +931,7 @@ def _is_newer_agent_record(candidate: dict[str, Any], current: dict[str, Any]) -
 
 def list_agents(tenant_context: TenantContext) -> dict[str, Any]:
     db = TenantScopedDynamoDB(tenant_context)
-
-    items: list[dict[str, Any]] = []
-    exclusive_start_key = None
-    while True:
-        page = db.scan(AGENTS_TABLE, exclusive_start_key=exclusive_start_key)
-        items.extend(page.items)
-        exclusive_start_key = page.last_evaluated_key
-        if not exclusive_start_key:
-            break
+    items = db.scan_all(AGENTS_TABLE)
 
     latest_by_name: dict[str, dict[str, Any]] = {}
     for item in items:

--- a/src/data-access-lib/src/data_access/client.py
+++ b/src/data-access-lib/src/data_access/client.py
@@ -240,6 +240,37 @@ class TenantScopedDynamoDB:
             last_evaluated_key=response.get("LastEvaluatedKey"),
         )
 
+    def query_all(
+        self,
+        table_name: str,
+        *,
+        sk_condition: ConditionBase | None = None,
+        filter_expression: ConditionBase | None = None,
+        index_name: str | None = None,
+        scan_index_forward: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Query all items in the caller's tenant partition, handling pagination.
+
+        The PK is always forced to TENANT#{tenant_id}.
+        Returns a flat list of all items.
+        """
+        items: list[dict[str, Any]] = []
+        exclusive_start_key = None
+        while True:
+            result = self.query(
+                table_name,
+                sk_condition=sk_condition,
+                filter_expression=filter_expression,
+                index_name=index_name,
+                scan_index_forward=scan_index_forward,
+                exclusive_start_key=exclusive_start_key,
+            )
+            items.extend(result.items)
+            exclusive_start_key = result.last_evaluated_key
+            if not exclusive_start_key:
+                break
+        return items
+
     def scan(
         self,
         table_name: str,
@@ -280,6 +311,37 @@ class TenantScopedDynamoDB:
             items=response.get("Items", []),
             last_evaluated_key=response.get("LastEvaluatedKey"),
         )
+
+    def scan_all(
+        self,
+        table_name: str,
+        *,
+        filter_expression: ConditionBase | str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Scan all items in a table, handling pagination.
+
+        SECURITY: Scanning is an administrative operation. Isolation is
+        NOT enforced by this method.
+
+        Returns a flat list of all items.
+        """
+        items: list[dict[str, Any]] = []
+        exclusive_start_key = None
+        while True:
+            result = self.scan(
+                table_name,
+                filter_expression=filter_expression,
+                exclusive_start_key=exclusive_start_key,
+                expression_attribute_names=expression_attribute_names,
+                expression_attribute_values=expression_attribute_values,
+            )
+            items.extend(result.items)
+            exclusive_start_key = result.last_evaluated_key
+            if not exclusive_start_key:
+                break
+        return items
 
 
 # ---------------------------------------------------------------------------

--- a/src/data-access-lib/tests/test_client.py
+++ b/src/data-access-lib/tests/test_client.py
@@ -14,7 +14,7 @@ Coverage assertions (required by TASK-013):
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import boto3
 import pytest
@@ -597,6 +597,48 @@ class TestTenantScopedDynamoDBScan:
             result = db.scan(TABLE_NAME, filter_expression=Attr("status").eq("ok"))
         assert len(result.items) == 1
         assert result.items[0]["SK"] == "INV#001"
+
+    def test_scan_all_paginates(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
+        """Scan_all should automatically loop until all items are returned."""
+        with mock_aws():
+            db, dynamo = _make_dynamo_db(ctx, cw=mock_cw)
+            table = dynamo.Table(TABLE_NAME)
+            for i in range(5):
+                table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": f"INV#{i:03d}"})
+
+            # Force small limit internally by mocking scan
+            original_scan = db.scan
+
+            def mock_scan_side_effect(*args, **kwargs):
+                return original_scan(*args, **{**kwargs, "limit": 2})
+
+            with patch.object(db, "scan", side_effect=mock_scan_side_effect) as mock_s:
+                items = db.scan_all(TABLE_NAME)
+                assert len(items) == 5
+                # Should have been called 3 times (2+2+1)
+                assert mock_s.call_count == 3
+
+
+class TestTenantScopedDynamoDBQueryAll:
+    def test_query_all_paginates(self, ctx: TenantContext, mock_cw: MagicMock) -> None:
+        """Query_all should automatically loop until all items are returned."""
+        with mock_aws():
+            db, dynamo = _make_dynamo_db(ctx, cw=mock_cw)
+            table = dynamo.Table(TABLE_NAME)
+            for i in range(5):
+                table.put_item(Item={"PK": f"TENANT#{TENANT_ID}", "SK": f"INV#{i:03d}"})
+
+            # Force small limit internally by mocking query
+            original_query = db.query
+
+            def mock_query_side_effect(*args, **kwargs):
+                return original_query(*args, **{**kwargs, "limit": 2})
+
+            with patch.object(db, "query", side_effect=mock_query_side_effect) as mock_q:
+                items = db.query_all(TABLE_NAME)
+                assert len(items) == 5
+                # Should have been called 3 times (2+2+1)
+                assert mock_q.call_count == 3
 
 
 # ===========================================================================

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -1692,10 +1692,12 @@ def _handle_platform_billing_status(
     # We aggregate global status across all tenants for the current month
     year_month = datetime.now(UTC).strftime("%Y-%m")
 
-    table = deps.dynamodb.Table(_tenants_table_name())
-    # This is an admin scan for metrics
-    response = table.scan(FilterExpression=Key("SK").eq(f"BILLING#{year_month}"))
-    summaries = response.get("Items", [])
+    # Use data-access-lib for admin scan
+    db = _control_plane_db(caller)
+    summaries = db.scan_all(
+        _tenants_table_name(),
+        filter_expression=Key("SK").eq(f"BILLING#{year_month}"),
+    )
 
     total_cost = sum(float(s.get("total_cost_usd", 0.0)) for s in summaries)
     total_input = sum(int(s.get("total_input_tokens", 0)) for s in summaries)

--- a/tests/unit/test_billing_pagination.py
+++ b/tests/unit/test_billing_pagination.py
@@ -1,0 +1,234 @@
+"""
+test_billing_pagination.py — Verification tests for billing pagination fixes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# Set environment variables for handler
+os.environ["AWS_REGION"] = "eu-west-2"
+os.environ["AWS_ACCESS_KEY_ID"] = "testing"  # pragma: allowlist secret
+os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # pragma: allowlist secret
+os.environ["AWS_SECURITY_TOKEN"] = "testing"  # pragma: allowlist secret
+os.environ["AWS_SESSION_TOKEN"] = "testing"  # pragma: allowlist secret
+os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+os.environ["TENANTS_TABLE_NAME"] = "platform-tenants"
+os.environ["INVOCATIONS_TABLE_NAME"] = "platform-invocations"
+
+from src.billing.handler import _get_active_tenants, _process_tenant
+from src.tenant_api.handler import (
+    CallerIdentity,
+    TenantApiDependencies,
+    _handle_platform_billing_status,
+)
+
+
+@pytest.fixture
+def mock_aws_clients() -> Generator[None, None, None]:
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+        ddb.create_table(
+            TableName="platform-tenants",
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        ddb.create_table(
+            TableName="platform-invocations",
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield
+
+
+def test_get_active_tenants_paginated(mock_aws_clients: Any) -> None:
+    """Verify that _get_active_tenants returns all pages of tenants."""
+    # We patch the _dynamodb resource in the handler
+    with patch("src.billing.handler._dynamodb") as mock_ddb_resource:
+        mock_table = MagicMock()
+        mock_ddb_resource.Table.return_value = mock_table
+
+        call_count = 0
+
+        def mock_scan(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {
+                    "Items": [
+                        {
+                            "PK": "TENANT#t0",
+                            "SK": "METADATA",
+                            "tenant_id": "t0",
+                            "status": "active",
+                            "tier": "basic",
+                        }
+                    ],
+                    "LastEvaluatedKey": {"PK": "TENANT#t0", "SK": "METADATA"},
+                }
+            if call_count == 2:
+                return {
+                    "Items": [
+                        {
+                            "PK": "TENANT#t1",
+                            "SK": "METADATA",
+                            "tenant_id": "t1",
+                            "status": "active",
+                            "tier": "basic",
+                        },
+                        {
+                            "PK": "TENANT#t2",
+                            "SK": "METADATA",
+                            "tenant_id": "t2",
+                            "status": "active",
+                            "tier": "basic",
+                        },
+                    ],
+                }
+            return {"Items": []}
+
+        mock_table.scan.side_effect = mock_scan
+
+        tenants = _get_active_tenants()
+
+        # Should have all 3 tenants
+        assert len(tenants) == 3
+        assert call_count == 2
+
+
+def test_process_tenant_query_pagination(mock_aws_clients: Any) -> None:
+    """Verify that _process_tenant processes all pages of invocations."""
+    tenant_id = "t-heavy"
+    app_id = "app-heavy"
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    ts1 = yesterday.replace(hour=10).isoformat()
+    ts2 = yesterday.replace(hour=14).isoformat()
+
+    # Seed pricing in SSM
+    ssm = boto3.client("ssm", region_name="eu-west-2")
+    ssm.put_parameter(
+        Name="/platform/billing/pricing/basic",
+        Value=json.dumps({"input_1k": 0.1, "output_1k": 0.2}),
+        Type="String",
+    )
+
+    with patch("src.billing.handler._dynamodb") as mock_ddb_resource:
+        mock_table = MagicMock()
+        mock_ddb_resource.Table.return_value = mock_table
+        mock_table.get_item.return_value = {}
+
+        # mock_table.query (for invocations)
+        mock_table.query.side_effect = [
+            {
+                "Items": [
+                    {
+                        "PK": f"TENANT#{tenant_id}",
+                        "SK": f"INV#{ts1}#1",
+                        "input_tokens": 1000,
+                        "output_tokens": 0,
+                    }
+                ],
+                "LastEvaluatedKey": {"PK": f"TENANT#{tenant_id}", "SK": f"INV#{ts1}#1"},
+            },
+            {
+                "Items": [
+                    {
+                        "PK": f"TENANT#{tenant_id}",
+                        "SK": f"INV#{ts2}#2",
+                        "input_tokens": 1000,
+                        "output_tokens": 0,
+                    }
+                ],
+            },
+        ]
+
+        tenant = {"tenant_id": tenant_id, "tier": "basic", "app_id": app_id, "status": "active"}
+        _process_tenant(tenant, yesterday)
+
+        # Verify that total_input_tokens is 2000 (both pages)
+        args, kwargs = mock_table.put_item.call_args
+        item = kwargs["Item"]
+        assert item["total_input_tokens"] == 2000
+        assert mock_table.query.call_count == 2
+
+
+def test_platform_billing_status_pagination(mock_aws_clients: Any) -> None:
+    """Verify that _handle_platform_billing_status paginates through billing summaries."""
+    year_month = datetime.now(UTC).strftime("%Y-%m")
+
+    caller = CallerIdentity(
+        tenant_id="platform-admin",
+        app_id="platform-admin",
+        tier="premium",
+        sub="admin-sub",
+        roles=frozenset(["Platform.Admin"]),
+        usage_identifier_key="key-123",
+    )
+
+    deps = TenantApiDependencies(
+        secretsmanager=MagicMock(),
+        events=MagicMock(),
+        dynamodb=boto3.resource("dynamodb", region_name="eu-west-2"),
+        ssm=MagicMock(),
+        usage_client=MagicMock(),
+        memory_provisioner=MagicMock(),
+        platform_quota_client=MagicMock(),
+    )
+
+    with patch("src.tenant_api.handler.TenantScopedDynamoDB") as mock_db_class:
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        # mock scan_all for BILLING records
+        mock_db.scan_all.return_value = [
+            {
+                "PK": "TENANT#t1",
+                "SK": f"BILLING#{year_month}",
+                "total_cost_usd": 10.0,
+                "total_input_tokens": 1000,
+                "total_output_tokens": 500,
+            },
+            {
+                "PK": "TENANT#t2",
+                "SK": f"BILLING#{year_month}",
+                "total_cost_usd": 20.0,
+                "total_input_tokens": 2000,
+                "total_output_tokens": 1000,
+            },
+        ]
+
+        result = _handle_platform_billing_status(caller, deps)
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["tenantCount"] == 2
+        assert body["totalCostUsd"] == 30.0
+        assert body["totalTokens"] == 4500  # (1000+500) + (2000+1000) = 1500 + 3000 = 4500
+        assert mock_db.scan_all.call_count == 1

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -215,33 +215,22 @@ def test_list_agents_returns_openapi_shape_and_tier_filtered(setup_data):
 
 
 def test_list_agents_handles_multiple_scan_pages(setup_data):
-    from data_access.models import PaginatedItems
 
     # Mock TenantScopedDynamoDB.scan to return two pages
     mock_db = MagicMock()
-    mock_db.scan.side_effect = [
-        PaginatedItems(
-            items=[
-                {
-                    "agent_name": "agent-1",
-                    "version": "1.0.0",
-                    "tier_minimum": "basic",
-                    "deployed_at": "2026-01-01T00:00:00Z",
-                }
-            ],
-            last_evaluated_key={"PK": "AGENT#agent-1", "SK": "VERSION#1.0.0"},
-        ),
-        PaginatedItems(
-            items=[
-                {
-                    "agent_name": "agent-2",
-                    "version": "1.0.0",
-                    "tier_minimum": "basic",
-                    "deployed_at": "2026-01-01T00:00:00Z",
-                }
-            ],
-            last_evaluated_key=None,
-        ),
+    mock_db.scan_all.return_value = [
+        {
+            "agent_name": "agent-1",
+            "version": "1.0.0",
+            "tier_minimum": "basic",
+            "deployed_at": "2026-01-01T00:00:00Z",
+        },
+        {
+            "agent_name": "agent-2",
+            "version": "1.0.0",
+            "tier_minimum": "basic",
+            "deployed_at": "2026-01-01T00:00:00Z",
+        },
     ]
 
     with patch("src.bridge.handler.TenantScopedDynamoDB", return_value=mock_db):
@@ -266,7 +255,7 @@ def test_list_agents_handles_multiple_scan_pages(setup_data):
         agent_names = [item["agentName"] for item in body["items"]]
         assert "agent-1" in agent_names
         assert "agent-2" in agent_names
-        assert mock_db.scan.call_count == 2
+        assert mock_db.scan_all.call_count == 1
 
 
 def test_get_agent_detail_returns_latest_version_and_versions(setup_data):


### PR DESCRIPTION
Closes #228

Implements pagination for billing scans and admin totals, including data-access and unit test coverage.