### PR TITLE
issue #267: include uv.lock state in agent layer cache hash

### DIFF
--- a/docs/development/AGENT-DEVELOPER-GUIDE.md
+++ b/docs/development/AGENT-DEVELOPER-GUIDE.md
@@ -158,10 +158,10 @@ def invoke(payload: dict, context: RequestContext):
 ## Dependency Management
 
 Dependencies are cross-compiled for arm64 (AgentCore Runtime requirement).
-The platform hashes `[project.dependencies]` to detect changes:
+The platform hashes `[project.dependencies]` **and** `uv.lock` to detect changes:
 
-- **Warm push** (deps unchanged): <30 seconds — zip code only.
-- **Cold push** (deps changed): <2 minutes — `uv` cross-compiles arm64 deps.
+- **Warm push** (deps and lockfile unchanged): <30 seconds — zip code only.
+- **Cold push** (deps or lockfile changed): <2 minutes — `uv` cross-compiles arm64 deps.
 
 To add a dependency:
 ```bash

--- a/scripts/build_layer.py
+++ b/scripts/build_layer.py
@@ -96,9 +96,25 @@ def read_agent_deps(agent_name: str) -> list[str]:
     return [str(dep) for dep in deps]
 
 
-def compute_dependency_hash(deps: list[str]) -> str:
-    """Return canonical dependency hash used for S3 key and SSM metadata."""
+def read_agent_lockfile(agent_name: str) -> str | None:
+    """Read uv.lock from agents/{agent_name}/uv.lock if it exists.
+
+    Returns the file content as a string, or None if the lockfile is absent.
+    """
+    lock_path = REPO_ROOT / "agents" / agent_name / "uv.lock"
+    if not lock_path.exists():
+        return None
+    return lock_path.read_text(encoding="utf-8")
+
+
+def compute_dependency_hash(deps: list[str], lockfile_content: str | None = None) -> str:
+    """Return canonical dependency hash used for S3 key and SSM metadata.
+
+    Includes lockfile content when present to track transitive dependency changes.
+    """
     canonical = "\n".join(sorted(dep.strip() for dep in deps))
+    if lockfile_content is not None:
+        canonical = canonical + "\n---lockfile---\n" + lockfile_content
     return hashlib.sha256(canonical.encode()).hexdigest()[:HASH_LENGTH]
 
 
@@ -249,7 +265,8 @@ def run(agent_name: str, env: str) -> int:
     """Run dependency layer build and publish flow."""
     aws_region = require_aws_region()
     deps = read_agent_deps(agent_name)
-    dep_hash = compute_dependency_hash(deps)
+    lockfile = read_agent_lockfile(agent_name)
+    dep_hash = compute_dependency_hash(deps, lockfile_content=lockfile)
 
     deps_dir = BUILD_DIR / "deps"
     zip_path = BUILD_DIR / f"{agent_name}-deps-{dep_hash}.zip"

--- a/scripts/hash_layer.py
+++ b/scripts/hash_layer.py
@@ -1,8 +1,9 @@
 """
 hash_layer.py — Dependency hash checker for agent layer caching.
 
-Reads [project.dependencies] from the agent's pyproject.toml, computes a
-canonical SHA256 hash, and compares against the stored hash in SSM.
+Reads [project.dependencies] from the agent's pyproject.toml and the resolved
+lockfile (uv.lock), computes a canonical SHA256 hash, and compares against the
+stored hash in SSM.
 
 Exit codes:
     0  Hash matches — dependencies unchanged, use warm push path (~15s)
@@ -10,14 +11,16 @@ Exit codes:
 
 Hash algorithm:
     - Read [project.dependencies] list
-    - Canonicalise: sort, strip whitespace
-    - SHA256 of canonical form
+    - Read uv.lock content (if present)
+    - Canonicalise deps: sort, strip whitespace
+    - Combine canonical deps with lockfile content
+    - SHA256 of combined form
     - First 16 hex characters
 
 Usage:
     uv run python scripts/hash_layer.py <agent_name> --env <env>
 
-Implemented in TASK-033.
+Implemented in TASK-033, updated in issue #267.
 ADRs: ADR-006, ADR-008
 """
 
@@ -43,14 +46,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 HASH_LENGTH = 16
 
 
-def compute_dependency_hash(deps: list[str]) -> str:
-    """Return a canonical SHA256 hash of a dependency list.
+def compute_dependency_hash(deps: list[str], lockfile_content: str | None = None) -> str:
+    """Return a canonical SHA256 hash of dependencies and lockfile state.
 
-    Canonical form: each entry stripped of whitespace, sorted, joined by
-    newline.  Returns the first HASH_LENGTH hex characters of SHA256.
+    Canonical form: each dep entry stripped of whitespace, sorted, joined by
+    newline.  When lockfile content is provided it is appended after a separator.
+    Returns the first HASH_LENGTH hex characters of SHA256.
     Same deps in any order produce the same hash.
     """
     canonical = "\n".join(sorted(d.strip() for d in deps))
+    if lockfile_content is not None:
+        canonical = canonical + "\n---lockfile---\n" + lockfile_content
     return hashlib.sha256(canonical.encode()).hexdigest()[:HASH_LENGTH]
 
 
@@ -67,6 +73,17 @@ def read_agent_deps(agent_name: str) -> list[str]:
     if not isinstance(deps, list):
         raise ValueError(f"[project.dependencies] must be a list in {toml_path}")
     return [str(d) for d in deps]
+
+
+def read_agent_lockfile(agent_name: str) -> str | None:
+    """Read uv.lock from agents/{agent_name}/uv.lock if it exists.
+
+    Returns the file content as a string, or None if the lockfile is absent.
+    """
+    lock_path = REPO_ROOT / "agents" / agent_name / "uv.lock"
+    if not lock_path.exists():
+        return None
+    return lock_path.read_text(encoding="utf-8")
 
 
 def get_ssm_hash(agent_name: str, env: str, aws_region: str) -> str | None:
@@ -124,12 +141,14 @@ def run(agent_name: str, env: str) -> int:
     aws_region = require_aws_region()
 
     deps = read_agent_deps(agent_name)
-    computed = compute_dependency_hash(deps)
+    lockfile = read_agent_lockfile(agent_name)
+    computed = compute_dependency_hash(deps, lockfile_content=lockfile)
     logger.info(
-        "Computed hash for %s: %s (%d deps)",
+        "Computed hash for %s: %s (%d deps, lockfile=%s)",
         agent_name,
         computed,
         len(deps),
+        "present" if lockfile is not None else "absent",
     )
 
     stored = get_ssm_hash(agent_name, env, aws_region)

--- a/tests/unit/test_build_layer.py
+++ b/tests/unit/test_build_layer.py
@@ -136,7 +136,10 @@ def test_run_uploads_zip_and_updates_ssm(tmp_path: Path, monkeypatch: pytest.Mon
     exit_code = bl.run("echo-agent", "dev")
     assert exit_code == 0
 
-    expected_hash = bl.compute_dependency_hash(bl.read_agent_deps("echo-agent"))
+    expected_hash = bl.compute_dependency_hash(
+        bl.read_agent_deps("echo-agent"),
+        lockfile_content=bl.read_agent_lockfile("echo-agent"),
+    )
     expected_key = f"layers/echo-agent-deps-{expected_hash}.zip"
 
     ssm = boto3.client("ssm", region_name=_REGION)

--- a/tests/unit/test_hash_layer.py
+++ b/tests/unit/test_hash_layer.py
@@ -76,6 +76,59 @@ def test_empty_deps_returns_hash() -> None:
 
 
 # ---------------------------------------------------------------------------
+# compute_dependency_hash — lockfile-aware tests (issue #267)
+# ---------------------------------------------------------------------------
+
+
+def test_lockfile_content_changes_hash() -> None:
+    """Changing lockfile content must produce a different hash."""
+    deps = ["boto3>=1.37.0", "requests>=2.31.0"]
+    lockfile_a = "# uv.lock v1\nboto3==1.37.0\nrequests==2.31.0\n"
+    lockfile_b = "# uv.lock v1\nboto3==1.37.1\nrequests==2.31.0\n"
+
+    hash_a = hl.compute_dependency_hash(deps, lockfile_content=lockfile_a)
+    hash_b = hl.compute_dependency_hash(deps, lockfile_content=lockfile_b)
+    assert hash_a != hash_b
+
+
+def test_same_deps_same_lockfile_same_hash() -> None:
+    """Identical deps + lockfile must produce the same hash."""
+    deps = ["boto3>=1.37.0"]
+    lockfile = "# uv.lock v1\nboto3==1.37.0\n"
+    hash_a = hl.compute_dependency_hash(deps, lockfile_content=lockfile)
+    hash_b = hl.compute_dependency_hash(deps, lockfile_content=lockfile)
+    assert hash_a == hash_b
+
+
+def test_no_lockfile_preserves_original_hash() -> None:
+    """When lockfile_content is None, hash matches the original deps-only hash."""
+    deps = ["boto3>=1.37.0", "requests>=2.31.0"]
+    hash_no_lock = hl.compute_dependency_hash(deps)
+    hash_none = hl.compute_dependency_hash(deps, lockfile_content=None)
+    assert hash_no_lock == hash_none
+
+
+def test_lockfile_vs_no_lockfile_different_hash() -> None:
+    """Adding a lockfile where none existed must change the hash."""
+    deps = ["boto3>=1.37.0"]
+    lockfile = "# uv.lock v1\nboto3==1.37.0\n"
+    hash_without = hl.compute_dependency_hash(deps, lockfile_content=None)
+    hash_with = hl.compute_dependency_hash(deps, lockfile_content=lockfile)
+    assert hash_without != hash_with
+
+
+# ---------------------------------------------------------------------------
+# read_agent_lockfile — file-system tests
+# ---------------------------------------------------------------------------
+
+
+def test_read_agent_lockfile_returns_none_when_absent() -> None:
+    """Agents without uv.lock should return None."""
+    result = hl.read_agent_lockfile("nonexistent-agent-xyz")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
 # read_agent_deps — file-system tests against echo-agent fixture
 # ---------------------------------------------------------------------------
 
@@ -135,7 +188,8 @@ def test_run_returns_0_when_hash_matches(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("AWS_REGION", _REGION)
 
     deps = hl.read_agent_deps("echo-agent")
-    computed = hl.compute_dependency_hash(deps)
+    lockfile = hl.read_agent_lockfile("echo-agent")
+    computed = hl.compute_dependency_hash(deps, lockfile_content=lockfile)
 
     ssm = boto3.client("ssm", region_name=_REGION)
     ssm.put_parameter(


### PR DESCRIPTION
## Summary
- Layer cache hash now includes `uv.lock` content alongside `[project.dependencies]`, so transitive dependency changes trigger a cold rebuild
- Both `hash_layer.py` and `build_layer.py` updated with aligned `compute_dependency_hash(deps, lockfile_content)` and new `read_agent_lockfile()` function
- Agent Developer Guide updated to reflect the true rebuild trigger

## Test plan
- [x] 5 new unit tests proving lockfile changes affect hash, no-lockfile preserves backward compat
- [x] All 27 existing + new tests pass
- [x] `make preflight-session` passes
- [x] `make pre-validate-session` passes
- [x] Ruff, mypy, detect-secrets clean

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)