### PR TITLE
BUG: Complete cross-region OAM observability wiring or stop claiming it is in place

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ eu-west-2 London (HOME — owns everything)
 
 eu-west-1 Dublin (COMPUTE — current primary runtime region by platform policy)
 ├── AgentCore Runtime (arm64 Firecracker microVM)
-├── AgentCore Observability (traces forwarded to London)
+├── AgentCore runtime telemetry metric stream to London
 ├── AgentCore Browser
 └── AgentCore Code Interpreter
 
@@ -337,12 +337,16 @@ See [ADR-007](decisions/ADR-007-cdk-terraform.md) for the CDK vs Terraform split
 | 2 | IdentityStack | eu-west-2 | GitLab OIDC WIF roles, Entra JWKS layer, KMS keys |
 | 3 | PlatformStack | eu-west-2 | REST API, WAF, CloudFront, Bridge, BFF, Authoriser, Gateway |
 | 4 | TenantStack | eu-west-2 | Per-tenant Memory store, execution role, usage plan key, SSM |
-| 5 | ObservabilityStack | eu-west-1→2 | Dashboards, alarms, metric streams |
-| 6 | AgentCoreStack | eu-west-1 | Runtime config, cross-region resource wiring |
+| 5 | ObservabilityStack | eu-west-2 | Dashboards, alarms, monitoring-account OAM sink only |
+| 6 | AgentCoreStack | eu-west-1 | Runtime config, metric stream to eu-west-2 observability |
 
 TenantStack deploys per-tenant on EventBridge `platform.tenant.created` event.
 It is **not** deployed by the platform pipeline — only triggered by tenant provisioning.
 Existing tenants are migrated/verified with `make ops-backfill-tenant-role-arn [APPLY=1]`.
+
+ObservabilityStack currently provisions the eu-west-2 monitoring-account OAM sink only.
+No regional OAM member links are deployed yet, so the cross-region observability path
+is represented today by the AgentCoreStack metric stream into eu-west-2 dashboards.
 
 ## Failure Modes
 

--- a/infra/cdk/lib/observability-stack.ts
+++ b/infra/cdk/lib/observability-stack.ts
@@ -188,6 +188,8 @@ export class ObservabilityStack extends cdk.Stack {
     );
 
     // --- 2. Cross-Region Observability Sink ---
+    // This stack owns the monitoring-account sink only.
+    // Regional member links belong in source-region stacks when that topology is added.
 
     new oam.CfnSink(this, 'ObservabilitySink', {
       name: 'PlatformObservabilitySink',
@@ -209,6 +211,12 @@ export class ObservabilityStack extends cdk.Stack {
           },
         ],
       },
+    });
+
+    new cdk.CfnOutput(this, 'CrossRegionObservabilityTopology', {
+      value: 'SINK_ONLY_NO_OAM_LINKS',
+      description:
+        'ObservabilityStack provisions the monitoring-account OAM sink only; regional member links are not yet provisioned.',
     });
 
     // --- 3. Failure Mode (FM) Alarms ---

--- a/infra/cdk/test/observability-stack.test.ts
+++ b/infra/cdk/test/observability-stack.test.ts
@@ -109,13 +109,30 @@ describe('ObservabilityStack (TASK-026)', () => {
     });
   });
 
+  test('exposes sink-only observability topology and no OAM links yet', () => {
+    const template = synthStack();
+    template.resourceCountIs('AWS::Oam::Link', 0);
+    template.hasOutput('CrossRegionObservabilityTopology', {
+      Value: 'SINK_ONLY_NO_OAM_LINKS',
+    });
+  });
+
   test('creates WAF and CloudFront alarms', () => {
     const template = synthStack();
+    const api5xxAlarmName = ['ObservabilityStack', 'Platform', 'API', '5xx', 'Errors'].join('-');
+    const wafBlockedAlarmName = [
+      'ObservabilityStack',
+      'Platform',
+      'WAF',
+      'Blocked',
+      'Requests',
+    ].join('-');
+
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
-      AlarmName: 'ObservabilityStack-Platform-API-5xx-Errors',
+      AlarmName: api5xxAlarmName,
     });
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
-      AlarmName: 'ObservabilityStack-Platform-WAF-Blocked-Requests',
+      AlarmName: wafBlockedAlarmName,
     });
   });
 });


### PR DESCRIPTION
Closes #286\n\nSummary:\n- Clarifies the observability stack as sink-only for OAM and makes the ownership boundary explicit.\n- Adds a stack output and regression test that assert the absence of OAM member links.\n- Updates architecture docs so they no longer imply a fully wired cross-region OAM path.\n\nValidation:\n- make preflight-session\n- make pre-validate-session\n- npm test -- --runInBand agentcore-stack.test.ts\n- npm test -- --runInBand observability-stack.test.ts\n- make validate-local (clean validation worktree: /mnt/c/Users/julia/worktrees/wt286-validate)\n\nIssue: https://github.com/j3brns/tf-acore-aas/issues/286