### PR TITLE
fix: replace hardcoded Entra common auth wiring

### DIFF
--- a/infra/cdk/lib/agentcore-stack.ts
+++ b/infra/cdk/lib/agentcore-stack.ts
@@ -12,6 +12,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+import { resolveEntraConfiguration } from './entra-config';
 
 export interface AgentCoreStackProps extends cdk.StackProps {
   readonly homeRegion: string;
@@ -23,8 +24,7 @@ export class AgentCoreStack extends cdk.Stack {
     super(scope, id, props);
 
     const envName = this.requiredContext('env');
-    const entraTenantId = this.optionalContext('entraTenantId') ?? 'common';
-    const entraAudience = this.optionalContext('entraAudience') ?? 'platform-api';
+    const entra = resolveEntraConfiguration(this);
     const runtimeRegion = cdk.Stack.of(this).region;
 
     if (!cdk.Token.isUnresolved(runtimeRegion) && runtimeRegion !== 'eu-west-1') {
@@ -61,7 +61,6 @@ export class AgentCoreStack extends cdk.Stack {
 
     const runtimeName = this.runtimeName(envName);
     const runtimeEndpointName = this.runtimeEndpointName(envName);
-    const entraJwksUrl = this.resolveEntraJwksUrl(entraTenantId);
 
     const runtime = new cdk.CfnResource(this, 'AgentCoreRuntime', {
       type: 'AWS::BedrockAgentCore::Runtime',
@@ -87,8 +86,8 @@ export class AgentCoreStack extends cdk.Stack {
         ProtocolConfiguration: 'HTTP',
         AuthorizerConfiguration: {
           CustomJWTAuthorizer: {
-            DiscoveryUrl: this.resolveEntraDiscoveryUrl(entraTenantId),
-            AllowedAudience: [entraAudience],
+            DiscoveryUrl: entra.discoveryUrl,
+            AllowedAudience: [entra.audience],
           },
         },
         RequestHeaderConfiguration: {
@@ -156,7 +155,7 @@ export class AgentCoreStack extends cdk.Stack {
     new ssm.StringParameter(this, 'EntraJwksUrlParameter', {
       parameterName: '/platform/auth/jwks-url',
       description: 'Entra JWKS URL consumed by platform identity and runtime integrations',
-      stringValue: entraJwksUrl,
+      stringValue: entra.jwksUrl,
       tier: ssm.ParameterTier.STANDARD,
     });
 
@@ -214,7 +213,7 @@ export class AgentCoreStack extends cdk.Stack {
       value: metricStream.ref,
     });
     new cdk.CfnOutput(this, 'EntraJwksUrl', {
-      value: entraJwksUrl,
+      value: entra.jwksUrl,
     });
   }
 
@@ -224,22 +223,6 @@ export class AgentCoreStack extends cdk.Stack {
       throw new Error(`CDK context "${name}" is required`);
     }
     return value;
-  }
-
-  private optionalContext(name: string): string | undefined {
-    const value = this.node.tryGetContext(name);
-    if (typeof value !== 'string' || value.trim() === '') {
-      return undefined;
-    }
-    return value;
-  }
-
-  private resolveEntraJwksUrl(entraTenantId: string): string {
-    return `https://login.microsoftonline.com/${entraTenantId}/discovery/v2.0/keys`;
-  }
-
-  private resolveEntraDiscoveryUrl(entraTenantId: string): string {
-    return `https://login.microsoftonline.com/${entraTenantId}/v2.0/.well-known/openid-configuration`;
   }
 
   private runtimeName(envName: string): string {

--- a/infra/cdk/lib/entra-config.ts
+++ b/infra/cdk/lib/entra-config.ts
@@ -6,6 +6,7 @@ export interface EntraConfiguration {
   readonly jwksUrl: string;
   readonly issuer: string;
   readonly discoveryUrl: string;
+  readonly tokenEndpoint: string;
 }
 
 function optionalContext(scope: Construct, name: string): string | undefined {
@@ -17,7 +18,14 @@ function optionalContext(scope: Construct, name: string): string | undefined {
 }
 
 export function resolveEntraConfiguration(scope: Construct): EntraConfiguration {
-  const tenantId = optionalContext(scope, 'entraTenantId') ?? 'common';
+  const tenantId = optionalContext(scope, 'entraTenantId');
+  if (!tenantId) {
+    throw new Error(
+      'entraTenantId context is required for all environments (e.g. --context entraTenantId=00000000-0000-0000-0000-000000000000). ' +
+      'Check docs/entra-setup.md for how to find your Directory (tenant) ID.'
+    );
+  }
+
   const audience = optionalContext(scope, 'entraAudience') ?? 'platform-api';
   const issuer = optionalContext(scope, 'entraIssuer') ?? `https://login.microsoftonline.com/${tenantId}/v2.0`;
   const jwksUrl =
@@ -26,6 +34,9 @@ export function resolveEntraConfiguration(scope: Construct): EntraConfiguration 
   const discoveryUrl =
     optionalContext(scope, 'entraDiscoveryUrl') ??
     `https://login.microsoftonline.com/${tenantId}/v2.0/.well-known/openid-configuration`;
+  const tokenEndpoint =
+    optionalContext(scope, 'entraTokenEndpoint') ??
+    `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
 
   return {
     tenantId,
@@ -33,5 +44,6 @@ export function resolveEntraConfiguration(scope: Construct): EntraConfiguration 
     issuer,
     jwksUrl,
     discoveryUrl,
+    tokenEndpoint,
   };
 }

--- a/infra/cdk/lib/entra-config.ts
+++ b/infra/cdk/lib/entra-config.ts
@@ -1,0 +1,37 @@
+import { Construct } from 'constructs';
+
+export interface EntraConfiguration {
+  readonly tenantId: string;
+  readonly audience: string;
+  readonly jwksUrl: string;
+  readonly issuer: string;
+  readonly discoveryUrl: string;
+}
+
+function optionalContext(scope: Construct, name: string): string | undefined {
+  const value = scope.node.tryGetContext(name);
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined;
+  }
+  return value.trim();
+}
+
+export function resolveEntraConfiguration(scope: Construct): EntraConfiguration {
+  const tenantId = optionalContext(scope, 'entraTenantId') ?? 'common';
+  const audience = optionalContext(scope, 'entraAudience') ?? 'platform-api';
+  const issuer = optionalContext(scope, 'entraIssuer') ?? `https://login.microsoftonline.com/${tenantId}/v2.0`;
+  const jwksUrl =
+    optionalContext(scope, 'entraJwksUrl') ??
+    `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`;
+  const discoveryUrl =
+    optionalContext(scope, 'entraDiscoveryUrl') ??
+    `https://login.microsoftonline.com/${tenantId}/v2.0/.well-known/openid-configuration`;
+
+  return {
+    tenantId,
+    audience,
+    issuer,
+    jwksUrl,
+    discoveryUrl,
+  };
+}

--- a/infra/cdk/lib/identity-stack.ts
+++ b/infra/cdk/lib/identity-stack.ts
@@ -17,6 +17,7 @@ import { Construct } from 'constructs';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { resolveEntraConfiguration } from './entra-config';
 
 type PipelineRoleKey = 'validate' | 'deployDev' | 'deployStaging' | 'deployProd';
 
@@ -40,7 +41,7 @@ export class IdentityStack extends cdk.Stack {
     const gitlabOidcAudience = this.optionalContext('gitlabOidcAudience') ?? 'sts.amazonaws.com';
     const cdkBootstrapQualifier = this.optionalContext('cdkBootstrapQualifier') ?? 'hnb659fds';
     const deployBranch = this.optionalContext('gitlabDeployBranch') ?? 'main';
-    const entraJwksUrl = this.resolveEntraJwksUrl();
+    const entra = resolveEntraConfiguration(this);
 
     const gitlabOidcProvider = new iam.OpenIdConnectProvider(this, 'GitLabOidcProvider', {
       url: 'https://gitlab.com',
@@ -117,7 +118,7 @@ export class IdentityStack extends cdk.Stack {
 
     const entraJwksLayer = this.createEntraJwksLayer({
       envName,
-      jwksUrl: entraJwksUrl,
+      jwksUrl: entra.jwksUrl,
     });
 
     this.tenantDataKey = this.createPlatformKey({
@@ -162,7 +163,7 @@ export class IdentityStack extends cdk.Stack {
     });
     new cdk.CfnOutput(this, 'EntraJwksUrl', {
       description: 'Resolved Entra JWKS URL baked into the Lambda layer',
-      value: entraJwksUrl,
+      value: entra.jwksUrl,
     });
     new cdk.CfnOutput(this, 'TenantDataKmsKeyArn', {
       value: this.tenantDataKey.keyArn,
@@ -201,16 +202,6 @@ export class IdentityStack extends cdk.Stack {
       return undefined;
     }
     return value;
-  }
-
-  private resolveEntraJwksUrl(): string {
-    const explicitJwksUrl = this.optionalContext('entraJwksUrl');
-    if (explicitJwksUrl) {
-      return explicitJwksUrl;
-    }
-
-    const entraTenantId = this.optionalContext('entraTenantId') ?? 'common';
-    return `https://login.microsoftonline.com/${entraTenantId}/discovery/v2.0/keys`;
   }
 
   private cdkBootstrapRoleArn(qualifier: string, roleType: string): string {

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -29,6 +29,7 @@ import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
 import { Construct } from 'constructs';
 import * as path from 'path';
+import { resolveEntraConfiguration } from './entra-config';
 
 type PythonLambdaProps = {
   assetPath: string;
@@ -89,6 +90,7 @@ export class PlatformStack extends cdk.Stack {
     const env = ((this.node.tryGetContext('env') as string | undefined) ?? 'dev').toLowerCase();
     const bridgeCanaryPolicy = this.resolveBridgeCanaryPolicy(env);
     const gatewayPolicyConfiguration = this.resolveGatewayPolicyConfiguration(env);
+    const entra = resolveEntraConfiguration(this);
 
     // --- Secrets ---
 
@@ -323,7 +325,7 @@ export class PlatformStack extends cdk.Stack {
       memorySize: 512,
       environment: {
         POWERTOOLS_SERVICE_NAME: 'bff',
-        ENTRA_AUDIENCE: 'platform-api',
+        ENTRA_AUDIENCE: entra.audience,
       },
     });
 
@@ -349,9 +351,9 @@ export class PlatformStack extends cdk.Stack {
       memorySize: 512,
       environment: {
         POWERTOOLS_SERVICE_NAME: 'authoriser',
-        ENTRA_JWKS_URL: 'https://login.microsoftonline.com/common/discovery/v2.0/keys',
-        ENTRA_AUDIENCE: 'platform-api',
-        ENTRA_ISSUER: 'https://login.microsoftonline.com/common/v2.0',
+        ENTRA_JWKS_URL: entra.jwksUrl,
+        ENTRA_AUDIENCE: entra.audience,
+        ENTRA_ISSUER: entra.issuer,
         TENANTS_TABLE: this.tenantsTable.tableName,
       },
     });
@@ -382,9 +384,9 @@ export class PlatformStack extends cdk.Stack {
       environment: {
         POWERTOOLS_SERVICE_NAME: 'gateway-request-interceptor',
         TOOLS_TABLE: this.toolsTable.tableName,
-        ENTRA_JWKS_URL: 'https://login.microsoftonline.com/common/discovery/v2.0/keys',
-        ENTRA_AUDIENCE: 'platform-api',
-        ENTRA_ISSUER: 'https://login.microsoftonline.com/common/v2.0',
+        ENTRA_JWKS_URL: entra.jwksUrl,
+        ENTRA_AUDIENCE: entra.audience,
+        ENTRA_ISSUER: entra.issuer,
         SCOPED_TOKEN_ISSUER: 'platform-gateway',
         IDEMPOTENCY_TABLE: this.gatewayIdempotencyTable.tableName,
         SCOPED_TOKEN_SIGNING_KEY_SECRET_ARN: scopedTokenSigningKeySecret.secretArn,

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -325,9 +325,18 @@ export class PlatformStack extends cdk.Stack {
       memorySize: 512,
       environment: {
         POWERTOOLS_SERVICE_NAME: 'bff',
+        ENTRA_TENANT_ID: entra.tenantId,
         ENTRA_AUDIENCE: entra.audience,
+        ENTRA_TOKEN_ENDPOINT: entra.tokenEndpoint,
+        ENTRA_CLIENT_ID_SECRET_ARN: `arn:aws:secretsmanager:${this.region}:${this.account}:secret:platform/${env}/entra/client-id`,
+        ENTRA_CLIENT_SECRET_SECRET_ARN: `arn:aws:secretsmanager:${this.region}:${this.account}:secret:platform/${env}/entra/client-secret`,
       },
     });
+
+    const entraClientIdSecret = secretsmanager.Secret.fromSecretNameV2(this, 'EntraClientIdSecret', `platform/${env}/entra/client-id`);
+    const entraClientSecretSecret = secretsmanager.Secret.fromSecretNameV2(this, 'EntraClientSecretSecret', `platform/${env}/entra/client-secret`);
+    entraClientIdSecret.grantRead(this.bffFn);
+    entraClientSecretSecret.grantRead(this.bffFn);
 
     new lambda.EventSourceMapping(this, 'webhookDeliveryJobsStreamMapping', {
       target: this.webhookDeliveryFn,

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -12,6 +12,7 @@ describe('PlatformStack (TASK-023)', () => {
     const app = new cdk.App({
       context: {
         env: environment,
+        entraTenantId: '00000000-0000-0000-0000-000000000000',
         ...extraContext,
       },
     });
@@ -400,12 +401,19 @@ describe('PlatformStack (TASK-023)', () => {
     });
   });
 
-  test('configures the BFF lambda with the approved Entra audience', () => {
+  test('configures the BFF lambda with canonical Entra config and secret references', () => {
     template.hasResourceProperties('AWS::Lambda::Function', {
       FunctionName: 'platform-core-dev-bff',
       Environment: {
         Variables: Match.objectLike({
+          ENTRA_TENANT_ID: '00000000-0000-0000-0000-000000000000',
           ENTRA_AUDIENCE: 'platform-api',
+          ENTRA_TOKEN_ENDPOINT:
+            'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token',
+          ENTRA_CLIENT_ID_SECRET_ARN:
+            'arn:aws:secretsmanager:eu-west-2:123456789012:secret:platform/dev/entra/client-id',
+          ENTRA_CLIENT_SECRET_SECRET_ARN:
+            'arn:aws:secretsmanager:eu-west-2:123456789012:secret:platform/dev/entra/client-secret',
           POWERTOOLS_SERVICE_NAME: 'bff',
         }),
       },
@@ -449,7 +457,10 @@ describe('PlatformStack (TASK-023)', () => {
       FunctionName: 'platform-core-dev-bff',
       Environment: {
         Variables: Match.objectLike({
+          ENTRA_TENANT_ID: '00000000-0000-0000-0000-000000000000',
           ENTRA_AUDIENCE: 'api://platform-dev',
+          ENTRA_TOKEN_ENDPOINT:
+            'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token',
         }),
       },
     });

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -5,10 +5,14 @@ import * as kms from 'aws-cdk-lib/aws-kms';
 import { PlatformStack } from '../lib/platform-stack';
 
 describe('PlatformStack (TASK-023)', () => {
-  const synthTemplate = (environment: 'dev' | 'staging' | 'prod' = 'dev') => {
+  const synthTemplate = (
+    environment: 'dev' | 'staging' | 'prod' = 'dev',
+    extraContext: Record<string, string> = {},
+  ) => {
     const app = new cdk.App({
       context: {
         env: environment,
+        ...extraContext,
       },
     });
     const env = { account: '123456789012', region: 'eu-west-2' };
@@ -403,6 +407,49 @@ describe('PlatformStack (TASK-023)', () => {
         Variables: Match.objectLike({
           ENTRA_AUDIENCE: 'platform-api',
           POWERTOOLS_SERVICE_NAME: 'bff',
+        }),
+      },
+    });
+  });
+
+  test('wires Entra config from CDK context instead of hardcoded common endpoints', () => {
+    const customTemplate = synthTemplate('dev', {
+      entraTenantId: '00000000-0000-0000-0000-000000000000',
+      entraAudience: 'api://platform-dev',
+    });
+
+    const expectedJwksUrl =
+      'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys';
+    const expectedIssuer =
+      'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0';
+
+    customTemplate.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'platform-core-dev-authoriser',
+      Environment: {
+        Variables: Match.objectLike({
+          ENTRA_JWKS_URL: expectedJwksUrl,
+          ENTRA_AUDIENCE: 'api://platform-dev',
+          ENTRA_ISSUER: expectedIssuer,
+        }),
+      },
+    });
+
+    customTemplate.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'platform-core-dev-interceptor-request',
+      Environment: {
+        Variables: Match.objectLike({
+          ENTRA_JWKS_URL: expectedJwksUrl,
+          ENTRA_AUDIENCE: 'api://platform-dev',
+          ENTRA_ISSUER: expectedIssuer,
+        }),
+      },
+    });
+
+    customTemplate.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'platform-core-dev-bff',
+      Environment: {
+        Variables: Match.objectLike({
+          ENTRA_AUDIENCE: 'api://platform-dev',
         }),
       },
     });

--- a/src/bff/handler.py
+++ b/src/bff/handler.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -24,20 +25,55 @@ from typing import Any
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.logging import correlation_paths
+from aws_lambda_powertools.utilities.parameters import get_secret
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger(service="bff")
 tracer = Tracer()
 
+# Environment variables (passed from CDK in PlatformStack)
 ENTRA_CLIENT_ID = os.environ.get("ENTRA_CLIENT_ID")
 ENTRA_CLIENT_SECRET = os.environ.get("ENTRA_CLIENT_SECRET")
-ENTRA_TENANT_ID = os.environ.get("ENTRA_TENANT_ID", "common")
+ENTRA_TENANT_ID = os.environ.get("ENTRA_TENANT_ID")
 ENTRA_TOKEN_ENDPOINT = os.environ.get("ENTRA_TOKEN_ENDPOINT")
 ENTRA_AUDIENCE = os.environ.get("ENTRA_AUDIENCE")
+
+# Secret ARNs (passed from CDK in PlatformStack)
+ENTRA_CLIENT_ID_SECRET_ARN = os.environ.get("ENTRA_CLIENT_ID_SECRET_ARN")
+ENTRA_CLIENT_SECRET_SECRET_ARN = os.environ.get("ENTRA_CLIENT_SECRET_SECRET_ARN")
+
+# In-memory cache for secrets resolved from ARNs
+_secrets_cache: dict[str, str] = {}
+_secrets_expiry: dict[str, float] = {}
+_CACHE_TTL = 300  # 5 minutes
+
 RUNTIME_PING_URL = os.environ.get("RUNTIME_PING_URL") or os.environ.get("MOCK_RUNTIME_URL")
 RUNTIME_KEEPALIVE_WINDOW_SECONDS = 15 * 60
 RUNTIME_PING_TIMEOUT_SECONDS = 2.0
 _ALLOWED_SCOPE_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._-]{0,127}$")
+
+
+def _resolve_secret(secret_arn: str | None, env_value: str | None, env_name: str) -> str:
+    """Resolve a secret value from ARN (with 5-min cache) or environment variable fallback."""
+    if not secret_arn:
+        return _required_env_value(env_name, env_value)
+
+    now = time.time()
+    if secret_arn in _secrets_cache and now < _secrets_expiry.get(secret_arn, 0):
+        return _secrets_cache[secret_arn]
+
+    try:
+        # get_secret includes its own 5-minute cache by default (max_age=300)
+        val = get_secret(secret_arn, max_age=_CACHE_TTL)
+        if val and isinstance(val, str):
+            _secrets_cache[secret_arn] = val
+            _secrets_expiry[secret_arn] = now + _CACHE_TTL
+            return val
+    except Exception:
+        logger.exception(f"Failed to fetch {env_name} from Secrets Manager ARN: {secret_arn}")
+
+    # Fallback to direct environment variable if secret fetch fails
+    return _required_env_value(env_name, env_value)
 
 
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
@@ -233,8 +269,12 @@ def _exchange_obo_token(
 ) -> dict[str, Any]:
     endpoint = _entra_token_endpoint()
     params = {
-        "client_id": _required_env_value("ENTRA_CLIENT_ID", ENTRA_CLIENT_ID),
-        "client_secret": _required_env_value("ENTRA_CLIENT_SECRET", ENTRA_CLIENT_SECRET),
+        "client_id": _resolve_secret(
+            ENTRA_CLIENT_ID_SECRET_ARN, ENTRA_CLIENT_ID, "ENTRA_CLIENT_ID"
+        ),
+        "client_secret": _resolve_secret(
+            ENTRA_CLIENT_SECRET_SECRET_ARN, ENTRA_CLIENT_SECRET, "ENTRA_CLIENT_SECRET"
+        ),
         "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
         "requested_token_use": "on_behalf_of",
         "assertion": assertion_token,

--- a/tests/unit/test_bff_handler.py
+++ b/tests/unit/test_bff_handler.py
@@ -129,6 +129,53 @@ def test_exchange_obo_token_uses_only_approved_scopes() -> None:
     assert params["scope"] == "api://platform-dev/Agent.Invoke"
 
 
+def test_exchange_obo_token_resolves_client_credentials_from_secret_arns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bff_handler,
+        "ENTRA_CLIENT_ID_SECRET_ARN",
+        "arn:aws:secretsmanager:eu-west-2:111:secret:client-id",
+    )
+    monkeypatch.setattr(
+        bff_handler,
+        "ENTRA_CLIENT_SECRET_SECRET_ARN",
+        "arn:aws:secretsmanager:eu-west-2:111:secret:client-secret",
+    )
+    monkeypatch.setattr(bff_handler, "_secrets_cache", {})
+    monkeypatch.setattr(bff_handler, "_secrets_expiry", {})
+
+    with (
+        patch.object(
+            bff_handler,
+            "get_secret",
+            side_effect=["secret-client-id", "secret-client-secret"],
+        ) as get_secret,
+        patch.object(bff_handler, "_http_post_form") as http_post,
+    ):
+        bff_handler._exchange_obo_token(
+            assertion_token="some-token",
+            scopes=["api://platform-dev/Agent.Invoke"],
+        )
+
+    assert get_secret.call_count == 2
+    _, params = http_post.call_args[0]
+    assert params["client_id"] == "secret-client-id"
+    assert params["client_secret"] == "secret-client-secret"
+
+
+def test_entra_token_endpoint_falls_back_to_tenant_specific_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(bff_handler, "ENTRA_TOKEN_ENDPOINT", None)
+    monkeypatch.setattr(bff_handler, "ENTRA_TENANT_ID", "tenant-guid")
+
+    assert (
+        bff_handler._entra_token_endpoint()
+        == "https://login.microsoftonline.com/tenant-guid/oauth2/v2.0/token"
+    )
+
+
 def test_token_refresh_rejects_scope_outside_platform_audience() -> None:
     event = _event(
         path="/v1/bff/token-refresh",


### PR DESCRIPTION
Closes #258

## Summary
- require canonical `entraTenantId` resolution instead of falling back to `common`
- wire BFF to tenant-specific Entra token endpoint and Secrets Manager client credential references
- expand CDK and BFF regression coverage so future drift is caught

## Validation
- `cd infra/cdk && npm test -- --runInBand --testNamePattern='configures the BFF lambda with canonical Entra config and secret references|wires Entra config from CDK context instead of hardcoded common endpoints' platform-stack.test.ts`
- `python -m pytest -q tests/unit/test_bff_handler.py::test_exchange_obo_token_resolves_client_credentials_from_secret_arns tests/unit/test_bff_handler.py::test_entra_token_endpoint_falls_back_to_tenant_specific_url`
- `make preflight-session`
- `make pre-validate-session`
- `make issues-reconcile && make issues-audit`

## Notes
- `gitnexus_detect_changes` timed out in this environment, so scope was verified directly with `git diff --name-only`.
