### PR TITLE
Fix bootstrap first-deploy scope

### DIFF
--- a/ai-context/AGENTS.md
+++ b/ai-context/AGENTS.md
@@ -109,7 +109,7 @@ ADR-013: Entra group-to-role claim for RBAC
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tf-acore-aas** (2553 symbols, 8100 relationships, 207 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2686 symbols, 8508 relationships, 219 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/ai-context/CLAUDE.md
+++ b/ai-context/CLAUDE.md
@@ -343,7 +343,7 @@ git worktree prune
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tf-acore-aas** (2553 symbols, 8100 relationships, 207 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2686 symbols, 8508 relationships, 219 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/ai-context/GEMINI.md
+++ b/ai-context/GEMINI.md
@@ -343,7 +343,7 @@ git worktree prune
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationships, 192 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tf-acore-aas** (2686 symbols, 8508 relationships, 219 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -359,7 +359,7 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt193/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tf-acore-aas/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -398,10 +398,10 @@ This project is indexed by GitNexus as **wt193** (2376 symbols, 7527 relationshi
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/wt193/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt193/clusters` | All functional areas |
-| `gitnexus://repo/wt193/processes` | All execution flows |
-| `gitnexus://repo/wt193/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tf-acore-aas/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tf-acore-aas/clusters` | All functional areas |
+| `gitnexus://repo/tf-acore-aas/processes` | All execution flows |
+| `gitnexus://repo/tf-acore-aas/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/docs/bootstrap-guide.md
+++ b/docs/bootstrap-guide.md
@@ -54,7 +54,8 @@ Ordered steps with validation at each:
 2. **CDK bootstrap** — creates CDKToolkit stacks in eu-west-2, eu-west-1, eu-central-1
 3. **Seed secrets** — writes Entra credentials and platform private key to Secrets Manager
 4. **OIDC wiring** — creates GitLab OIDC provider and pipeline roles, prints ARNs
-5. **First CDK deploy** — deploys all 6 stacks from local machine (not pipeline)
+5. **First CDK deploy** — deploys the 5 bootstrap-supported home-region stacks from the
+   local machine (not pipeline)
 6. **Post-deploy seeding** — creates first admin, seeds SSM, registers echo-agent
 7. **Smoke test** — invokes echo-agent, checks alarms, confirms quota headroom
 8. **Delete bootstrap user** — removes temporary IAM user (MANDATORY)
@@ -102,3 +103,17 @@ make infra-destroy ENV=dev
 ```
 
 Re-bootstrapping after destroy takes ~35 minutes (CDK re-uses existing ECR/S3 ARNs).
+
+## Bootstrap Deploy Scope
+
+The day-zero `first-deploy` bootstrap step intentionally deploys only:
+- `platform-network-{env}`
+- `platform-identity-{env}`
+- `platform-core-{env}`
+- `platform-tenant-stub-{env}`
+- `platform-observability-{env}`
+
+It does not deploy `platform-agentcore-{env}`. `AgentCoreStack` requires explicit runtime
+artifact and metric-stream parameters, and the bootstrap path does not have a supported
+automatic source for those values on a fresh account. The bootstrap flow and runbooks are
+therefore scoped to the 5-stack control-plane deployment until that contract changes.

--- a/docs/operations/RUNBOOK-000-bootstrap.md
+++ b/docs/operations/RUNBOOK-000-bootstrap.md
@@ -47,10 +47,19 @@ make bootstrap-gitlab-oidc ENV=dev
 ### Step 4: First CDK Deploy (local, not pipeline)
 ```bash
 make infra-deploy ENV=dev
-# Runs cdk deploy --all from local machine using bootstrap IAM user
+# Runs cdk deploy for the bootstrap-supported home-region stacks only:
+#   platform-network-{env}
+#   platform-identity-{env}
+#   platform-core-{env}
+#   platform-tenant-stub-{env}
+#   platform-observability-{env}
 # Takes 15–20 minutes on first deploy
-# Expected output: 6 stacks deployed successfully
+# Expected output: 5 stacks deployed successfully
 ```
+
+`platform-agentcore-{env}` is intentionally excluded from the day-zero bootstrap deploy.
+That stack requires runtime-specific CloudFormation parameters such as artifact and metric
+stream wiring that the local bootstrap flow does not source automatically.
 
 ### Step 5: Post-Deploy Seeding
 ```bash
@@ -88,6 +97,9 @@ make bootstrap-delete-iam-user ENV=dev
 - Each step is idempotent — safe to re-run after fixing the issue
 - Check CloudFormation Events in the AWS console for CDK deploy failures
 - Check scripts/bootstrap.py output for step-specific error messages
+- Do not expect `platform-agentcore-{env}` from the first bootstrap deploy; deploy it only
+  once its required runtime parameters are available through the supported release path
+  or an explicit operator procedure.
 
 ## Time Estimate
 First run: approximately 45 minutes end-to-end.

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -499,47 +499,55 @@ def step_first_deploy(ctx: BootstrapContext) -> dict[str, Any]:
     if ctx.env == "prod":
         raise RuntimeError("first-deploy is disabled for prod; use CI/CD pipeline")
 
+    command = build_first_deploy_command(ctx)
+    return {"command": run_command(command, cwd=CDK_DIR)}
+
+
+def bootstrap_first_deploy_stacks(ctx: BootstrapContext) -> tuple[str, ...]:
+    """Return the stack names supported by the day-zero local bootstrap flow."""
+    return tuple(template.format(env=ctx.env) for template in STACKS_HOME)
+
+
+def build_first_deploy_command(ctx: BootstrapContext) -> list[str]:
+    """Build the explicit CDK deploy command for the supported bootstrap stacks."""
     command = [
         "npx",
         "cdk",
         "deploy",
-        "--all",
+        *bootstrap_first_deploy_stacks(ctx),
         "--context",
         f"env={ctx.env}",
         "--require-approval",
         "never",
     ]
-    return {"command": run_command(command, cwd=CDK_DIR)}
+    return command
 
 
-def _validate_expected_stacks(ctx: BootstrapContext) -> dict[str, dict[str, str]]:
-    """Validate all expected stacks are complete in home/runtime regions."""
-    statuses_home: dict[str, str] = {}
-    statuses_runtime: dict[str, str] = {}
-
-    cfn_home = boto3.client("cloudformation", region_name=ctx.home_region)
-    for template in STACKS_HOME:
-        stack_name = template.format(env=ctx.env)
-        status = _stack_status(cfn_home, stack_name)
-        _validate_stack_complete(status, stack_name, ctx.home_region)
-        statuses_home[stack_name] = status
-
-    cfn_runtime = boto3.client("cloudformation", region_name=ctx.runtime_region)
-    for template in STACKS_RUNTIME:
-        stack_name = template.format(env=ctx.env)
-        status = _stack_status(cfn_runtime, stack_name)
-        _validate_stack_complete(status, stack_name, ctx.runtime_region)
-        statuses_runtime[stack_name] = status
-
-    return {
-        "homeRegion": statuses_home,
-        "runtimeRegion": statuses_runtime,
-    }
+def _validate_stack_set(
+    ctx: BootstrapContext,
+    *,
+    region: str,
+    stack_names: tuple[str, ...],
+) -> dict[str, str]:
+    """Validate a stack set in one region reached a complete status."""
+    statuses: dict[str, str] = {}
+    cfn = boto3.client("cloudformation", region_name=region)
+    for stack_name in stack_names:
+        status = _stack_status(cfn, stack_name)
+        _validate_stack_complete(status, stack_name, region)
+        statuses[stack_name] = status
+    return statuses
 
 
 def validate_first_deploy(ctx: BootstrapContext) -> dict[str, Any]:
-    """Validate all expected stacks are deployed and complete."""
-    return _validate_expected_stacks(ctx)
+    """Validate the supported bootstrap stack set is deployed and complete."""
+    return {
+        "homeRegion": _validate_stack_set(
+            ctx,
+            region=ctx.home_region,
+            stack_names=bootstrap_first_deploy_stacks(ctx),
+        )
+    }
 
 
 def _upsert_ssm_parameter(ssm_client: Any, *, name: str, value: str) -> None:
@@ -752,7 +760,7 @@ def _try_smoke_invoke(ctx: BootstrapContext) -> dict[str, Any]:
 
 def step_verify(ctx: BootstrapContext) -> dict[str, Any]:
     """Run smoke checks for the bootstrapped environment."""
-    stack_details = _validate_expected_stacks(ctx)
+    stack_details = validate_first_deploy(ctx)
     seed_details = validate_post_deploy(ctx)
     smoke = _try_smoke_invoke(ctx)
     return {

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -48,6 +48,58 @@ def test_parse_args_supports_first_deploy_step() -> None:
     assert args.env == "dev"
 
 
+def test_build_first_deploy_command_targets_supported_bootstrap_stacks_only() -> None:
+    command = bootstrap.build_first_deploy_command(_ctx())
+
+    assert command[:3] == ["npx", "cdk", "deploy"]
+    assert "--all" not in command
+    assert command[3:8] == [
+        "platform-network-dev",
+        "platform-identity-dev",
+        "platform-core-dev",
+        "platform-tenant-stub-dev",
+        "platform-observability-dev",
+    ]
+    assert "platform-agentcore-dev" not in command
+    assert command[-4:] == ["--context", "env=dev", "--require-approval", "never"]
+
+
+def test_validate_first_deploy_checks_home_region_bootstrap_stacks_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_client(service_name: str, *, region_name: str) -> str:
+        assert service_name == "cloudformation"
+        return region_name
+
+    def _fake_stack_status(client: str, stack_name: str) -> str:
+        calls.append((client, stack_name))
+        return "CREATE_COMPLETE"
+
+    monkeypatch.setattr(bootstrap.boto3, "client", _fake_client)
+    monkeypatch.setattr(bootstrap, "_stack_status", _fake_stack_status)
+
+    result = bootstrap.validate_first_deploy(_ctx())
+
+    assert result == {
+        "homeRegion": {
+            "platform-network-dev": "CREATE_COMPLETE",
+            "platform-identity-dev": "CREATE_COMPLETE",
+            "platform-core-dev": "CREATE_COMPLETE",
+            "platform-tenant-stub-dev": "CREATE_COMPLETE",
+            "platform-observability-dev": "CREATE_COMPLETE",
+        }
+    }
+    assert calls == [
+        ("eu-west-2", "platform-network-dev"),
+        ("eu-west-2", "platform-identity-dev"),
+        ("eu-west-2", "platform-core-dev"),
+        ("eu-west-2", "platform-tenant-stub-dev"),
+        ("eu-west-2", "platform-observability-dev"),
+    ]
+
+
 @mock_aws
 def test_upsert_secret_create_then_update() -> None:
     client = boto3.client("secretsmanager", region_name=_REGION)


### PR DESCRIPTION
Closes #260.

## Summary
- stop bootstrap `first-deploy` from advertising or executing `cdk deploy --all`
- deploy and validate only the supported 5-stack bootstrap control-plane set
- align bootstrap docs/runbook with the real deployment contract
- sync stale `ai-context/` rules mirrors so repository validation passes again

## Validation
- `pytest -q tests/unit/test_bootstrap.py`
- `make preflight-session`
- `make pre-validate-session`
- clean worktree branch-state validation:
  - `npm ci` in `infra/cdk`
  - temporary local `infra/cdk/cdk.context.json` with the same placeholder Entra values used by CDK tests
  - `make validate-local`
