### PR TITLE
BUG: Make the plan stage post infra diffs to merge requests or stop claiming it does

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,3 +4,105 @@ Pointer only.
 
 Read [CLAUDE.md](CLAUDE.md) for the authoritative rules for AI coding assistants.
 This file exists so tools that look for assistant instruction files can redirect to the source of truth.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **wt281** (2209 symbols, 5750 relationships, 179 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/wt281/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/wt281/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/wt281/clusters` | All functional areas |
+| `gitnexus://repo/wt281/processes` | All execution flows |
+| `gitnexus://repo/wt281/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -423,7 +423,7 @@ sees results. Admin view shows platform health metrics.
               Stages: validate → test → plan → deploy-dev → deploy-staging → deploy-prod
               validate: ruff, mypy, tsc, cdk synth, cfn-guard, detect-secrets
               test: Jest CDK tests + pytest unit + pytest integration
-              plan: cdk diff posted as MR comment
+              plan: cdk diff stored as artifacts for review
               deploy-dev: auto on merge to main
               deploy-staging: manual gate, canary 10% for 30 minutes
               deploy-prod: two-reviewer approval, canary, auto-rollback

--- a/tests/unit/test_issue_110_ci_policy.py
+++ b/tests/unit/test_issue_110_ci_policy.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 CI_FILE = Path(__file__).resolve().parents[2] / ".gitlab-ci.yml"
+TASKS_FILE = Path(__file__).resolve().parents[2] / "docs" / "TASKS.md"
 
 
 def _job_block(name: str, content: str) -> str:
@@ -35,6 +36,18 @@ def test_validate_pipeline_policy_runs_ci_contract_and_protection_script_tests()
     validate = _job_block("validate-pipeline-policy", content)
     assert "tests/unit/test_issue_110_ci_policy.py" in validate
     assert "tests/unit/test_check_gitlab_protected_environment.py" in validate
+
+
+def test_task_044_plan_stage_claim_matches_artifact_only_pipeline() -> None:
+    tasks = TASKS_FILE.read_text(encoding="utf-8")
+    content = CI_FILE.read_text(encoding="utf-8")
+    plan = _job_block("plan-infra", content)
+
+    assert "plan: cdk diff stored as artifacts for review" in tasks
+    assert "plan: cdk diff posted as MR comment" not in tasks
+    assert "dev-diff.txt" in plan
+    assert "staging-diff.txt" in plan
+    assert "prod-diff.txt" in plan
 
 
 def test_staging_and_prod_gates_have_manual_approvals_and_rollout_windows() -> None:


### PR DESCRIPTION
Fixes #281

Summary:
- Update docs/TASKS.md so TASK-044 says plan-stage diffs are stored as artifacts for review, matching the current .gitlab-ci.yml behavior.
- Add a CI policy regression test that fails if the TASK-044 text drifts back to MR-comment wording while plan-infra still only publishes diff artifacts.
- Sync GEMINI.md with AGENTS.md so the repository rules-sync audit passes in this worktree.

Validation:
- make preflight-session PASS
- make pre-validate-session PASS
- uv run pytest tests/unit/test_issue_110_ci_policy.py -q PASS
- make validate-local currently fails in the repo-wide CDK TypeScript step due pre-existing infra compile errors outside this issue scope
