### PR TITLE
Docs: align bootstrap verify with actual checks

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,14 +8,101 @@ This file exists so tools that look for assistant instruction files can redirect
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-GitNexus context is stored in `.gitnexus/ai-context.md`.
-Read that file for the current repository guidance, generated skills references, and safety rules.
+This project is indexed by GitNexus as **wt282** (2242 symbols, 5833 relationships, 182 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
-## Loader Contract
+## Always Do
 
-- Keep this file as a stable pointer.
-- Update `.gitnexus/ai-context.md` for generated GitNexus content.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/wt282/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/wt282/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/wt282/clusters` | All functional areas |
+| `gitnexus://repo/wt282/processes` | All execution flows |
+| `gitnexus://repo/wt282/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->

--- a/docs/bootstrap-guide.md
+++ b/docs/bootstrap-guide.md
@@ -57,7 +57,7 @@ Ordered steps with validation at each:
 5. **First CDK deploy** — deploys the 5 bootstrap-supported home-region stacks from the
    local machine (not pipeline)
 6. **Post-deploy seeding** — creates first admin, seeds SSM, registers echo-agent
-7. **Smoke test** — invokes echo-agent, checks alarms, confirms quota headroom
+7. **Smoke test** — validates deployed stacks and seeded records, then optionally invokes echo-agent
 8. **Delete bootstrap user** — removes temporary IAM user (MANDATORY)
 
 Each step writes to bootstrap-report.json (S3 bucket: platform-bootstrap-reports-{env}).

--- a/docs/operations/RUNBOOK-000-bootstrap.md
+++ b/docs/operations/RUNBOOK-000-bootstrap.md
@@ -73,11 +73,10 @@ make bootstrap-post-deploy ENV=dev
 ### Step 6: Smoke Test
 ```bash
 make bootstrap-verify ENV=dev
-# Invokes echo-agent as admin user
-# Checks all 10 FM alarms exist and are in OK state
-# Checks quota headroom (should be near 0%)
-# Prints: "Bootstrap complete. Delete bootstrap IAM user."
-# Expected output: All checks pass
+# Validates the deployed stacks and seeded records
+# Invokes echo-agent as admin user when BOOTSTRAP_ADMIN_JWT is set
+# Prints the recorded verification summary to bootstrap-report.json
+# Expected output: stack, seed, and smoke checks pass
 ```
 
 ### Step 7: Delete Bootstrap IAM User (MANDATORY)


### PR DESCRIPTION
Closes #282\n\nWhat changed:\n- Updated docs/bootstrap-guide.md and docs/operations/RUNBOOK-000-bootstrap.md so bootstrap verify is described as the stack/seed/smoke validation it actually performs today.\n- Synced GEMINI.md with AGENTS.md to satisfy the repo mirror check required by validate-local.\n\nValidation:\n- make validate-local ✅\n- make preflight-session ✅\n- make pre-validate-session ✅\n- git push origin HEAD ✅\n\nIssue: https://github.com/j3brns/tf-acore-aas/issues/282