### PR TITLE
Fix agent-push deploying before agent tests pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,10 +411,10 @@ agent-push:
 	fi
 	@echo "==> Packaging agent code"
 	uv run python scripts/package_agent.py $(AGENT)
-	@echo "==> Deploying to AgentCore Runtime"
-	uv run python scripts/deploy_agent.py $(AGENT) --env $(ENV)
 	@echo "==> Running agent tests"
 	$(MAKE) test-agent AGENT=$(AGENT)
+	@echo "==> Deploying to AgentCore Runtime"
+	uv run python scripts/deploy_agent.py $(AGENT) --env $(ENV)
 	@echo "==> Registering agent"
 	uv run python scripts/register_agent.py $(AGENT) --env $(ENV)
 	@echo "==> Agent $(AGENT) deployed successfully to $(ENV)"

--- a/docs/development/AGENT-DEVELOPER-GUIDE.md
+++ b/docs/development/AGENT-DEVELOPER-GUIDE.md
@@ -23,8 +23,8 @@ make test-agent AGENT=my-agent               # Run unit + golden tests
 make dev                                    # Start local environment (LocalStack + mocks)
 make agent-invoke AGENT=my-agent ENV=local  # Invoke via local bridge (canned mock response)
 
-# 5. Deploy to AWS dev (real compute, real compute)
-make agent-push AGENT=my-agent ENV=dev      # Package, deploy to Runtime, and register
+# 5. Validate locally, then push to AWS dev (real compute)
+make agent-push AGENT=my-agent ENV=dev      # Package, run agent tests, deploy to Runtime, and register
 make agent-invoke AGENT=my-agent ENV=dev    # Invoke your agent on real AWS
 ```
 

--- a/tests/unit/test_agent_scripts.py
+++ b/tests/unit/test_agent_scripts.py
@@ -58,6 +58,26 @@ def _patch_deploy_agentcore(monkeypatch, fake_client: _FakeAgentCoreClient) -> N
     monkeypatch.setattr(deploy_agent, "boto3", types.SimpleNamespace(client=_client))
 
 
+def _makefile_recipe_lines(target: str) -> list[str]:
+    makefile_lines = (REPO_ROOT / "Makefile").read_text().splitlines()
+    recipe_lines: list[str] = []
+    in_target = False
+
+    for line in makefile_lines:
+        if in_target:
+            if line.startswith("\t"):
+                recipe_lines.append(line.strip())
+                continue
+            break
+        if line == f"{target}:":
+            in_target = True
+
+    if not recipe_lines:
+        raise AssertionError(f"Target {target} not found in Makefile")
+
+    return recipe_lines
+
+
 # ---------------------------------------------------------------------------
 # package_agent.py tests
 # ---------------------------------------------------------------------------
@@ -87,6 +107,18 @@ def test_package_agent_creates_zip(tmp_path, monkeypatch):
         assert "handler.py" in names
         assert "pyproject.toml" in names
         assert "__pycache__/test.pyc" not in names
+
+
+def test_agent_push_runs_tests_before_deploy_and_register():
+    recipe_lines = _makefile_recipe_lines("agent-push")
+
+    test_index = recipe_lines.index("$(MAKE) test-agent AGENT=$(AGENT)")
+    deploy_index = recipe_lines.index("uv run python scripts/deploy_agent.py $(AGENT) --env $(ENV)")
+    register_index = recipe_lines.index(
+        "uv run python scripts/register_agent.py $(AGENT) --env $(ENV)"
+    )
+
+    assert test_index < deploy_index < register_index
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- move `make agent-push` test execution ahead of deploy/register mutations
- add a regression test that asserts the `agent-push` recipe order in `Makefile`
- update the agent developer guide so the documented push flow matches the safe order

## Validation
- `PYTHONPATH=. uv run pytest tests/unit/test_agent_scripts.py -v --tb=short`
  - `7 passed in 70.18s`
- `make preflight-session`
  - `PASS`
- `make pre-validate-session`
  - `PASS`
- enforced git pre-push hook on `git push`
  - lint, format, pyright, openapi contract test, and detect-secrets all passed
- `make issues-audit`
  - `PASS`
- `gitnexus_detect_changes`
  - `risk_level: low`, `affected_count: 0`

## Issue
Refs #269
