### PR TITLE
fix(issue-256): align TenantStack memory with AgentCore template

### DIFF
--- a/infra/cdk/lib/agentcore-memory-template.ts
+++ b/infra/cdk/lib/agentcore-memory-template.ts
@@ -1,0 +1,51 @@
+export const TENANT_MEMORY_TEMPLATE_PARAMETER_NAME =
+  '/platform/agentcore/memory/template/default';
+
+export interface SemanticMemoryTemplate {
+  readonly strategy: 'SEMANTIC';
+  readonly strategyNameTemplate: string;
+  readonly namespaceTemplate: string;
+  readonly descriptionTemplate: string;
+}
+
+export interface AgentCoreTenantMemoryTemplate {
+  readonly provisionedBy: 'TenantStack';
+  readonly eventExpiryDurationDays: number;
+  readonly semanticMemory: SemanticMemoryTemplate;
+}
+
+export const DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE: AgentCoreTenantMemoryTemplate = {
+  provisionedBy: 'TenantStack',
+  eventExpiryDurationDays: 90,
+  semanticMemory: {
+    strategy: 'SEMANTIC',
+    strategyNameTemplate: 'TenantSemanticMemory',
+    namespaceTemplate: 'tenant/{tenantId}',
+    descriptionTemplate: 'Per-tenant AgentCore memory for {tenantId}',
+  },
+};
+
+const renderTemplate = (template: string, tenantId: string): string =>
+  template.split('{tenantId}').join(tenantId);
+
+export const serializeAgentCoreTenantMemoryTemplate = (
+  template: AgentCoreTenantMemoryTemplate = DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE,
+): string => JSON.stringify(template);
+
+export const resolveTenantMemoryProperties = (
+  tenantId: string,
+  template: AgentCoreTenantMemoryTemplate = DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE,
+) => ({
+  description: renderTemplate(template.semanticMemory.descriptionTemplate, tenantId),
+  eventExpiryDuration: template.eventExpiryDurationDays,
+  memoryStrategies: [
+    {
+      SemanticMemoryStrategy: {
+        Name: template.semanticMemory.strategyNameTemplate,
+        Description: renderTemplate(template.semanticMemory.descriptionTemplate, tenantId),
+        Namespaces: [renderTemplate(template.semanticMemory.namespaceTemplate, tenantId)],
+        Type: template.semanticMemory.strategy,
+      },
+    },
+  ],
+});

--- a/infra/cdk/lib/agentcore-stack.ts
+++ b/infra/cdk/lib/agentcore-stack.ts
@@ -12,6 +12,10 @@
 import * as cdk from 'aws-cdk-lib';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+import {
+  serializeAgentCoreTenantMemoryTemplate,
+  TENANT_MEMORY_TEMPLATE_PARAMETER_NAME,
+} from './agentcore-memory-template';
 
 export interface AgentCoreStackProps extends cdk.StackProps {
   readonly homeRegion: string;
@@ -140,16 +144,10 @@ export class AgentCoreStack extends cdk.Stack {
     runtimeEndpoint.addDependency(runtime);
 
     const memoryTemplateParameter = new ssm.StringParameter(this, 'TenantMemoryTemplateParameter', {
-      parameterName: '/platform/agentcore/memory/template/default',
+      parameterName: TENANT_MEMORY_TEMPLATE_PARAMETER_NAME,
       description:
         'Template used by TenantStack when provisioning per-tenant AWS::BedrockAgentCore::Memory resources',
-      stringValue: JSON.stringify({
-        provisionedBy: 'TenantStack',
-        eventExpiryDurationDays: 90,
-        strategy: 'SEMANTIC',
-        namespaceTemplate: 'tenant/{tenantId}',
-        descriptionTemplate: 'Per-tenant AgentCore memory',
-      }),
+      stringValue: serializeAgentCoreTenantMemoryTemplate(),
       tier: ssm.ParameterTier.STANDARD,
     });
 

--- a/infra/cdk/lib/tenant-stack.ts
+++ b/infra/cdk/lib/tenant-stack.ts
@@ -20,6 +20,7 @@ import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+import { resolveTenantMemoryProperties } from './agentcore-memory-template';
 
 export interface TenantStackProps extends cdk.StackProps {
   readonly authorizedRuntimeRegions?: readonly string[];
@@ -155,16 +156,17 @@ export class TenantStack extends cdk.Stack {
         resources: [tenantDataKeyArn],
       }),
     );
+    const tenantMemory = resolveTenantMemoryProperties(tenantId);
 
     const memoryStore = new cdk.CfnResource(this, 'TenantMemoryStore', {
       type: 'AWS::BedrockAgentCore::Memory',
       properties: {
         Name: `platform-memory-${tenantId}`,
-        Description: `Memory store for tenant ${tenantId}`,
+        Description: tenantMemory.description,
         EncryptionKeyArn: tenantDataKeyArn,
-        EventExpiryDuration: 30,
+        EventExpiryDuration: tenantMemory.eventExpiryDuration,
         MemoryExecutionRoleArn: memoryServiceRole.roleArn,
-        MemoryStrategies: [{ StrategyType: 'SUMMARY' }, { StrategyType: 'USER_PREFERENCES' }],
+        MemoryStrategies: tenantMemory.memoryStrategies,
         Tags: {
           TenantId: tenantId,
           Tier: tier,

--- a/infra/cdk/test/agentcore-stack.test.ts
+++ b/infra/cdk/test/agentcore-stack.test.ts
@@ -1,6 +1,10 @@
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { AgentCoreStack } from '../lib/agentcore-stack';
+import {
+  DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE,
+  TENANT_MEMORY_TEMPLATE_PARAMETER_NAME,
+} from '../lib/agentcore-memory-template';
 
 describe('AgentCoreStack (TASK-024)', () => {
   const synthTemplate = () => {
@@ -69,13 +73,17 @@ describe('AgentCoreStack (TASK-024)', () => {
 
   test('creates SSM parameters for memory template and Entra JWKS URL', () => {
     template.hasResourceProperties('AWS::SSM::Parameter', {
-      Name: '/platform/agentcore/memory/template/default',
+      Name: TENANT_MEMORY_TEMPLATE_PARAMETER_NAME,
       Type: 'String',
       Value: Match.serializedJson(
         Match.objectLike({
-          provisionedBy: 'TenantStack',
-          eventExpiryDurationDays: 90,
-          strategy: 'SEMANTIC',
+          provisionedBy: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.provisionedBy,
+          eventExpiryDurationDays: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.eventExpiryDurationDays,
+          semanticMemory: Match.objectLike({
+            strategy: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.semanticMemory.strategy,
+            namespaceTemplate:
+              DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.semanticMemory.namespaceTemplate,
+          }),
         }),
       ),
     });

--- a/infra/cdk/test/tenant-stack.test.ts
+++ b/infra/cdk/test/tenant-stack.test.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import { DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE } from '../lib/agentcore-memory-template';
 import { TenantStack } from '../lib/tenant-stack';
 
 describe('TenantStack (TASK-025)', () => {
@@ -77,17 +78,25 @@ describe('TenantStack (TASK-025)', () => {
     });
   });
 
-  test('creates AgentCore Memory Store with service role and SUMMARY strategy', () => {
+  test('creates AgentCore Memory Store from the canonical semantic memory template', () => {
     const template = synthTemplate(defaultContext);
 
     template.hasResourceProperties('AWS::BedrockAgentCore::Memory', {
       Name: 'platform-memory-t-test123',
+      Description: 'Per-tenant AgentCore memory for t-test123',
       EncryptionKeyArn: Match.anyValue(),
+      EventExpiryDuration: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.eventExpiryDurationDays,
       MemoryExecutionRoleArn: Match.anyValue(),
-      MemoryStrategies: Match.arrayWith([
-        Match.objectLike({ StrategyType: 'SUMMARY' }),
-        Match.objectLike({ StrategyType: 'USER_PREFERENCES' }),
-      ]),
+      MemoryStrategies: [
+        Match.objectLike({
+          SemanticMemoryStrategy: Match.objectLike({
+            Name: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.semanticMemory.strategyNameTemplate,
+            Description: 'Per-tenant AgentCore memory for t-test123',
+            Namespaces: ['tenant/t-test123'],
+            Type: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.semanticMemory.strategy,
+          }),
+        }),
+      ],
     });
 
     template.hasResourceProperties('AWS::IAM::Role', {
@@ -169,5 +178,20 @@ describe('TenantStack (TASK-025)', () => {
         env: { region: 'eu-west-2' },
       });
     }).toThrow();
+  });
+
+  test('keeps tenant memory expiry aligned with the published AgentCore default contract', () => {
+    const template = synthTemplate(defaultContext);
+
+    template.hasResourceProperties('AWS::BedrockAgentCore::Memory', {
+      EventExpiryDuration: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.eventExpiryDurationDays,
+      MemoryStrategies: [
+        Match.objectLike({
+          SemanticMemoryStrategy: Match.objectLike({
+            Type: DEFAULT_AGENTCORE_TENANT_MEMORY_TEMPLATE.semanticMemory.strategy,
+          }),
+        }),
+      ],
+    });
   });
 });


### PR DESCRIPTION
Aligns TenantStack memory provisioning (Description, Expiry, Strategy) with the canonical template defined in AgentCoreStack. Fixes #256.