### PR TITLE
Fix local dev contract drift in docs sync audit

### DIFF
--- a/docs/development/LOCAL-SETUP.md
+++ b/docs/development/LOCAL-SETUP.md
@@ -54,13 +54,16 @@ for a stronger end-to-end check once the local stack is running.
 
 ## Test Tenants (seeded by dev-bootstrap.py)
 
-After `make dev`, two test tenants are available. Their JWTs are in `.env.test`:
+After `make dev`, two test tenants are available. Their tenant IDs and JWTs are in `.env.test`:
 
-| Variable              | Tenant     | Tier     |
+| Variable              | Value      | Purpose  |
 |-----------------------|------------|----------|
-| BASIC_TENANT_JWT      | t-test-001 | basic    |
-| PREMIUM_TENANT_JWT    | t-test-002 | premium  |
-| ADMIN_JWT             | admin-001  | Platform.Admin |
+| BASIC_TENANT_ID       | t-test-001 | Local basic tenant ID |
+| BASIC_TENANT_JWT      | JWT        | Basic tenant bearer token |
+| PREMIUM_TENANT_ID     | t-test-002 | Local premium tenant ID |
+| PREMIUM_TENANT_JWT    | JWT        | Premium tenant bearer token |
+| ADMIN_TENANT_ID       | admin-001  | Platform admin tenant ID |
+| ADMIN_JWT             | JWT        | Platform.Admin bearer token |
 
 To refresh the local JWT fixtures without rerunning bootstrap, keep the dev services up and run:
 

--- a/scripts/dev-bootstrap.py
+++ b/scripts/dev-bootstrap.py
@@ -2,7 +2,7 @@
 dev-bootstrap.py — Local development environment seeding script.
 
 Seeds LocalStack with:
-  - Two test tenants: basic-tier (t-basic-001) and premium-tier (t-premium-001)
+  - Two test tenants: basic-tier (t-test-001) and premium-tier (t-test-002)
   - All SSM parameters pointing to LocalStack endpoints
   - DynamoDB tables with fixture data (tables created if missing)
   - Test JWTs written to .env.test
@@ -147,9 +147,9 @@ TABLE_DEFINITIONS: list[dict[str, Any]] = [
 # ---------------------------------------------------------------------------
 TENANT_FIXTURES: list[dict[str, Any]] = [
     {
-        "PK": "TENANT#t-basic-001",
+        "PK": "TENANT#t-test-001",
         "SK": "METADATA",
-        "tenant_id": "t-basic-001",
+        "tenant_id": "t-test-001",
         "app_id": "platform-local",
         "display_name": "Test Tenant Basic",
         "tier": "basic",
@@ -160,14 +160,14 @@ TENANT_FIXTURES: list[dict[str, Any]] = [
         "owner_team": "platform-test",
         "account_id": "000000000000",
         "execution_role_arn": (
-            "arn:aws:iam::000000000000:role/platform-tenant-t-basic-001-execution-role"
+            "arn:aws:iam::000000000000:role/platform-tenant-t-test-001-execution-role"
         ),
         "monthly_budget_usd": Decimal("100"),
     },
     {
-        "PK": "TENANT#t-premium-001",
+        "PK": "TENANT#t-test-002",
         "SK": "METADATA",
-        "tenant_id": "t-premium-001",
+        "tenant_id": "t-test-002",
         "app_id": "platform-local",
         "display_name": "Test Tenant Premium",
         "tier": "premium",
@@ -178,7 +178,7 @@ TENANT_FIXTURES: list[dict[str, Any]] = [
         "owner_team": "platform-test",
         "account_id": "000000000000",
         "execution_role_arn": (
-            "arn:aws:iam::000000000000:role/platform-tenant-t-premium-001-execution-role"
+            "arn:aws:iam::000000000000:role/platform-tenant-t-test-002-execution-role"
         ),
         "monthly_budget_usd": Decimal("1000"),
     },
@@ -301,12 +301,12 @@ def fetch_jwts(mock_jwks_url: str) -> dict[str, str]:
     requests_to_make: list[tuple[str, dict[str, Any]]] = [
         (
             "basic",
-            {"tenant_id": "t-basic-001", "app_id": "platform-local", "tier": "basic", "ttl": 86400},
+            {"tenant_id": "t-test-001", "app_id": "platform-local", "tier": "basic", "ttl": 86400},
         ),
         (
             "premium",
             {
-                "tenant_id": "t-premium-001",
+                "tenant_id": "t-test-002",
                 "app_id": "platform-local",
                 "tier": "premium",
                 "ttl": 86400,
@@ -315,7 +315,7 @@ def fetch_jwts(mock_jwks_url: str) -> dict[str, str]:
         (
             "admin",
             {
-                "tenant_id": "t-basic-001",
+                "tenant_id": "admin-001",
                 "app_id": "platform-local",
                 "tier": "basic",
                 "sub": "admin-user",
@@ -360,16 +360,22 @@ def write_env_test(tokens: dict[str, str], env_test_path: Path) -> None:
     ]
     if tokens:
         lines += [
-            f"TEST_JWT_BASIC={tokens.get('basic', '')}",
-            f"TEST_JWT_PREMIUM={tokens.get('premium', '')}",
-            f"TEST_JWT_ADMIN={tokens.get('admin', '')}",
+            "BASIC_TENANT_ID=t-test-001",
+            f"BASIC_TENANT_JWT={tokens.get('basic', '')}",
+            "PREMIUM_TENANT_ID=t-test-002",
+            f"PREMIUM_TENANT_JWT={tokens.get('premium', '')}",
+            "ADMIN_TENANT_ID=admin-001",
+            f"ADMIN_JWT={tokens.get('admin', '')}",
         ]
     else:
         lines += [
             "# JWTs not available (mock-jwks service was not running)",
-            "TEST_JWT_BASIC=",
-            "TEST_JWT_PREMIUM=",
-            "TEST_JWT_ADMIN=",
+            "BASIC_TENANT_ID=t-test-001",
+            "BASIC_TENANT_JWT=",
+            "PREMIUM_TENANT_ID=t-test-002",
+            "PREMIUM_TENANT_JWT=",
+            "ADMIN_TENANT_ID=admin-001",
+            "ADMIN_JWT=",
         ]
     env_test_path.write_text("\n".join(lines) + "\n")
     logger.info("Written %s", env_test_path)

--- a/scripts/docs_sync_audit.py
+++ b/scripts/docs_sync_audit.py
@@ -29,11 +29,21 @@ CDK_PACKAGE = ROOT / "infra" / "cdk" / "package.json"
 SPA_PACKAGE = ROOT / "spa" / "package.json"
 TASKS_MD = ROOT / "docs" / "TASKS.md"
 OPS_PY = ROOT / "scripts" / "ops.py"
+MAKEFILE = ROOT / "Makefile"
+DEV_BOOTSTRAP_PY = ROOT / "scripts" / "dev-bootstrap.py"
+LOCAL_SETUP_MD = ROOT / "docs" / "development" / "LOCAL-SETUP.md"
+AGENT_GUIDE_MD = ROOT / "docs" / "development" / "AGENT-DEVELOPER-GUIDE.md"
+RUNBOOK_008_MD = ROOT / "docs" / "operations" / "RUNBOOK-008-developer-onboarding.md"
 STAMP_FILE = ROOT / "docs" / "DOCS_SYNC.json"
 
 
 SEMVER_RE = re.compile(r'^version\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
 TASK_PATH_RE = re.compile(r"\b(src/[A-Za-z0-9._/-]+/handler\.py)\b")
+DOC_TENANT_ID_RE = re.compile(r"\bt-test-\d+\b")
+BOOTSTRAP_TENANT_ID_RE = re.compile(r"\bt-(?:basic|premium)-\d+\b")
+ENV_TEST_KEY_RE = re.compile(
+    r"\b(?:BASIC_TENANT_ID|BASIC_TENANT_JWT|PREMIUM_TENANT_ID|PREMIUM_TENANT_JWT|ADMIN_TENANT_ID|ADMIN_JWT|TEST_JWT_BASIC|TEST_JWT_PREMIUM|TEST_JWT_ADMIN)\b"
+)
 
 
 def _run(cmd: list[str]) -> str:
@@ -102,6 +112,75 @@ def detect_ops_cli_stub_drift() -> list[str]:
     return findings
 
 
+def detect_local_env_test_key_drift() -> list[str]:
+    """Detect mismatches between .env.test keys written by bootstrap.
+
+    The audit compares the .env.test contract against the docs and consumers
+    that read those keys.
+    """
+    findings: list[str] = []
+    makefile_text = MAKEFILE.read_text(encoding="utf-8")
+    bootstrap_text = DEV_BOOTSTRAP_PY.read_text(encoding="utf-8")
+    docs_text = "\n".join(
+        [
+            LOCAL_SETUP_MD.read_text(encoding="utf-8"),
+            AGENT_GUIDE_MD.read_text(encoding="utf-8"),
+            RUNBOOK_008_MD.read_text(encoding="utf-8"),
+        ]
+    )
+
+    makefile_keys = sorted(set(ENV_TEST_KEY_RE.findall(makefile_text)))
+    bootstrap_keys = sorted(set(ENV_TEST_KEY_RE.findall(bootstrap_text)))
+    docs_keys = sorted(set(ENV_TEST_KEY_RE.findall(docs_text)))
+
+    if {"BASIC_TENANT_ID", "BASIC_TENANT_JWT"}.issubset(makefile_keys) and {
+        "TEST_JWT_BASIC",
+        "TEST_JWT_PREMIUM",
+        "TEST_JWT_ADMIN",
+    }.issubset(bootstrap_keys):
+        findings.append(
+            "make dev-invoke reads BASIC_TENANT_ID/BASIC_TENANT_JWT from .env.test, "
+            "but scripts/dev-bootstrap.py writes TEST_JWT_BASIC/"
+            "TEST_JWT_PREMIUM/TEST_JWT_ADMIN instead."
+        )
+
+    if {"BASIC_TENANT_JWT", "PREMIUM_TENANT_JWT", "ADMIN_JWT"}.intersection(docs_keys) and {
+        "TEST_JWT_BASIC",
+        "TEST_JWT_PREMIUM",
+        "TEST_JWT_ADMIN",
+    }.issubset(bootstrap_keys):
+        findings.append(
+            "docs/development/LOCAL-SETUP.md and onboarding docs describe BASIC_TENANT_JWT/"
+            "PREMIUM_TENANT_JWT/ADMIN_JWT, but scripts/dev-bootstrap.py writes TEST_JWT_* keys."
+        )
+
+    return findings
+
+
+def detect_local_fixture_name_drift() -> list[str]:
+    """Detect tenant fixture name drift between local docs and the dev bootstrap seed data."""
+    findings: list[str] = []
+    docs_text = "\n".join(
+        [
+            LOCAL_SETUP_MD.read_text(encoding="utf-8"),
+            AGENT_GUIDE_MD.read_text(encoding="utf-8"),
+            RUNBOOK_008_MD.read_text(encoding="utf-8"),
+        ]
+    )
+    bootstrap_text = DEV_BOOTSTRAP_PY.read_text(encoding="utf-8")
+
+    doc_tenants = sorted(set(DOC_TENANT_ID_RE.findall(docs_text)))
+    bootstrap_tenants = sorted(set(BOOTSTRAP_TENANT_ID_RE.findall(bootstrap_text)))
+
+    if doc_tenants and bootstrap_tenants and set(doc_tenants) != set(bootstrap_tenants):
+        findings.append(
+            "Local docs reference tenant fixtures "
+            f"{doc_tenants}, but scripts/dev-bootstrap.py seeds {bootstrap_tenants}."
+        )
+
+    return findings
+
+
 def load_stamp() -> dict[str, Any]:
     if not STAMP_FILE.exists():
         return {}
@@ -167,6 +246,8 @@ def cmd_check(json_output: bool = False) -> int:
 
     warnings.extend(detect_task_handler_path_drift())
     warnings.extend(detect_ops_cli_stub_drift())
+    warnings.extend(detect_local_env_test_key_drift())
+    warnings.extend(detect_local_fixture_name_drift())
 
     result = {
         "ok": len(errors) == 0,

--- a/tests/unit/test_dev_bootstrap.py
+++ b/tests/unit/test_dev_bootstrap.py
@@ -104,8 +104,8 @@ def test_seed_tenants_correct_tiers() -> None:
     bootstrap.ensure_tables(ddb_client)  # type: ignore[attr-defined]
     bootstrap.seed_tenants(ddb_resource)  # type: ignore[attr-defined]
     items = {item["tenant_id"]: item for item in _scan_table(ddb_resource, "platform-tenants")}
-    assert items["t-basic-001"]["tier"] == "basic"
-    assert items["t-premium-001"]["tier"] == "premium"
+    assert items["t-test-001"]["tier"] == "basic"
+    assert items["t-test-002"]["tier"] == "premium"
 
 
 @mock_aws
@@ -298,9 +298,12 @@ def test_write_env_test_with_tokens(tmp_path: Path) -> None:
         "# Re-run `uv run python scripts/dev-bootstrap.py` (with dev services up) to refresh JWTs"
         in content
     )
-    assert "TEST_JWT_BASIC=jwt-basic" in content
-    assert "TEST_JWT_PREMIUM=jwt-premium" in content
-    assert "TEST_JWT_ADMIN=jwt-admin" in content
+    assert "BASIC_TENANT_ID=t-test-001" in content
+    assert "BASIC_TENANT_JWT=jwt-basic" in content
+    assert "PREMIUM_TENANT_ID=t-test-002" in content
+    assert "PREMIUM_TENANT_JWT=jwt-premium" in content
+    assert "ADMIN_TENANT_ID=admin-001" in content
+    assert "ADMIN_JWT=jwt-admin" in content
     assert "AWS_REGION=eu-west-2" in content
     assert "LOCALSTACK_ENDPOINT=http://localhost:4566" in content
 
@@ -309,8 +312,12 @@ def test_write_env_test_without_tokens_writes_empty_values(tmp_path: Path) -> No
     env_test_path = tmp_path / ".env.test"
     bootstrap.write_env_test({}, env_test_path)  # type: ignore[attr-defined]
     content = env_test_path.read_text()
-    assert "TEST_JWT_BASIC=" in content
-    assert "TEST_JWT_PREMIUM=" in content
+    assert "BASIC_TENANT_ID=t-test-001" in content
+    assert "BASIC_TENANT_JWT=" in content
+    assert "PREMIUM_TENANT_ID=t-test-002" in content
+    assert "PREMIUM_TENANT_JWT=" in content
+    assert "ADMIN_TENANT_ID=admin-001" in content
+    assert "ADMIN_JWT=" in content
     assert "mock-jwks service was not running" in content
 
 

--- a/tests/unit/test_docs_sync_audit.py
+++ b/tests/unit/test_docs_sync_audit.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_docs_sync_audit_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "docs_sync_audit", repo_root / "scripts" / "docs_sync_audit.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+docs_sync_audit = _load_docs_sync_audit_module()
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_detect_local_env_test_key_drift_reports_makefile_and_docs_mismatch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    makefile = _write(
+        tmp_path / "Makefile",
+        """
+dev-invoke:
+\t@TENANT=$$(grep BASIC_TENANT_ID .env.test); \\
+\tJWT=$$(grep BASIC_TENANT_JWT .env.test)
+""".lstrip(),
+    )
+    bootstrap = _write(
+        tmp_path / "scripts" / "dev-bootstrap.py",
+        """
+def write_env_test(tokens, env_test_path):
+    lines = [
+        "TEST_JWT_BASIC=",
+        "TEST_JWT_PREMIUM=",
+        "TEST_JWT_ADMIN=",
+    ]
+""".lstrip(),
+    )
+    local_setup = _write(
+        tmp_path / "docs" / "development" / "LOCAL-SETUP.md",
+        """
+| BASIC_TENANT_JWT      | t-test-001 | basic    |
+| PREMIUM_TENANT_JWT    | t-test-002 | premium  |
+| ADMIN_JWT             | admin-001  | Platform.Admin |
+""".lstrip(),
+    )
+    agent_guide = _write(
+        tmp_path / "docs" / "development" / "AGENT-DEVELOPER-GUIDE.md",
+        "Use make agent-invoke AGENT=my-agent ENV=local\n",
+    )
+    runbook = _write(
+        tmp_path / "docs" / "operations" / "RUNBOOK-008-developer-onboarding.md",
+        "make dev-invoke\n",
+    )
+
+    monkeypatch.setattr(docs_sync_audit, "MAKEFILE", makefile)
+    monkeypatch.setattr(docs_sync_audit, "DEV_BOOTSTRAP_PY", bootstrap)
+    monkeypatch.setattr(docs_sync_audit, "LOCAL_SETUP_MD", local_setup)
+    monkeypatch.setattr(docs_sync_audit, "AGENT_GUIDE_MD", agent_guide)
+    monkeypatch.setattr(docs_sync_audit, "RUNBOOK_008_MD", runbook)
+
+    warnings = docs_sync_audit.detect_local_env_test_key_drift()
+
+    assert any("make dev-invoke reads BASIC_TENANT_ID/BASIC_TENANT_JWT" in msg for msg in warnings)
+    assert any("TEST_JWT_BASIC/TEST_JWT_PREMIUM/TEST_JWT_ADMIN" in msg for msg in warnings)
+
+
+def test_detect_local_fixture_name_drift_reports_docs_and_bootstrap_mismatch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    local_setup = _write(
+        tmp_path / "docs" / "development" / "LOCAL-SETUP.md",
+        """
+After make dev, two test tenants are available:
+t-test-001
+t-test-002
+""".lstrip(),
+    )
+    agent_guide = _write(
+        tmp_path / "docs" / "development" / "AGENT-DEVELOPER-GUIDE.md",
+        'tenantId": "t-test-001"\n',
+    )
+    runbook = _write(
+        tmp_path / "docs" / "operations" / "RUNBOOK-008-developer-onboarding.md",
+        "make agent-invoke AGENT=my-first-agent TENANT=t-test-001\n",
+    )
+    bootstrap = _write(
+        tmp_path / "scripts" / "dev-bootstrap.py",
+        """
+TENANT_FIXTURES = [
+    {"tenant_id": "t-basic-001"},
+    {"tenant_id": "t-premium-001"},
+]
+""".lstrip(),
+    )
+
+    monkeypatch.setattr(docs_sync_audit, "LOCAL_SETUP_MD", local_setup)
+    monkeypatch.setattr(docs_sync_audit, "AGENT_GUIDE_MD", agent_guide)
+    monkeypatch.setattr(docs_sync_audit, "RUNBOOK_008_MD", runbook)
+    monkeypatch.setattr(docs_sync_audit, "DEV_BOOTSTRAP_PY", bootstrap)
+
+    warnings = docs_sync_audit.detect_local_fixture_name_drift()
+
+    assert warnings == [
+        "Local docs reference tenant fixtures ['t-test-001', 't-test-002'], "
+        "but scripts/dev-bootstrap.py seeds ['t-basic-001', 't-premium-001']."
+    ]
+
+
+def test_cmd_check_surfaces_local_dev_drift_warnings(monkeypatch, tmp_path: Path, capsys) -> None:
+    makefile = _write(
+        tmp_path / "Makefile",
+        (
+            "dev-invoke:\n\t@TENANT=$$(grep BASIC_TENANT_ID .env.test)\n"
+            "\tJWT=$$(grep BASIC_TENANT_JWT .env.test)\n"
+        ),
+    )
+    bootstrap = _write(
+        tmp_path / "scripts" / "dev-bootstrap.py",
+        """
+TENANT_FIXTURES = [
+    {"tenant_id": "t-basic-001"},
+    {"tenant_id": "t-premium-001"},
+]
+print("TEST_JWT_BASIC")
+print("TEST_JWT_PREMIUM")
+print("TEST_JWT_ADMIN")
+""".lstrip(),
+    )
+    local_setup = _write(
+        tmp_path / "docs" / "development" / "LOCAL-SETUP.md",
+        "BASIC_TENANT_JWT | t-test-001\nPREMIUM_TENANT_JWT | t-test-002\n",
+    )
+    agent_guide = _write(
+        tmp_path / "docs" / "development" / "AGENT-DEVELOPER-GUIDE.md",
+        'tenantId": "t-test-001"\n',
+    )
+    runbook = _write(
+        tmp_path / "docs" / "operations" / "RUNBOOK-008-developer-onboarding.md",
+        "make dev-invoke\n",
+    )
+
+    monkeypatch.setattr(docs_sync_audit, "MAKEFILE", makefile)
+    monkeypatch.setattr(docs_sync_audit, "DEV_BOOTSTRAP_PY", bootstrap)
+    monkeypatch.setattr(docs_sync_audit, "LOCAL_SETUP_MD", local_setup)
+    monkeypatch.setattr(docs_sync_audit, "AGENT_GUIDE_MD", agent_guide)
+    monkeypatch.setattr(docs_sync_audit, "RUNBOOK_008_MD", runbook)
+    monkeypatch.setattr(
+        docs_sync_audit,
+        "collect_versions",
+        lambda: {"python": "1.0.0", "cdk": "1.0.0", "spa": "1.0.0"},
+    )
+    monkeypatch.setattr(
+        docs_sync_audit,
+        "load_stamp",
+        lambda: {
+            "semver": "1.0.0",
+            "components": {"python": "1.0.0", "cdk": "1.0.0", "spa": "1.0.0"},
+        },
+    )
+
+    rc = docs_sync_audit.cmd_check(json_output=False)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Docs sync audit: PASS" in out
+    assert "make dev-invoke reads BASIC_TENANT_ID/BASIC_TENANT_JWT" in out
+    assert "Local docs reference tenant fixtures" in out
+
+
+def test_cmd_check_passes_on_repository_local_contract(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        docs_sync_audit,
+        "collect_versions",
+        lambda: {"python": "1.0.0", "cdk": "1.0.0", "spa": "1.0.0"},
+    )
+    monkeypatch.setattr(
+        docs_sync_audit,
+        "load_stamp",
+        lambda: {
+            "semver": "1.0.0",
+            "components": {"python": "1.0.0", "cdk": "1.0.0", "spa": "1.0.0"},
+        },
+    )
+
+    rc = docs_sync_audit.cmd_check(json_output=False)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Docs sync audit: PASS" in out
+    assert "WARN:" not in out


### PR DESCRIPTION
## Summary
- Align dev-bootstrap, local setup docs, and docs-sync-audit with the real local developer loop contract
- Add regression coverage for the drift detectors and bootstrap outputs

## Validation
- `uv run python scripts/docs_sync_audit.py check`
- `uv run pytest tests/unit/test_dev_bootstrap.py tests/unit/test_docs_sync_audit.py tests/unit/test_dev_invoke.py -q` -> 31 passed
- Pre-push hook validation passed, including `ruff check`, `ruff format --check`, `pyright`, `tests/unit/test_openapi_contract_routes.py`, and `detect-secrets`

## Issue
- https://github.com/j3brns/tf-acore-aas/issues/276
- Confirmation comment: https://github.com/j3brns/tf-acore-aas/issues/276#issuecomment-4084033115
