### PR TITLE
feat: implement EventBridge-driven TenantStack provisioning (#291)

### DIFF
--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -30,6 +30,7 @@ import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
+import * as s3assets from 'aws-cdk-lib/aws-s3-assets';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import { resolveEntraConfiguration } from './entra-config';
@@ -454,6 +455,98 @@ export class PlatformStack extends cdk.Stack {
     new events.Rule(this, 'DailyBillingRule', {
       schedule: events.Schedule.cron({ hour: '0', minute: '0' }),
       targets: [new targets.LambdaFunction(this.billingFn)],
+    });
+
+    // --- Tenant Provisioner (Issue #291) ---
+
+    // The TenantStack template is synthesized during 'cdk synth' and needs to be
+    // available to the provisioner Lambda via S3.
+    // NOTE: This assumes 'cdk synth' has run and populated cdk.out.
+    const tenantStackTemplateAsset = new s3assets.Asset(this, 'TenantStackTemplateAsset', {
+      path: path.join(__dirname, `../cdk.out/platform-tenant-stub-${env}.template.json`),
+    });
+
+    const tenantProvisionerFn = this.createPythonLambda({
+      assetPath: path.join(__dirname, '../../../src/tenant_provisioner'),
+      handler: 'handler.lambda_handler',
+      functionNameSuffix: 'tenant-provisioner',
+      timeout: cdk.Duration.minutes(11), // Must be > stack deployment poll (10m)
+      memorySize: 512,
+      environment: {
+        POWERTOOLS_SERVICE_NAME: 'tenant-provisioner',
+        PLATFORM_ENV: env,
+        TENANTS_TABLE_NAME: this.tenantsTable.tableName,
+        TENANT_STACK_TEMPLATE_URL: tenantStackTemplateAsset.bucket.s3UrlForObject(tenantStackTemplateAsset.s3ObjectKey),
+      },
+    });
+
+    this.tenantsTable.grantReadWriteData(tenantProvisionerFn);
+    tenantStackTemplateAsset.grantRead(tenantProvisionerFn);
+
+    tenantProvisionerFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'TenantStackCloudFormationAccess',
+        actions: [
+          'cloudformation:CreateStack',
+          'cloudformation:UpdateStack',
+          'cloudformation:DescribeStacks',
+          'cloudformation:GetTemplate',
+        ],
+        resources: [`arn:aws:cloudformation:${this.region}:${this.account}:stack/platform-tenant-*/*`],
+      }),
+    );
+
+    tenantProvisionerFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'TenantStackIamAccess',
+        actions: [
+          'iam:CreateRole',
+          'iam:DeleteRole',
+          'iam:PutRolePolicy',
+          'iam:DeleteRolePolicy',
+          'iam:GetRole',
+          'iam:PassRole',
+          'iam:TagRole',
+        ],
+        resources: [`arn:aws:iam::${this.account}:role/platform-tenant-*`],
+      }),
+    );
+
+    tenantProvisionerFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'TenantStackSsmAccess',
+        actions: [
+          'ssm:PutParameter',
+          'ssm:GetParameter',
+          'ssm:DeleteParameter',
+          'ssm:AddTagsToResource',
+        ],
+        resources: [`arn:aws:ssm:${this.region}:${this.account}:parameter/platform/tenants/*`],
+      }),
+    );
+
+    tenantProvisionerFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'TenantStackBedrockAccess',
+        actions: [
+          'bedrock-agentcore:CreateMemory',
+          'bedrock-agentcore:UpdateMemory',
+          'bedrock-agentcore:DeleteMemory',
+          'bedrock-agentcore:GetMemory',
+          'bedrock-agentcore:TagResource',
+        ],
+        resources: ['*'], // Resource-level permissions not fully supported for all AgentCore resources yet
+      }),
+    );
+
+    new events.Rule(this, 'TenantCreatedRule', {
+      ruleName: `platform-tenant-created-${env}`,
+      description: 'Trigger tenant provisioning when a new tenant is created',
+      eventPattern: {
+        source: ['platform.tenant_api'],
+        detailType: ['tenant.created'],
+      },
+      targets: [new targets.LambdaFunction(tenantProvisionerFn)],
     });
 
     this.toolsTable.grantReadData(this.requestInterceptorFn);

--- a/infra/cdk/lib/tenant-stack.ts
+++ b/infra/cdk/lib/tenant-stack.ts
@@ -52,14 +52,29 @@ export class TenantStack extends cdk.Stack {
       throw new Error('env context is required');
     }
 
-    const tenantId = this.node.tryGetContext('tenantId') || 'stub';
-    const tier = this.node.tryGetContext('tier') || 'basic';
-    const accountId = this.node.tryGetContext('accountId') || cdk.Aws.ACCOUNT_ID;
+    const tenantIdParam = new cdk.CfnParameter(this, 'tenantId', {
+      type: 'String',
+      description: 'The unique identifier for the tenant',
+      noEcho: false,
+    });
+    const tierParam = new cdk.CfnParameter(this, 'tier', {
+      type: 'String',
+      description: 'The service tier for the tenant (basic, standard, premium)',
+      default: 'basic',
+    });
+    const accountIdParam = new cdk.CfnParameter(this, 'accountId', {
+      type: 'String',
+      description: 'The AWS account ID where tenant-scoped resources are authorized',
+      default: cdk.Aws.ACCOUNT_ID,
+    });
+
+    const tenantId = tenantIdParam.valueAsString;
+    const tier = tierParam.valueAsString;
+    const accountId = accountIdParam.valueAsString;
+
     const authorizedRuntimeRegions = resolveAuthorizedRuntimeRegions(
       props?.authorizedRuntimeRegions,
     );
-
-    const isStub = tenantId === 'stub';
 
     // 1. Look up shared resources from SSM
     const tenantDataKeyArn = ssm.StringParameter.valueForStringParameter(
@@ -70,10 +85,10 @@ export class TenantStack extends cdk.Stack {
       this,
       `/platform/core/${env}/rest-api-id`,
     );
-    const usagePlanId = ssm.StringParameter.valueForStringParameter(
-      this,
-      `/platform/core/${env}/usage-plan-${tier}-id`,
-    );
+    const usagePlanId = ssm.StringParameter.fromStringParameterAttributes(this, 'UsagePlanIdLookup', {
+      parameterName: `/platform/core/${env}/usage-plan-${tier}-id`,
+      simpleName: false,
+    }).stringValue;
     const bridgeLambdaRoleArn = ssm.StringParameter.valueForStringParameter(
       this,
       `/platform/core/${env}/bridge-lambda-role-arn`,
@@ -185,21 +200,24 @@ export class TenantStack extends cdk.Stack {
     usagePlan.addApiKey(apiKey);
 
     // 5. SSM Parameters for tenant configuration (used by Bridge/Authoriser)
-    new ssm.StringParameter(this, 'TenantExecutionRoleArnParam', {
-      parameterName: `/platform/tenants/${tenantId}/execution-role-arn`,
-      stringValue: executionRole.roleArn,
+    new ssm.CfnParameter(this, 'TenantExecutionRoleArnParam', {
+      name: `/platform/tenants/${tenantId}/execution-role-arn`,
+      type: 'String',
+      value: executionRole.roleArn,
       description: `Execution role ARN for tenant ${tenantId}`,
     });
 
-    new ssm.StringParameter(this, 'TenantMemoryStoreArnParam', {
-      parameterName: `/platform/tenants/${tenantId}/memory-store-arn`,
-      stringValue: memoryStore.getAtt('Arn').toString(),
+    new ssm.CfnParameter(this, 'TenantMemoryStoreArnParam', {
+      name: `/platform/tenants/${tenantId}/memory-store-arn`,
+      type: 'String',
+      value: memoryStore.getAtt('Arn').toString(),
       description: `Memory store ARN for tenant ${tenantId}`,
     });
 
-    new ssm.StringParameter(this, 'TenantApiKeyIdParam', {
-      parameterName: `/platform/tenants/${tenantId}/api-key-id`,
-      stringValue: apiKey.keyId,
+    new ssm.CfnParameter(this, 'TenantApiKeyIdParam', {
+      name: `/platform/tenants/${tenantId}/api-key-id`,
+      type: 'String',
+      value: apiKey.keyId,
       description: `API key ID for tenant ${tenantId}`,
     });
 

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -731,7 +731,13 @@ def _handle_create(
     _put_event(
         deps,
         detail_type="tenant.created",
-        detail={"tenantId": tenant_id, "appId": app_id, "actorSub": caller.sub},
+        detail={
+            "tenantId": tenant_id,
+            "appId": app_id,
+            "tier": tier,
+            "accountId": attributes["accountId"],
+            "actorSub": caller.sub,
+        },
     )
     return _response(201, {"tenant": _serialize_tenant(item)})
 

--- a/src/tenant_provisioner/handler.py
+++ b/src/tenant_provisioner/handler.py
@@ -1,0 +1,153 @@
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+# Use powertools if available, else standard logging
+try:
+    from aws_lambda_powertools import Logger
+
+    logger = Logger()
+except ImportError:
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(level=logging.INFO)
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """
+    Tenant Provisioner — Triggers CloudFormation deployment for TenantStack.
+
+    Trigger: EventBridge platform.tenant.created
+    Source: platform.tenant_api
+    """
+    detail = event.get("detail", {})
+    tenant_id = detail.get("tenantId")
+    tier = detail.get("tier", "basic")
+    account_id = detail.get("accountId")
+
+    if not tenant_id:
+        logger.error("Missing tenantId in event detail")
+        return {"status": "FAILED", "reason": "Missing tenantId"}
+
+    env = os.environ["PLATFORM_ENV"]
+    template_url = os.environ["TENANT_STACK_TEMPLATE_URL"]
+    table_name = os.environ["TENANTS_TABLE_NAME"]
+
+    cfn = boto3.client("cloudformation")
+    stack_name = f"platform-tenant-{tenant_id}-{env}"
+
+    # 1. Resolve parameters
+    account_id = account_id or context.invoked_function_arn.split(":")[4]
+    params = [
+        {"ParameterKey": "tenantId", "ParameterValue": tenant_id},
+        {"ParameterKey": "tier", "ParameterValue": tier},
+        {"ParameterKey": "accountId", "ParameterValue": account_id},
+    ]
+
+    # 2. Start deployment
+    logger.info(
+        f"Deploying TenantStack for {tenant_id} (tier: {tier})",
+        extra={"tenant_id": tenant_id, "stack_name": stack_name, "operation": "upsert"},
+    )
+
+    try:
+        cfn.describe_stacks(StackName=stack_name)
+        operation = "UPDATE"
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code")
+        if error_code == "ValidationError":
+            operation = "CREATE"
+        else:
+            raise
+
+    try:
+        if operation == "CREATE":
+            cfn.create_stack(
+                StackName=stack_name,
+                TemplateURL=template_url,
+                Parameters=params,  # type: ignore
+                Capabilities=["CAPABILITY_NAMED_IAM"],
+                OnFailure="ROLLBACK",
+                Tags=[
+                    {"Key": "tenantid", "Value": tenant_id},
+                    {"Key": "platform:env", "Value": env},
+                ],
+            )
+        else:
+            cfn.update_stack(
+                StackName=stack_name,
+                TemplateURL=template_url,
+                Parameters=params,  # type: ignore
+                Capabilities=["CAPABILITY_NAMED_IAM"],
+            )
+    except ClientError as e:
+        if "No updates are to be performed" in str(e):
+            logger.info(f"No changes for stack {stack_name}")
+        else:
+            logger.error(f"CloudFormation operation failed: {e}")
+            raise
+
+    # 3. Wait for completion (poll)
+    # TenantStack usually takes 1-3 minutes.
+    max_wait_seconds = 600  # 10 minutes
+    start_time = time.time()
+
+    logger.info(f"Waiting for stack {stack_name} to complete...")
+
+    outputs: dict[str, str] = {}
+    while time.time() - start_time < max_wait_seconds:
+        try:
+            resp = cfn.describe_stacks(StackName=stack_name)
+            stack = resp["Stacks"][0]
+            status = stack["StackStatus"]
+
+            if status in ("CREATE_COMPLETE", "UPDATE_COMPLETE"):
+                for output in stack.get("Outputs", []):
+                    key = output.get("OutputKey")
+                    val = output.get("OutputValue")
+                    if key and val:
+                        outputs[key] = val
+                break
+            elif status in (
+                "CREATE_FAILED",
+                "ROLLBACK_COMPLETE",
+                "UPDATE_ROLLBACK_COMPLETE",
+                "DELETE_COMPLETE",
+            ):
+                raise RuntimeError(f"Stack deployment failed with status: {status}")
+
+            time.sleep(10)
+        except ClientError as e:
+            logger.error(f"Error polling stack: {e}")
+            raise
+
+    if not outputs:
+        raise RuntimeError(f"Stack {stack_name} did not complete within timeout or has no outputs")
+
+    # 4. Write back to DynamoDB
+    logger.info(f"Writing resource refs back to {table_name} for {tenant_id}")
+    ddb = boto3.resource("dynamodb")
+    table = ddb.Table(table_name)
+
+    # Use update_item to be safe
+    update_expr = (
+        "SET executionRoleArn = :role, execution_role_arn = :role, "
+        "memoryStoreArn = :mem, memory_store_arn = :mem, updatedAt = :now"
+    )
+    expr_values = {
+        ":role": outputs.get("ExecutionRoleArn"),
+        ":mem": outputs.get("MemoryStoreArn"),
+        ":now": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    table.update_item(
+        Key={"PK": f"TENANT#{tenant_id}", "SK": "METADATA"},
+        UpdateExpression=update_expr,
+        ExpressionAttributeValues=expr_values,
+    )
+
+    logger.info(f"Provisioning complete for {tenant_id}")
+    return {"status": "SUCCESS", "tenantId": tenant_id, "stackName": stack_name, "outputs": outputs}

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -534,6 +534,9 @@ def test_create_tenant_writes_record_provisions_memory_secret_and_emits_event(
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "tenant.created"
     assert detail["tenantId"] == "t-001"
+    assert detail["appId"] == "app-001"
+    assert detail["tier"] == "standard"
+    assert detail["accountId"] == "123456789012"
 
 
 def test_create_tenant_normalizes_tenant_id_to_lowercase(fake_state: dict[str, Any]) -> None:

--- a/tests/unit/test_tenant_provisioner_handler.py
+++ b/tests/unit/test_tenant_provisioner_handler.py
@@ -1,0 +1,128 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+from src.tenant_provisioner.handler import lambda_handler
+
+
+class TestTenantProvisioner(unittest.TestCase):
+    def setUp(self):
+        self.env_patcher = patch.dict(
+            os.environ,
+            {
+                "PLATFORM_ENV": "dev",
+                "TENANT_STACK_TEMPLATE_URL": "s3://bucket/template.json",
+                "TENANTS_TABLE_NAME": "platform-tenants",
+                "AWS_REGION": "eu-west-2",
+            },
+        )
+        self.env_patcher.start()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+
+    @patch("boto3.client")
+    @patch("boto3.resource")
+    @patch("time.sleep", return_value=None)
+    def test_lambda_handler_create_success(self, mock_sleep, mock_resource, mock_client):
+        # Mock CloudFormation client
+        mock_cfn = MagicMock()
+        mock_client.return_value = mock_cfn
+
+        # describe_stacks fails first (stack doesn't exist)
+        mock_cfn.describe_stacks.side_effect = [
+            ClientError(
+                {"Error": {"Code": "ValidationError", "Message": "Stack does not exist"}},
+                "DescribeStacks",
+            ),
+            {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},  # poll 1
+            {
+                "Stacks": [
+                    {
+                        "StackStatus": "CREATE_COMPLETE",
+                        "Outputs": [
+                            {"OutputKey": "ExecutionRoleArn", "OutputValue": "arn:role"},
+                            {"OutputKey": "MemoryStoreArn", "OutputValue": "arn:mem"},
+                        ],
+                    }
+                ]
+            },  # poll 2
+        ]
+
+        # Mock DynamoDB resource
+        mock_ddb = MagicMock()
+        mock_resource.return_value = mock_ddb
+        mock_table = MagicMock()
+        mock_ddb.Table.return_value = mock_table
+
+        event = {
+            "detail": {"tenantId": "t-test-001", "tier": "premium", "accountId": "123456789012"}
+        }
+        context = MagicMock()
+        context.invoked_function_arn = "arn:aws:lambda:eu-west-2:123456789012:function:prov"
+
+        result = lambda_handler(event, context)
+
+        self.assertEqual(result["status"], "SUCCESS")
+        self.assertEqual(result["tenantId"], "t-test-001")
+
+        # Verify CFN calls
+        mock_cfn.create_stack.assert_called_once()
+        args, kwargs = mock_cfn.create_stack.call_args
+        self.assertEqual(kwargs["StackName"], "platform-tenant-t-test-001-dev")
+        self.assertIn(
+            {"ParameterKey": "tenantId", "ParameterValue": "t-test-001"}, kwargs["Parameters"]
+        )
+        self.assertIn({"ParameterKey": "tier", "ParameterValue": "premium"}, kwargs["Parameters"])
+
+        # Verify DynamoDB update
+        mock_table.update_item.assert_called_once()
+        args, kwargs = mock_table.update_item.call_args
+        self.assertEqual(kwargs["Key"], {"PK": "TENANT#t-test-001", "SK": "METADATA"})
+        self.assertIn("executionRoleArn = :role", kwargs["UpdateExpression"])
+
+    @patch("boto3.client")
+    @patch("boto3.resource")
+    @patch("time.sleep", return_value=None)
+    def test_lambda_handler_update_success(self, mock_sleep, mock_resource, mock_client):
+        # Mock CloudFormation client
+        mock_cfn = MagicMock()
+        mock_client.return_value = mock_cfn
+
+        # describe_stacks succeeds first (stack exists)
+        mock_cfn.describe_stacks.side_effect = [
+            {"Stacks": [{"StackStatus": "UPDATE_COMPLETE"}]},  # describe (check exist)
+            {"Stacks": [{"StackStatus": "UPDATE_IN_PROGRESS"}]},  # poll 1
+            {
+                "Stacks": [
+                    {
+                        "StackStatus": "UPDATE_COMPLETE",
+                        "Outputs": [
+                            {"OutputKey": "ExecutionRoleArn", "OutputValue": "arn:role"},
+                            {"OutputKey": "MemoryStoreArn", "OutputValue": "arn:mem"},
+                        ],
+                    }
+                ]
+            },  # poll 2
+        ]
+
+        # Mock DynamoDB resource
+        mock_ddb = MagicMock()
+        mock_resource.return_value = mock_ddb
+        mock_table = MagicMock()
+        mock_ddb.Table.return_value = mock_table
+
+        event = {"detail": {"tenantId": "t-test-001", "tier": "premium"}}
+        context = MagicMock()
+        context.invoked_function_arn = "arn:aws:lambda:eu-west-2:123456789012:function:prov"
+
+        result = lambda_handler(event, context)
+
+        self.assertEqual(result["status"], "SUCCESS")
+        mock_cfn.update_stack.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR implements the missing EventBridge-driven TenantStack provisioning as described in issue #291.

- **tenant-api**: Include 'tier' and 'accountId' in the 'tenant.created' event detail.
- **TenantStack**: Refactored to use CloudFormation parameters for per-tenant variables (tenantId, tier, accountId), allowing a single template to be used for all tenants.
- **TenantProvisioner**: New Lambda function that listens for 'tenant.created' events, deploys the TenantStack via CloudFormation, and updates the tenant record in DynamoDB with the resulting ARNs.
- **PlatformStack**: Wired the TenantProvisioner Lambda and EventBridge rule. The TenantStack template is bundled as an S3 asset.

Verification:
- Added unit tests for TenantProvisioner handler.
- Updated existing tenant-api unit tests.
- Verified CDK synthesis.
- Ran 'make pre-validate-session'.