### PR TITLE
#284: Align FM alarm catalogue with ObservabilityStack

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,18 +346,18 @@ Existing tenants are migrated/verified with `make ops-backfill-tenant-role-arn [
 
 ## Failure Modes
 
-| ID | Failure | Detection | Response |
-|----|---------|-----------|----------|
-| FM-1 | Runtime region unavailable | `ServiceUnavailableException` | [RUNBOOK-001](operations/RUNBOOK-001-runtime-region-failover.md) |
-| FM-2 | Authoriser cold start spike | P99 > 500ms | Provisioned concurrency |
-| FM-3 | Secrets Manager throttling | Cache miss rate | By design (Lambda /tmp cache with TTL) |
-| FM-4 | DynamoDB hot partition | Throttle events on invocations table | Jitter suffix on SK |
-| FM-5 | Bridge Lambda timeout | 504 to client | 16-min Lambda timeout |
-| FM-6 | Interceptor retry storm | DLQ alarm | Idempotency key |
-| FM-7 | AgentCore Memory unavailable | Degraded mode metric | Agent runs without long-term memory |
-| FM-8 | Usage plan quota exhausted | 429 from API Gateway | By design (native enforcement) |
-| FM-9 | DLQ message arrival | DLQ CloudWatch alarm | [RUNBOOK-005](operations/RUNBOOK-005-dlq-management.md) |
-| FM-10 | Billing Lambda failure | DLQ alarm | [RUNBOOK-006](operations/RUNBOOK-006-budget-and-suspension.md) |
+| ID | Failure | Detection | Alarm | Response |
+|----|---------|-----------|-------|----------|
+| FM-1 | Runtime region unavailable | `ServiceUnavailableException` | `FM-1-RuntimeRegionUnavailable` | [RUNBOOK-001](operations/RUNBOOK-001-runtime-region-failover.md) |
+| FM-2 | Authoriser cold start spike | P99 > 500ms | `FM-2-AuthoriserColdStartSpike` | Provisioned concurrency |
+| FM-3 | Secrets Manager throttling | Cache miss rate | `FM-3-SecretsManagerThrottling` | By design (Lambda /tmp cache with TTL) |
+| FM-4 | DynamoDB hot partition | Throttle events on invocations table | `FM-4-DynamoDbHotPartition` | Jitter suffix on SK |
+| FM-5 | Bridge Lambda timeout | 504 to client | `FM-5-BridgeTimeout` | 16-min Lambda timeout |
+| FM-6 | Interceptor retry storm | Interceptor error rate | `FM-6-InterceptorRetryStorm` | Idempotency key |
+| FM-7 | AgentCore Memory unavailable | Degraded mode metric | `FM-7-AgentCoreMemoryDegraded` | Agent runs without long-term memory |
+| FM-8 | Usage plan quota exhausted | 429 from API Gateway | `FM-8-UsagePlanQuotaExhausted` | By design (native enforcement) |
+| FM-9 | DLQ message arrival | DLQ CloudWatch alarm | `FM-9-DLQ-Arrival-{name}` | [RUNBOOK-005](operations/RUNBOOK-005-dlq-management.md) |
+| FM-10 | Billing Lambda failure | Billing Lambda errors | `FM-10-BillingLambdaFailure` | [RUNBOOK-006](operations/RUNBOOK-006-budget-and-suspension.md) |
 
 ## Security Model
 

--- a/infra/cdk/bin/app.ts
+++ b/infra/cdk/bin/app.ts
@@ -96,6 +96,7 @@ new ObservabilityStack(app, `platform-observability-${env}`, {
   sessionsTable: platformStack.sessionsTable,
   toolsTable: platformStack.toolsTable,
   opsLocksTable: platformStack.opsLocksTable,
+  billingFn: platformStack.billingFn,
   dlqs: platformStack.dlqs,
 });
 

--- a/infra/cdk/lib/observability-stack.ts
+++ b/infra/cdk/lib/observability-stack.ts
@@ -25,6 +25,7 @@ export interface ObservabilityStackProps extends cdk.StackProps {
   readonly sessionsTable: dynamodb.ITable;
   readonly toolsTable: dynamodb.ITable;
   readonly opsLocksTable: dynamodb.ITable;
+  readonly billingFn: lambda.IFunction;
   readonly dlqs: Record<string, sqs.IQueue>;
 }
 
@@ -282,6 +283,47 @@ export class ObservabilityStack extends cdk.Stack {
       });
     }
 
+    // FM-3: Secrets Manager throttling (Cache miss rate)
+    // Detected via custom metric emitted by Lambda handlers when /tmp cache misses
+    new cloudwatch.Alarm(this, 'Fm3SecretsManagerThrottlingAlarm', {
+      alarmName: `${alarmNamePrefix}-FM-3-SecretsManagerThrottling`,
+      alarmDescription: 'Secrets Manager cache miss rate is high (throttling risk)',
+      metric: new cloudwatch.Metric({
+        namespace: 'Platform',
+        metricName: 'SecretsManagerCacheMissCount',
+        period: cdk.Duration.minutes(5),
+        statistic: 'Sum',
+      }),
+      threshold: 50,
+      evaluationPeriods: 2,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    // FM-6: Interceptor retry storm (high error rate on interceptor Lambdas)
+    new cloudwatch.Alarm(this, 'Fm6InterceptorRetryStormAlarm', {
+      alarmName: `${alarmNamePrefix}-FM-6-InterceptorRetryStorm`,
+      alarmDescription: 'Gateway interceptor error rate indicates retry storm',
+      metric: new cloudwatch.MathExpression({
+        expression: 'reqErrors + resErrors',
+        usingMetrics: {
+          reqErrors: props.requestInterceptorFn.metricErrors({
+            period: cdk.Duration.minutes(1),
+            statistic: 'Sum',
+          }),
+          resErrors: props.responseInterceptorFn.metricErrors({
+            period: cdk.Duration.minutes(1),
+            statistic: 'Sum',
+          }),
+        },
+        period: cdk.Duration.minutes(1),
+      }),
+      threshold: 20,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
     // FM-7: AgentCore Memory unavailable (Degraded mode metric)
     // Note: AgentCore metrics are custom metrics from the SDK
     new cloudwatch.Alarm(this, 'Fm7AgentCoreMemoryDegradedAlarm', {
@@ -310,6 +352,20 @@ export class ObservabilityStack extends cdk.Stack {
       threshold: 100, // Threshold for total 429s across all tenants
       evaluationPeriods: 1,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    });
+
+    // FM-10: Billing Lambda failure (errors or timeout)
+    new cloudwatch.Alarm(this, 'Fm10BillingLambdaFailureAlarm', {
+      alarmName: `${alarmNamePrefix}-FM-10-BillingLambdaFailure`,
+      alarmDescription: 'Billing Lambda is failing (errors detected)',
+      metric: props.billingFn.metricErrors({
+        period: cdk.Duration.minutes(5),
+        statistic: 'Sum',
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
 
     // API 5xx Errors Alarm

--- a/infra/cdk/test/observability-stack.test.ts
+++ b/infra/cdk/test/observability-stack.test.ts
@@ -62,6 +62,7 @@ describe('ObservabilityStack (TASK-026)', () => {
       sessionsTable: platformStack.sessionsTable,
       toolsTable: platformStack.toolsTable,
       opsLocksTable: platformStack.opsLocksTable,
+      billingFn: platformStack.billingFn,
       dlqs: platformStack.dlqs,
     });
 
@@ -93,11 +94,62 @@ describe('ObservabilityStack (TASK-026)', () => {
     });
   });
 
+  test('creates FM-3 Secrets Manager Throttling alarm', () => {
+    const template = synthStack();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'ObservabilityStack-FM-3-SecretsManagerThrottling',
+      MetricName: 'SecretsManagerCacheMissCount',
+    });
+  });
+
   test('creates FM-4 DynamoDB Hot Partition alarm', () => {
     const template = synthStack();
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmName: 'ObservabilityStack-FM-4-DynamoDbHotPartition',
       MetricName: 'ThrottledRequests',
+    });
+  });
+
+  test('creates FM-5 Bridge Timeout alarm', () => {
+    const template = synthStack();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'ObservabilityStack-FM-5-BridgeTimeout',
+    });
+  });
+
+  test('creates FM-6 Interceptor Retry Storm alarm', () => {
+    const template = synthStack();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'ObservabilityStack-FM-6-InterceptorRetryStorm',
+    });
+  });
+
+  test('creates FM-7 AgentCore Memory Degraded alarm', () => {
+    const template = synthStack();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'ObservabilityStack-FM-7-AgentCoreMemoryDegraded',
+      MetricName: 'DegradedMode',
+    });
+  });
+
+  test('creates FM-8 Usage Plan Quota Exhausted alarm', () => {
+    const template = synthStack();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'ObservabilityStack-FM-8-UsagePlanQuotaExhausted',
+    });
+  });
+
+  test('creates FM-9 DLQ Arrival alarms for each DLQ', () => {
+    const template = synthStack();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: Match.stringLikeRegexp('ObservabilityStack-FM-9-DLQ-Arrival-'),
+    });
+  });
+
+  test('creates FM-10 Billing Lambda Failure alarm', () => {
+    const template = synthStack();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'ObservabilityStack-FM-10-BillingLambdaFailure',
     });
   });
 
@@ -109,7 +161,7 @@ describe('ObservabilityStack (TASK-026)', () => {
     });
   });
 
-  test('creates WAF and CloudFront alarms', () => {
+  test('creates WAF and API 5xx alarms', () => {
     const template = synthStack();
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmName: 'ObservabilityStack-Platform-API-5xx-Errors',
@@ -117,5 +169,26 @@ describe('ObservabilityStack (TASK-026)', () => {
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmName: 'ObservabilityStack-Platform-WAF-Blocked-Requests',
     });
+  });
+
+  test('every documented FM (1-10) has a corresponding alarm', () => {
+    const template = synthStack();
+    const documentedFMs = [
+      'FM-1-RuntimeRegionUnavailable',
+      'FM-2-AuthoriserColdStartSpike',
+      'FM-3-SecretsManagerThrottling',
+      'FM-4-DynamoDbHotPartition',
+      'FM-5-BridgeTimeout',
+      'FM-6-InterceptorRetryStorm',
+      'FM-7-AgentCoreMemoryDegraded',
+      'FM-8-UsagePlanQuotaExhausted',
+      'FM-9-DLQ-Arrival-',
+      'FM-10-BillingLambdaFailure',
+    ];
+    for (const fm of documentedFMs) {
+      template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+        AlarmName: Match.stringLikeRegexp(`ObservabilityStack-${fm}`),
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add missing FM-3 (Secrets Manager throttling), FM-6 (interceptor retry storm), and FM-10 (billing Lambda failure) alarms to `ObservabilityStack`
- Update `docs/ARCHITECTURE.md` failure mode table with explicit alarm name column mapping each FM to its concrete CloudWatch alarm
- Add regression test asserting all documented FM-1 through FM-10 have corresponding provisioned alarms

## Test plan
- [x] All 14 ObservabilityStack tests pass (including individual FM alarm tests and full-catalogue regression test)
- [x] `make validate-local` passes
- [x] `make preflight-session` and `make pre-validate-session` pass
- [x] CDK synth succeeds

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)