### PR TITLE
Document explicit WAF posture for the public SPA CloudFront distribution

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ infrastructure releases. Platform operators monitor, scale, and respond to incid
 ```
 eu-west-2 London (HOME — owns everything)
 ├── REST API Gateway + WAF
-├── CloudFront + SPA (S3)
+├── CloudFront + SPA (S3, no CloudFront WebACL by explicit exception)
 ├── AgentCore Gateway (native)
 ├── AgentCore Memory (native)
 ├── AgentCore Identity (native)
@@ -79,7 +79,7 @@ Failover controlled by SSM `/platform/config/runtime-region` with DynamoDB distr
 
 ```
 Client
-  → CloudFront (CSP headers, edge caching)
+  → CloudFront (CSP headers, edge caching, no CloudFront WebACL by explicit exception)
   → REST API Gateway (usage plan throttle, WAF)
   → Authoriser Lambda eu-west-2
       Validates Entra JWT (JWKS cached 5min in /tmp)
@@ -107,6 +107,17 @@ Client
       Gateway RESPONSE interceptor: filters by tier, redacts PII
   → Response stream back through bridge → API Gateway → client
 ```
+
+Current SPA edge exception: the public SPA distribution does not yet have its own
+CloudFront-scope WebACL. That is intentional for now, not an undocumented omission.
+The current approved region topology in [ADR-009](decisions/ADR-009-region-zigzag.md)
+keeps the platform home region in eu-west-2, while CloudFront-scope WAF resources
+require a dedicated global/us-east-1 management path. This repository does not yet
+contain an approved edge-security stack for that path, so the documented posture is:
+CloudFront provides TLS termination, OAC-backed S3 origin protection, and SPA security
+headers, while the WAF-enforced northbound boundary starts at REST API Gateway.
+Any future move to attach a CloudFront WebACL must be an explicit architecture change,
+not silent drift in stack code.
 
 ## Invocation Modes
 

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -3,11 +3,14 @@
  *                 Authoriser Lambda, AgentCore Gateway.
  *
  * REST API (not HTTP API) with usage plans, per-method throttling, WAF association.
+ * Public SPA CloudFront distribution currently has an explicit no-WebACL exception:
+ * the platform has not yet introduced an approved global/us-east-1 edge security stack,
+ * so only the regional API surface is WAF-protected in this stack.
  * Authoriser Lambda: provisioned concurrency 10.
  * AgentCore Gateway with REQUEST and RESPONSE interceptors wired.
  *
  * Implemented in TASK-023.
- * ADRs: ADR-003, ADR-004, ADR-011
+ * ADRs: ADR-003, ADR-004, ADR-009, ADR-011
  */
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
@@ -621,6 +624,9 @@ export class PlatformStack extends cdk.Stack {
         viewerCertificate: {
           cloudFrontDefaultCertificate: true,
         },
+        // No WebACLId is wired here by design. A CloudFront-scope WAF must be managed
+        // via a dedicated global/us-east-1 path, which this repository has not yet
+        // approved under the current ADR-009 region topology.
       },
     });
 

--- a/infra/cdk/test/observability-stack.test.ts
+++ b/infra/cdk/test/observability-stack.test.ts
@@ -12,12 +12,18 @@ import { PlatformStack } from '../lib/platform-stack';
 
 describe('ObservabilityStack (TASK-026)', () => {
   const synthStack = () => {
-    const app = new cdk.App();
+    const app = new cdk.App({
+      context: {
+        env: 'dev',
+        entraTenantId: '00000000-0000-0000-0000-000000000000',
+        entraAudience: 'platform-api',
+      },
+    });
     const env = { account: '123456789012', region: 'eu-west-2' };
-    
+
     const identityStack = new cdk.Stack(app, 'IdentityStack', { env });
     const mockKey = new kms.Key(identityStack, 'MockKey');
-    
+
     const networkStack = new cdk.Stack(app, 'NetworkStack', { env });
     const mockVpc = new ec2.Vpc(networkStack, 'MockVpc', {
       subnetConfiguration: [

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -209,6 +209,19 @@ describe('PlatformStack (TASK-023)', () => {
     template.resourceCountIs('AWS::WAFv2::WebACLAssociation', 1);
   });
 
+  test('documents the current explicit SPA edge exception by omitting CloudFront WebACL wiring', () => {
+    template.resourceCountIs('AWS::WAFv2::WebACL', 1);
+
+    const distributions = template.findResources('AWS::CloudFront::Distribution');
+    expect(Object.keys(distributions)).toHaveLength(1);
+
+    const [distribution] = Object.values(distributions) as Array<{
+      Properties?: { DistributionConfig?: Record<string, unknown> };
+    }>;
+
+    expect(distribution.Properties?.DistributionConfig).not.toHaveProperty('WebACLId');
+  });
+
   test('creates CloudFront distribution with OAC and CSP response headers policy', () => {
     template.resourceCountIs('AWS::CloudFront::OriginAccessControl', 1);
 


### PR DESCRIPTION
## Summary
- document the current explicit no-CloudFront-WebACL posture for the public SPA in architecture docs and CDK source
- add a CDK regression test asserting the SPA distribution intentionally omits `WebACLId` while the regional API WAF remains present
- fix the observability stack test harness so it provides the required Entra CDK context during synth

## Validation
- `npm test -- --runInBand platform-stack.test.ts observability-stack.test.ts`
- `make preflight-session`
- `make pre-validate-session`
- `make issues-audit`

## Issue
- Closes #265
