### PR TITLE
#354: Make wt-batch launch detached agent runs

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,101 +8,14 @@ This file exists so tools that look for assistant instruction files can redirect
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt282** (2242 symbols, 5833 relationships, 182 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+GitNexus context is stored in `.gitnexus/ai-context.md`.
+Read that file for the current repository guidance, generated skills references, and safety rules.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
-## Always Do
+## Loader Contract
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
-- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
-
-## When Debugging
-
-1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
-2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt282/process/{processName}` — trace the full execution flow step by step
-4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
-
-## When Refactoring
-
-- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
-- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
-- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
-
-## Never Do
-
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
-- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
-
-## Tools Quick Reference
-
-| Tool | When to use | Command |
-|------|-------------|---------|
-| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
-| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
-| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
-| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
-| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
-| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
-
-## Impact Risk Levels
-
-| Depth | Meaning | Action |
-|-------|---------|--------|
-| d=1 | WILL BREAK — direct callers/importers | MUST update these |
-| d=2 | LIKELY AFFECTED — indirect deps | Should test |
-| d=3 | MAY NEED TESTING — transitive | Test if critical path |
-
-## Resources
-
-| Resource | Use for |
-|----------|---------|
-| `gitnexus://repo/wt282/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt282/clusters` | All functional areas |
-| `gitnexus://repo/wt282/processes` | All execution flows |
-| `gitnexus://repo/wt282/process/{name}` | Step-by-step execution trace |
-
-## Self-Check Before Finishing
-
-Before completing any code modification task, verify:
-1. `gitnexus_impact` was run for all modified symbols
-2. No HIGH/CRITICAL risk warnings were ignored
-3. `gitnexus_detect_changes()` confirms changes match expected scope
-4. All d=1 (WILL BREAK) dependents were updated
-
-## Keeping the Index Fresh
-
-After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
-
-```bash
-npx gitnexus analyze
-```
-
-If the index previously included embeddings, preserve them by adding `--embeddings`:
-
-```bash
-npx gitnexus analyze --embeddings
-```
-
-To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
-
-> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
-
-## CLI
-
-| Task | Read this skill file |
-|------|---------------------|
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
-| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
-| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
-| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
-| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+- Keep this file as a stable pointer.
+- Update `.gitnexus/ai-context.md` for generated GitNexus content.
 
 <!-- gitnexus:end -->

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ help:
 		echo "  Worktrees / issues"; \
 		ex "worktree" "open the interactive issue queue"; \
 		ex "wt-go" "launch the next runnable issue in zellij"; \
-		ex "wt-batch [COUNT=${c_def}3${c_rst}] [AGENTS=${c_def}gemini,codex${c_rst}] [AGENT_MODE=${c_def}yolo${c_rst}]" "open several runnable issue worktrees"; \
+		ex "wt-batch [COUNT=${c_def}3${c_rst}] [AGENTS=${c_def}gemini,codex${c_rst}] [AGENT_MODE=${c_def}yolo${c_rst}]" "start several detached agent runs with per-worktree logs"; \
 		ex "worktree-next-issue" "create a worktree for the next queued issue"; \
 		ex "worktree-create-issue" "create a worktree for a specific issue"; \
 		ex "worktree-resume-issue [OPEN_SHELL=off] [CMD='make test-unit']" "resume a linked issue worktree"; \
@@ -843,7 +843,7 @@ worktree-next-issue:
 		$(if $(TMUX),--tmux,) \
 		$(if $(PRINT_ONLY),--print-only,)
 
-## wt-batch: Create multiple runnable issue worktrees and open them in one tmux session grid
+## wt-batch: Create multiple runnable issue worktrees and start detached agent runs
 ## Usage: make wt-batch [COUNT=3] [AGENTS=gemini,codex] [AGENT_MODE=yolo]
 wt-batch:
 	uv run python scripts/worktree_issues.py wt-batch \

--- a/scripts/worktree_issues.py
+++ b/scripts/worktree_issues.py
@@ -105,6 +105,12 @@ class AuditFinding:
     message: str
 
 
+@dataclass(slots=True)
+class SessionPair:
+    label: str
+    session_name: str
+
+
 def run(
     cmd: list[str],
     *,
@@ -1332,6 +1338,12 @@ def tmux_session_name_for_worktree(path: Path) -> str:
     return path.name
 
 
+def worktree_session_pair(label: str) -> SessionPair:
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S-%f")
+    session_name = f"{label}-{stamp}-{os.getpid()}"
+    return SessionPair(label=label, session_name=session_name)
+
+
 def launch_tmux_session(
     *,
     path: Path,
@@ -1384,11 +1396,13 @@ def launch_tmux_session(
     )
     subprocess.run(["tmux", "select-pane", "-t", f"{name}:0.0"], check=True)
 
-    print(f"tmux session '{name}' created in {path}")
+    print(f"tmux session '{name}' launching in {path}")
+    print(f"  Session label: {name}")
+    print(f"  Session name:  {name}")
     print("  Left pane:  agent running")
     print("  Right pane: shell ready")
-    print(f"  Reattach:   tmux a -t {name}")
-    print("  List all:   tmux ls")
+    print(f"  Attach:    tmux a -t {name}")
+    print("  List:      tmux ls")
 
     if attach:
         os.execvp("tmux", ["tmux", "attach-session", "-t", name])
@@ -1526,17 +1540,21 @@ def launch_zellij_session(
     import tempfile
 
     zj = zellij_bin()
-    name = session_name or tmux_session_name_for_worktree(path)
+    pair = worktree_session_pair(path.name)
+    label = session_name or pair.label
+    name = session_name or pair.session_name
     path_str = str(path)
     disable_terminal_flow_control()
+
+    print(f"zellij session '{label}' launching in {path}")
+    print(f"  Session label: {label}")
+    print(f"  Session name:  {name}")
 
     if zellij_session_exists(name):
         print(f"zellij session '{name}' already exists — attaching.")
         if attach:
             os.execvp(zj, [zj, "attach", name])
         return
-
-    print(f"zellij session '{name}' launching in {path}")
 
     temp_dir = Path(tempfile.mkdtemp(prefix=f"wt-layout-{name}-"))
     layout_file = temp_dir / "layout.kdl"
@@ -1564,10 +1582,8 @@ layout {{
         encoding="utf-8",
     )
 
-    print("  Left pane:  agent running")
-    print("  Right pane: shell ready")
-    print(f"  Reattach:   zellij attach {name}")
-    print("  List all:   zellij ls")
+    print(f"  Attach:    zellij attach {name}")
+    print("  List:      zellij ls")
 
     if attach:
         _exec_zellij_with_layout_cleanup(
@@ -2312,6 +2328,9 @@ def cmd_worktree_next(args: argparse.Namespace) -> int:
         preflight=(not args.no_preflight),
         dry_run=args.dry_run,
     )
+    if getattr(args, "shell_only", False) and args.open_shell and not args.dry_run:
+        open_shell(wt_path)
+        return 0
     if args.open_shell and not args.dry_run:
         handoff_to_agent_or_shell(
             path=wt_path,
@@ -2414,6 +2433,8 @@ def cmd_worktree_resume(args: argparse.Namespace) -> int:
     prepare_gitnexus_for_worktree(target.path)
     if args.command:
         run_command_in_worktree(target.path, args.command)
+    elif getattr(args, "shell_only", False) and args.open_shell:
+        open_shell(target.path)
     elif args.open_shell:
         agent = getattr(args, "agent", None)
         agent_mode = getattr(args, "agent_mode", None)
@@ -2553,14 +2574,21 @@ def cmd_wt_batch(args: argparse.Namespace) -> int:
         print(f"[{idx}/{total}] #{issue.number} -> ready {wt_path}")
 
     if not args.dry_run:
+        session = worktree_session_pair("worktrees")
+        print(
+            f"tmux session '{session.session_name}' launching with "
+            f"{len(batch_launches)} worktree window(s)"
+        )
+        print(f"Session label: {session.label}")
+        print(f"Session name:  {session.session_name}")
         print()
-        print("Attach:  tmux a -t worktrees")
+        print(f"Attach:  tmux a -t {session.session_name}")
         print("List:    tmux ls")
         print("Session summary:")
         print(f"  created {len(batch_launches)} worktree window(s)")
         print()
         launch_tmux_batch_session(
-            session_name="worktrees",
+            session_name=session.session_name,
             launches=batch_launches,
             attach=True,
             announce_windows=False,
@@ -2620,6 +2648,7 @@ def cmd_menu(args: argparse.Namespace) -> int:
                     no_preflight=False,
                     dry_run=False,
                     open_shell=(post_create == "shell"),
+                    shell_only=(post_create == "shell"),
                     agent=None,
                     agent_mode=None,
                     handoff=None,
@@ -2643,6 +2672,7 @@ def cmd_menu(args: argparse.Namespace) -> int:
                     no_preflight=False,
                     dry_run=False,
                     open_shell=(post_create == "shell"),
+                    shell_only=(post_create == "shell"),
                     agent=None,
                     agent_mode=None,
                     handoff=None,
@@ -2654,6 +2684,7 @@ def cmd_menu(args: argparse.Namespace) -> int:
                     path=None,
                     no_preflight=False,
                     open_shell=True,
+                    shell_only=True,
                     command=None,
                     agent=None,
                     agent_mode=None,

--- a/scripts/worktree_issues.py
+++ b/scripts/worktree_issues.py
@@ -37,6 +37,8 @@ TITLE_TASK_RE = re.compile(r"^(TASK-\d+):\s")
 STATUS_LABELS = {"status:not-started", "status:in-progress", "status:blocked", "status:done"}
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 WORKTREE_CLOSEOUT_DIR = ".build/worktree-closeouts"
+WORKTREE_RUNS_DIR = ".build/worktree-runs"
+WORKTREE_AGENT_RUN_DIR = ".build/agent-run"
 
 
 class CliError(RuntimeError):
@@ -109,6 +111,21 @@ class AuditFinding:
 class SessionPair:
     label: str
     session_name: str
+
+
+@dataclass(slots=True)
+class BatchLaunchResult:
+    issue_number: int
+    agent: str
+    worktree_path: Path
+    branch: str
+    command: str
+    state: str
+    pid: int | None = None
+    local_status_path: Path | None = None
+    stdout_log_path: Path | None = None
+    stderr_log_path: Path | None = None
+    detail: str = ""
 
 
 def run(
@@ -1117,6 +1134,147 @@ def open_shell(path: Path) -> None:
 
 def shell_quote(value: str) -> str:
     return shlex.quote(value)
+
+
+def worktree_runs_root(root: Path) -> Path:
+    return root / WORKTREE_RUNS_DIR
+
+
+def worktree_agent_run_dir(path: Path) -> Path:
+    return path / WORKTREE_AGENT_RUN_DIR
+
+
+def write_json_file(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def read_json_file(path: Path) -> dict[str, object] | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def worktree_agent_status(path: Path) -> dict[str, object] | None:
+    return read_json_file(worktree_agent_run_dir(path) / "status.json")
+
+
+def worktree_agent_running(path: Path) -> bool:
+    status = worktree_agent_status(path)
+    if not status:
+        return False
+    pid = status.get("pid")
+    if not isinstance(pid, int):
+        return False
+    state = status.get("state")
+    return state in {"starting", "running"} and pid_is_running(pid)
+
+
+def batch_run_id() -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    suffix = f"{os.getpid():x}"
+    return f"run-{stamp}-{suffix}"
+
+
+def batch_run_dir(root: Path, run_id: str) -> Path:
+    return worktree_runs_root(root) / run_id
+
+
+def batch_manifest_path(root: Path, run_id: str) -> Path:
+    return batch_run_dir(root, run_id) / "manifest.json"
+
+
+def batch_entry_path(root: Path, run_id: str, issue_number: int, agent: str) -> Path:
+    return batch_run_dir(root, run_id) / f"issue-{issue_number}-{agent}.json"
+
+
+def write_batch_entry(root: Path, run_id: str, entry: BatchLaunchResult) -> Path:
+    payload = {
+        "issue_number": entry.issue_number,
+        "agent": entry.agent,
+        "worktree_path": str(entry.worktree_path),
+        "branch": entry.branch,
+        "command": entry.command,
+        "state": entry.state,
+        "pid": entry.pid,
+        "local_status_path": str(entry.local_status_path) if entry.local_status_path else None,
+        "stdout_log_path": str(entry.stdout_log_path) if entry.stdout_log_path else None,
+        "stderr_log_path": str(entry.stderr_log_path) if entry.stderr_log_path else None,
+        "detail": entry.detail,
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+    return write_json_file(batch_entry_path(root, run_id, entry.issue_number, entry.agent), payload)
+
+
+def launch_agent_detached(
+    *,
+    root: Path,
+    run_id: str,
+    issue_number: int,
+    path: Path,
+    branch: str,
+    agent: str,
+    command: str,
+) -> BatchLaunchResult:
+    ensure_uv_venv(path)
+    runtime_dir = worktree_agent_run_dir(path)
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    stdout_log = runtime_dir / "stdout.log"
+    stderr_log = runtime_dir / "stderr.log"
+    status_path = runtime_dir / "status.json"
+    pid_path = runtime_dir / "pid"
+    shell_cmd = f"if [ -f .venv/bin/activate ]; then source .venv/bin/activate; fi; exec {command}"
+    started_at = datetime.now(UTC).isoformat()
+    with stdout_log.open("ab") as stdout_fp, stderr_log.open("ab") as stderr_fp:
+        proc = subprocess.Popen(
+            ["bash", "-lc", shell_cmd],
+            cwd=path,
+            stdout=stdout_fp,
+            stderr=stderr_fp,
+            start_new_session=True,
+        )
+    state = "running" if proc.poll() is None else "failed"
+    detail = "started detached agent process" if state == "running" else "agent exited immediately"
+    status_payload: dict[str, object] = {
+        "run_id": run_id,
+        "issue_number": issue_number,
+        "agent": agent,
+        "branch": branch,
+        "command": command,
+        "state": state,
+        "pid": proc.pid,
+        "started_at": started_at,
+        "stdout_log_path": str(stdout_log),
+        "stderr_log_path": str(stderr_log),
+        "orchestrator_manifest": str(batch_manifest_path(root, run_id)),
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    write_json_file(status_path, status_payload)
+    pid_path.write_text(f"{proc.pid}\n", encoding="utf-8")
+    return BatchLaunchResult(
+        issue_number=issue_number,
+        agent=agent,
+        worktree_path=path,
+        branch=branch,
+        command=command,
+        state=state,
+        pid=proc.pid,
+        local_status_path=status_path,
+        stdout_log_path=stdout_log,
+        stderr_log_path=stderr_log,
+        detail=detail,
+    )
 
 
 def choose_agent_interactive(default: str = "codex") -> str:
@@ -2290,6 +2448,9 @@ def cmd_worktree_next(args: argparse.Namespace) -> int:
             if args.open_shell and not args.dry_run:
                 if not args.no_preflight:
                     run_preflight(path=existing_wt.path, root=root, repo=repo)
+                if getattr(args, "shell_only", False):
+                    open_shell(existing_wt.path)
+                    return 0
                 handoff_to_agent_or_shell(
                     path=existing_wt.path,
                     root=root,
@@ -2357,6 +2518,9 @@ def cmd_worktree_create(args: argparse.Namespace) -> int:
         if args.open_shell and not args.dry_run:
             if not args.no_preflight:
                 run_preflight(path=existing_wt.path, root=root, repo=repo)
+            if getattr(args, "shell_only", False):
+                open_shell(existing_wt.path)
+                return 0
             handoff_to_agent_or_shell(
                 path=existing_wt.path,
                 root=root,
@@ -2503,14 +2667,12 @@ def cmd_agent_handoff(args: argparse.Namespace) -> int:
 
 
 def cmd_wt_batch(args: argparse.Namespace) -> int:
-    """Create N worktrees for the next runnable issues, randomly assign agents, launch tmux."""
+    """Create N worktrees and start detached agent runs with orchestrator-owned state."""
     import random
 
     count = args.count
     agents = args.agents.split(",") if args.agents else ["gemini", "codex"]
     mode = args.agent_mode or "yolo"
-    if not tmux_available():
-        raise CliError("wt-batch requires tmux for visible batch sessions")
 
     root = repo_root()
     repo = args.repo or origin_repo_slug(root)
@@ -2520,79 +2682,125 @@ def cmd_wt_batch(args: argparse.Namespace) -> int:
         Path(args.base_dir).expanduser().resolve() if args.base_dir else default_worktrees_dir(root)
     )
 
-    picked: list[QueueItem] = []
+    picked: list[tuple[QueueItem, Path | None]] = []
     for item in selection.items:
         if len(picked) >= count:
             break
         if not item.runnable:
             continue
         existing = find_linked_worktree_for_issue(root, item.issue.number)
-        if existing is not None:
-            print(f"Skipping #{item.issue.number}: worktree already exists at {existing.path}")
+        if existing is not None and worktree_agent_running(existing.path):
+            print(f"Skipping #{item.issue.number}: agent already running in {existing.path}")
             continue
-        picked.append(item)
+        picked.append((item, existing.path if existing is not None else None))
 
     if not picked:
         raise CliError("No runnable issues available for batch creation.")
     if len(picked) < count:
         print(f"WARNING: only {len(picked)} runnable issue(s) available (requested {count})")
 
-    batch_launches: list[tuple[str, Path, str]] = []
+    run_id = batch_run_id()
+    run_dir = batch_run_dir(root, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    manifest_entries: list[dict[str, object]] = []
+    launch_results: list[BatchLaunchResult] = []
     total = len(picked)
 
-    print(f"Batch session: {total} issue(s)")
-    for idx, item in enumerate(picked, start=1):
+    print(f"Batch run: {total} issue(s)")
+    print(f"Run id:   {run_id}")
+    print(f"Manifest: {batch_manifest_path(root, run_id)}")
+    for idx, (item, existing_path) in enumerate(picked, start=1):
         agent = random.choice(agents)
         issue = item.issue
 
         print(f"[{idx}/{total}] #{issue.number} -> starting ({agent})")
-        with contextlib.redirect_stdout(io.StringIO()):
-            wt_path = create_worktree_for_issue(
-                root=root,
-                repo=repo,
-                issue=issue,
-                base_dir=base_dir,
-                base_ref=None,
-                scope=None,
-                slug=None,
-                folder_name=None,
-                auto_claim=True,
-                preflight=False,
-                dry_run=args.dry_run,
-            )
+        if existing_path is not None:
+            wt_path = existing_path
+        else:
+            with contextlib.redirect_stdout(io.StringIO()):
+                wt_path = create_worktree_for_issue(
+                    root=root,
+                    repo=repo,
+                    issue=issue,
+                    base_dir=base_dir,
+                    base_ref=None,
+                    scope=None,
+                    slug=None,
+                    folder_name=None,
+                    auto_claim=True,
+                    preflight=False,
+                    dry_run=args.dry_run,
+                )
 
         if args.dry_run:
             print(f"[{idx}/{total}] #{issue.number} -> dry-run {wt_path}")
+            manifest_entries.append(
+                {
+                    "issue_number": issue.number,
+                    "agent": agent,
+                    "worktree_path": str(wt_path),
+                    "state": "dry-run",
+                    "generated_at": datetime.now(UTC).isoformat(),
+                }
+            )
             continue
 
         with contextlib.redirect_stdout(io.StringIO()):
             prepare_gitnexus_for_worktree(wt_path)
         prompt = build_agent_prompt_for_worktree(wt_path, root, repo)
         command = build_agent_command(agent, mode, prompt)
-        tab_name = f"wt{issue.number}"
-        batch_launches.append((tab_name, wt_path, command))
-        print(f"[{idx}/{total}] #{issue.number} -> ready {wt_path}")
+        branch = run(["git", "branch", "--show-current"], cwd=wt_path).stdout.strip()
+        result = launch_agent_detached(
+            root=root,
+            run_id=run_id,
+            issue_number=issue.number,
+            path=wt_path,
+            branch=branch,
+            agent=agent,
+            command=command,
+        )
+        launch_results.append(result)
+        write_batch_entry(root, run_id, result)
+        manifest_entries.append(
+            {
+                "issue_number": result.issue_number,
+                "agent": result.agent,
+                "worktree_path": str(result.worktree_path),
+                "branch": result.branch,
+                "state": result.state,
+                "pid": result.pid,
+                "local_status_path": (
+                    str(result.local_status_path) if result.local_status_path else None
+                ),
+                "stdout_log_path": str(result.stdout_log_path) if result.stdout_log_path else None,
+                "stderr_log_path": str(result.stderr_log_path) if result.stderr_log_path else None,
+                "detail": result.detail,
+                "generated_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        print(f"[{idx}/{total}] #{issue.number} -> {result.state} pid={result.pid} {wt_path}")
+
+    manifest_payload = {
+        "run_id": run_id,
+        "repo": repo,
+        "count_requested": count,
+        "count_selected": total,
+        "agent_pool": agents,
+        "agent_mode": mode,
+        "state": "dry-run" if args.dry_run else "started",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "entries": manifest_entries,
+    }
+    write_json_file(batch_manifest_path(root, run_id), manifest_payload)
 
     if not args.dry_run:
-        session = worktree_session_pair("worktrees")
-        print(
-            f"tmux session '{session.session_name}' launching with "
-            f"{len(batch_launches)} worktree window(s)"
-        )
-        print(f"Session label: {session.label}")
-        print(f"Session name:  {session.session_name}")
+        started = sum(1 for item in launch_results if item.state == "running")
+        failed = sum(1 for item in launch_results if item.state != "running")
         print()
-        print(f"Attach:  tmux a -t {session.session_name}")
-        print("List:    tmux ls")
-        print("Session summary:")
-        print(f"  created {len(batch_launches)} worktree window(s)")
-        print()
-        launch_tmux_batch_session(
-            session_name=session.session_name,
-            launches=batch_launches,
-            attach=True,
-            announce_windows=False,
-        )
+        print("Run summary:")
+        print(f"  started:  {started}")
+        print(f"  failed:   {failed}")
+        print(f"  manifest: {batch_manifest_path(root, run_id)}")
 
     return 0
 
@@ -2939,7 +3147,7 @@ def build_parser() -> argparse.ArgumentParser:
     batch = sub.add_parser(
         "wt-batch",
         parents=[common_repo, queue_common],
-        help="Create N worktrees with randomly assigned agents in a visible tmux session grid",
+        help="Create N worktrees with randomly assigned detached agent runs and a run manifest",
     )
     batch.add_argument(
         "--count", "-n", type=int, default=3, help="Number of worktrees to create (default: 3)"

--- a/tests/unit/test_worktree_issues.py
+++ b/tests/unit/test_worktree_issues.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -400,6 +402,78 @@ def test_cmd_worktree_next_shell_only_opens_shell_directly(monkeypatch):
     assert opened == [Path("/tmp/worktrees/wt33")]
 
 
+def test_cmd_worktree_next_existing_worktree_shell_only_opens_shell_directly(monkeypatch):
+    root = Path("/tmp/repo")
+    repo = "owner/repo"
+    issue_33 = _issue(
+        number=33,
+        task_id="TASK-026",
+        seq=260,
+        labels=["type:task", "status:not-started", "ready"],
+    )
+    existing = worktree_issues.WorktreeInfo(
+        path=Path("/tmp/worktrees/wt33"),
+        head="abc123",
+        branch="wt/infra/33-observabilitystack",
+        is_primary=False,
+    )
+    opened: list[Path] = []
+
+    monkeypatch.setattr(worktree_issues, "repo_root", lambda: root)
+    monkeypatch.setattr(worktree_issues, "origin_repo_slug", lambda _root: repo)
+    monkeypatch.setattr(
+        worktree_issues,
+        "fetch_repo_issues",
+        lambda *_args, **_kwargs: [issue_33],
+    )
+    monkeypatch.setattr(
+        worktree_issues,
+        "build_queue",
+        lambda _issues, **_kwargs: worktree_issues.QueueSelection(
+            source_mode="open-task",
+            items=[worktree_issues.QueueItem(issue=issue_33, runnable=True)],
+        ),
+    )
+    monkeypatch.setattr(worktree_issues, "find_linked_worktree_for_issue", lambda *_args: existing)
+    monkeypatch.setattr(worktree_issues, "prepare_gitnexus_for_worktree", lambda _path: None)
+    monkeypatch.setattr(worktree_issues, "run_preflight", lambda **kwargs: None)
+    monkeypatch.setattr(worktree_issues, "open_shell", lambda path: opened.append(path))
+    monkeypatch.setattr(
+        worktree_issues,
+        "handoff_to_agent_or_shell",
+        lambda **kwargs: pytest.fail("handoff_to_agent_or_shell should not be used"),
+    )
+
+    args = argparse.Namespace(
+        repo=None,
+        stream_label=None,
+        mode="auto",
+        choose=True,
+        allow_blocked=False,
+        base_dir=None,
+        base_ref=None,
+        scope=None,
+        slug=None,
+        name=None,
+        no_claim=False,
+        no_preflight=False,
+        dry_run=False,
+        open_shell=True,
+        shell_only=True,
+        agent=None,
+        agent_mode=None,
+        handoff=None,
+        print_only=False,
+    )
+
+    monkeypatch.setattr(worktree_issues, "choose_issue_interactive", lambda selection: issue_33)
+
+    rc = worktree_issues.cmd_worktree_next(args)
+
+    assert rc == 0
+    assert opened == [existing.path]
+
+
 def test_create_worktree_for_issue_attaches_existing_local_branch(monkeypatch, tmp_path):
     root = tmp_path / "repo"
     root.mkdir(parents=True, exist_ok=True)
@@ -606,8 +680,7 @@ def test_prepare_gitnexus_for_worktree_warns_when_npm_cache_path_unavailable(mon
     assert "rebuilding local index" in captured.out
 
 
-def test_cmd_wt_batch_uses_single_tmux_session_for_multiple_worktrees(monkeypatch, capsys):
-    root = Path("/tmp/repo")
+def test_cmd_wt_batch_writes_manifest_and_launches_detached_agents(monkeypatch, capsys, tmp_path):
     repo = "owner/repo"
     issue_33 = _issue(
         number=33,
@@ -622,11 +695,13 @@ def test_cmd_wt_batch_uses_single_tmux_session_for_multiple_worktrees(monkeypatc
         labels=["type:task", "status:not-started", "ready"],
     )
     created: list[int] = []
-    captured: dict[str, object] = {}
+    launched: list[tuple[int, str, Path, str]] = []
+    manifest_payloads: dict[Path, dict[str, object]] = {}
+    root = tmp_path / "repo"
+    root.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(worktree_issues, "repo_root", lambda: root)
     monkeypatch.setattr(worktree_issues, "origin_repo_slug", lambda _root: repo)
-    monkeypatch.setattr(worktree_issues, "tmux_available", lambda: True)
     monkeypatch.setattr(
         worktree_issues,
         "fetch_repo_issues",
@@ -659,21 +734,47 @@ def test_cmd_wt_batch_uses_single_tmux_session_for_multiple_worktrees(monkeypatc
         "build_agent_command",
         lambda agent, mode, prompt: f"{agent}:{mode}:{prompt}",
     )
+    monkeypatch.setattr(worktree_issues, "batch_run_id", lambda: "run-20260320-000001")
     monkeypatch.setattr(
         worktree_issues,
-        "worktree_session_pair",
-        lambda label: worktree_issues.SessionPair(
-            label=label, session_name="worktrees-20260319-213333-000001"
-        ),
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "wt/task/test\n", ""),
     )
 
-    def _launch(*, session_name, launches, attach, announce_windows=True):
-        captured["session_name"] = session_name
-        captured["launches"] = launches
-        captured["attach"] = attach
-        captured["announce_windows"] = announce_windows
+    def _write_json(path, payload):
+        manifest_payloads[path] = payload
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
 
-    monkeypatch.setattr(worktree_issues, "launch_tmux_batch_session", _launch)
+    monkeypatch.setattr(worktree_issues, "write_json_file", _write_json)
+
+    def _launch(**kwargs):
+        launched.append(
+            (
+                kwargs["issue_number"],
+                kwargs["agent"],
+                kwargs["path"],
+                kwargs["command"],
+            )
+        )
+        issue_number = kwargs["issue_number"]
+        wt_path = kwargs["path"]
+        return worktree_issues.BatchLaunchResult(
+            issue_number=issue_number,
+            agent=kwargs["agent"],
+            worktree_path=wt_path,
+            branch="wt/task/test",
+            command=kwargs["command"],
+            state="running",
+            pid=2000 + issue_number,
+            local_status_path=wt_path / ".build" / "agent-run" / "status.json",
+            stdout_log_path=wt_path / ".build" / "agent-run" / "stdout.log",
+            stderr_log_path=wt_path / ".build" / "agent-run" / "stderr.log",
+            detail="started detached agent process",
+        )
+
+    monkeypatch.setattr(worktree_issues, "launch_agent_detached", _launch)
 
     rc = worktree_issues.cmd_wt_batch(
         argparse.Namespace(
@@ -692,22 +793,122 @@ def test_cmd_wt_batch_uses_single_tmux_session_for_multiple_worktrees(monkeypatc
 
     assert rc == 0
     assert created == [33, 35]
-    assert captured["session_name"] == "worktrees-20260319-213333-000001"
-    assert captured["attach"] is True
-    assert captured["announce_windows"] is False
-    assert [tab for tab, _, _ in captured["launches"]] == ["wt33", "wt35"]
-    assert "Batch session: 2 issue(s)" in out
-    assert "Session label: worktrees" in out
-    assert "Session name:  worktrees-20260319-213333-000001" in out
+    assert [item[0] for item in launched] == [33, 35]
+    manifest_path = root / ".build" / "worktree-runs" / "run-20260320-000001" / "manifest.json"
+    assert manifest_path in manifest_payloads
+    assert manifest_payloads[manifest_path]["run_id"] == "run-20260320-000001"
+    assert manifest_payloads[manifest_path]["count_selected"] == 2
+    assert len(manifest_payloads[manifest_path]["entries"]) == 2
+    assert "Batch run: 2 issue(s)" in out
+    assert "Run id:   run-20260320-000001" in out
+    assert f"Manifest: {manifest_path}" in out
     assert "[1/2] #33 -> starting" in out
-    assert "[1/2] #33 -> ready" in out
+    assert "[1/2] #33 -> running pid=2033" in out
     assert "[2/2] #35 -> starting" in out
-    assert "[2/2] #35 -> ready" in out
-    assert "Attach:  tmux a -t worktrees-20260319-213333-000001" in out
+    assert "[2/2] #35 -> running pid=2035" in out
+    assert "Run summary:" in out
 
 
-def test_cmd_wt_batch_hello_world_e2e_two_issues(monkeypatch, capsys):
-    root = Path("/tmp/repo")
+def test_cmd_wt_batch_reuses_existing_worktree_when_agent_not_running(
+    monkeypatch, capsys, tmp_path
+):
+    repo = "owner/repo"
+    issue_41 = _issue(
+        number=41,
+        task_id="TASK-041",
+        seq=410,
+        labels=["type:task", "status:not-started", "ready"],
+    )
+    root = tmp_path / "repo"
+    root.mkdir(parents=True, exist_ok=True)
+    existing = worktree_issues.WorktreeInfo(
+        path=tmp_path / "worktrees" / "wt41",
+        head="abc123",
+        branch="wt/infra/41-test",
+        is_primary=False,
+    )
+    launched: list[Path] = []
+
+    monkeypatch.setattr(worktree_issues, "repo_root", lambda: root)
+    monkeypatch.setattr(worktree_issues, "origin_repo_slug", lambda _root: repo)
+    monkeypatch.setattr(
+        worktree_issues,
+        "fetch_repo_issues",
+        lambda *_args, **_kwargs: [issue_41],
+    )
+    monkeypatch.setattr(
+        worktree_issues,
+        "build_queue",
+        lambda _issues, **_kwargs: worktree_issues.QueueSelection(
+            source_mode="open-task",
+            items=[worktree_issues.QueueItem(issue=issue_41, runnable=True)],
+        ),
+    )
+    monkeypatch.setattr(worktree_issues, "find_linked_worktree_for_issue", lambda *_args: existing)
+    monkeypatch.setattr(worktree_issues, "worktree_agent_running", lambda path: False)
+    monkeypatch.setattr(worktree_issues, "prepare_gitnexus_for_worktree", lambda path: None)
+    monkeypatch.setattr(worktree_issues, "build_agent_prompt_for_worktree", lambda *args: "prompt")
+    monkeypatch.setattr(
+        worktree_issues,
+        "build_agent_command",
+        lambda agent, mode, prompt: f"{agent}:{mode}:{prompt}",
+    )
+    monkeypatch.setattr(worktree_issues, "batch_run_id", lambda: "run-20260320-000002")
+    monkeypatch.setattr(
+        worktree_issues,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "wt/infra/41-test\n", ""),
+    )
+
+    def _launch(**kwargs):
+        launched.append(kwargs["path"])
+        return worktree_issues.BatchLaunchResult(
+            issue_number=41,
+            agent=kwargs["agent"],
+            worktree_path=kwargs["path"],
+            branch="wt/infra/41-test",
+            command=kwargs["command"],
+            state="running",
+            pid=2041,
+            local_status_path=kwargs["path"] / ".build" / "agent-run" / "status.json",
+            stdout_log_path=kwargs["path"] / ".build" / "agent-run" / "stdout.log",
+            stderr_log_path=kwargs["path"] / ".build" / "agent-run" / "stderr.log",
+            detail="started detached agent process",
+        )
+
+    monkeypatch.setattr(worktree_issues, "launch_agent_detached", _launch)
+    monkeypatch.setattr(worktree_issues, "write_json_file", worktree_issues.write_json_file)
+    monkeypatch.setattr(
+        worktree_issues,
+        "create_worktree_for_issue",
+        lambda **kwargs: pytest.fail("create_worktree_for_issue should not be used"),
+    )
+
+    rc = worktree_issues.cmd_wt_batch(
+        argparse.Namespace(
+            repo=None,
+            stream_label=None,
+            mode="auto",
+            count=1,
+            agents="gemini,codex",
+            agent_mode="yolo",
+            base_dir=None,
+            dry_run=False,
+        )
+    )
+
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert launched == [existing.path]
+    assert "Batch run: 1 issue(s)" in out
+    assert "[1/1] #41 -> starting" in out
+    assert "[1/1] #41 -> running pid=2041" in out
+
+
+def test_cmd_wt_batch_skips_existing_worktree_with_running_agent(monkeypatch, capsys, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir(parents=True, exist_ok=True)
     repo = "owner/repo"
     issue_41 = _issue(
         number=41,
@@ -721,14 +922,16 @@ def test_cmd_wt_batch_hello_world_e2e_two_issues(monkeypatch, capsys):
         seq=420,
         labels=["type:task", "status:not-started", "ready"],
     )
+    existing = worktree_issues.WorktreeInfo(
+        path=tmp_path / "worktrees" / "wt41",
+        head="abc123",
+        branch="wt/infra/41-test",
+        is_primary=False,
+    )
     created: list[int] = []
-    prepared: list[Path] = []
-    launched: dict[str, object] = {}
-    wt_paths: dict[int, Path] = {}
 
     monkeypatch.setattr(worktree_issues, "repo_root", lambda: root)
     monkeypatch.setattr(worktree_issues, "origin_repo_slug", lambda _root: repo)
-    monkeypatch.setattr(worktree_issues, "tmux_available", lambda: True)
     monkeypatch.setattr(
         worktree_issues,
         "fetch_repo_issues",
@@ -745,39 +948,51 @@ def test_cmd_wt_batch_hello_world_e2e_two_issues(monkeypatch, capsys):
             ],
         ),
     )
-    monkeypatch.setattr(worktree_issues, "find_linked_worktree_for_issue", lambda *_args: None)
+    monkeypatch.setattr(
+        worktree_issues,
+        "find_linked_worktree_for_issue",
+        lambda _root, issue_number: existing if issue_number == 41 else None,
+    )
+    monkeypatch.setattr(
+        worktree_issues, "worktree_agent_running", lambda path: path == existing.path
+    )
     monkeypatch.setattr(
         worktree_issues,
         "create_worktree_for_issue",
         lambda **kwargs: (
             created.append(kwargs["issue"].number)
-            or wt_paths.setdefault(
-                kwargs["issue"].number, Path(f"/tmp/worktrees/wt{kwargs['issue'].number}")
-            )
+            or tmp_path / "worktrees" / f"wt{kwargs['issue'].number}"
         ),
     )
-    monkeypatch.setattr(
-        worktree_issues,
-        "prepare_gitnexus_for_worktree",
-        lambda path: prepared.append(path),
-    )
+    monkeypatch.setattr(worktree_issues, "prepare_gitnexus_for_worktree", lambda path: None)
     monkeypatch.setattr(worktree_issues, "build_agent_prompt_for_worktree", lambda *args: "prompt")
     monkeypatch.setattr(
         worktree_issues,
         "build_agent_command",
         lambda agent, mode, prompt: f"{agent}:{mode}:{prompt}",
     )
+    monkeypatch.setattr(worktree_issues, "batch_run_id", lambda: "run-20260320-000003")
     monkeypatch.setattr(
         worktree_issues,
-        "worktree_session_pair",
-        lambda label: worktree_issues.SessionPair(
-            label=label, session_name="worktrees-20260319-213333-000002"
-        ),
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "wt/infra/42-test\n", ""),
     )
     monkeypatch.setattr(
         worktree_issues,
-        "launch_tmux_batch_session",
-        lambda **kwargs: launched.update(kwargs),
+        "launch_agent_detached",
+        lambda **kwargs: worktree_issues.BatchLaunchResult(
+            issue_number=kwargs["issue_number"],
+            agent=kwargs["agent"],
+            worktree_path=kwargs["path"],
+            branch="wt/infra/42-test",
+            command=kwargs["command"],
+            state="running",
+            pid=2042,
+            local_status_path=kwargs["path"] / ".build" / "agent-run" / "status.json",
+            stdout_log_path=kwargs["path"] / ".build" / "agent-run" / "stdout.log",
+            stderr_log_path=kwargs["path"] / ".build" / "agent-run" / "stderr.log",
+            detail="started detached agent process",
+        ),
     )
 
     rc = worktree_issues.cmd_wt_batch(
@@ -792,23 +1007,57 @@ def test_cmd_wt_batch_hello_world_e2e_two_issues(monkeypatch, capsys):
             dry_run=False,
         )
     )
-
     out = capsys.readouterr().out
 
     assert rc == 0
-    assert created == [41, 42]
-    assert prepared == [wt_paths[41], wt_paths[42]]
-    assert launched["session_name"] == "worktrees-20260319-213333-000002"
-    assert launched["attach"] is True
-    assert launched["announce_windows"] is False
-    assert [tab for tab, _, _ in launched["launches"]] == ["wt41", "wt42"]
-    assert "Batch session: 2 issue(s)" in out
-    assert "Session label: worktrees" in out
-    assert "Session name:  worktrees-20260319-213333-000002" in out
-    assert "[1/2] #41 -> starting" in out
-    assert "[1/2] #41 -> ready" in out
-    assert "[2/2] #42 -> starting" in out
-    assert "[2/2] #42 -> ready" in out
+    assert created == [42]
+    assert f"Skipping #41: agent already running in {existing.path}" in out
+    assert "WARNING: only 1 runnable issue(s) available (requested 2)" in out
+    assert "[1/1] #42 -> running pid=2042" in out
+
+
+def test_launch_agent_detached_writes_runtime_state(monkeypatch, tmp_path):
+    root = tmp_path / "repo"
+    worktree = tmp_path / "wt41"
+    root.mkdir(parents=True, exist_ok=True)
+    worktree.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(worktree_issues, "ensure_uv_venv", lambda path: None)
+
+    result = worktree_issues.launch_agent_detached(
+        root=root,
+        run_id="run-20260320-000004",
+        issue_number=41,
+        path=worktree,
+        branch="wt/infra/41-test",
+        agent="codex",
+        command='python3 -c "import time; time.sleep(5)"',
+    )
+
+    try:
+        assert result.state == "running"
+        assert result.pid is not None
+        assert worktree_issues.pid_is_running(result.pid) is True
+        assert result.local_status_path is not None and result.local_status_path.exists()
+        assert result.stdout_log_path is not None and result.stdout_log_path.exists()
+        assert result.stderr_log_path is not None and result.stderr_log_path.exists()
+        pid_path = worktree / ".build" / "agent-run" / "pid"
+        assert pid_path.read_text(encoding="utf-8").strip() == str(result.pid)
+        status = json.loads(result.local_status_path.read_text(encoding="utf-8"))
+        assert status["run_id"] == "run-20260320-000004"
+        assert status["issue_number"] == 41
+        assert status["branch"] == "wt/infra/41-test"
+        assert status["agent"] == "codex"
+        assert status["state"] == "running"
+        assert status["pid"] == result.pid
+        assert status["orchestrator_manifest"].endswith(
+            ".build/worktree-runs/run-20260320-000004/manifest.json"
+        )
+        assert worktree_issues.worktree_agent_running(worktree) is True
+    finally:
+        if result.pid is not None and worktree_issues.pid_is_running(result.pid):
+            os.kill(result.pid, signal.SIGTERM)
+            subprocess.run(["bash", "-lc", f"wait {result.pid}"], check=False)
 
 
 def test_launch_tmux_batch_session_starts_grid(monkeypatch, capsys):

--- a/tests/unit/test_worktree_issues.py
+++ b/tests/unit/test_worktree_issues.py
@@ -229,6 +229,42 @@ def test_cmd_worktree_resume_open_shell_tolerates_missing_agent_namespace_attrs(
     assert called["mux"] is None
 
 
+def test_cmd_worktree_resume_shell_only_opens_shell_directly(monkeypatch):
+    root = Path("/tmp/repo")
+    wt = worktree_issues.WorktreeInfo(
+        path=Path("/tmp/worktrees/wt33"),
+        head="abc123",
+        branch="wt/infra/33-observabilitystack",
+        is_primary=False,
+    )
+    opened: list[Path] = []
+
+    monkeypatch.setattr(worktree_issues, "repo_root", lambda: root)
+    monkeypatch.setattr(worktree_issues, "list_resume_candidates", lambda _root: [wt])
+    monkeypatch.setattr(worktree_issues, "select_worktree_interactive", lambda items: wt)
+    monkeypatch.setattr(worktree_issues, "origin_repo_slug", lambda _root: "owner/repo")
+    monkeypatch.setattr(worktree_issues, "run_preflight", lambda **kwargs: None)
+    monkeypatch.setattr(worktree_issues, "prepare_gitnexus_for_worktree", lambda _path: None)
+    monkeypatch.setattr(worktree_issues, "open_shell", lambda path: opened.append(path))
+    monkeypatch.setattr(
+        worktree_issues,
+        "handoff_to_agent_or_shell",
+        lambda **kwargs: pytest.fail("handoff_to_agent_or_shell should not be used"),
+    )
+
+    args = argparse.Namespace(
+        path=None,
+        no_preflight=False,
+        open_shell=True,
+        shell_only=True,
+        command=None,
+    )
+    rc = worktree_issues.cmd_worktree_resume(args)
+
+    assert rc == 0
+    assert opened == [wt.path]
+
+
 def test_cmd_worktree_next_skips_runnable_issue_with_existing_worktree(monkeypatch):
     root = Path("/tmp/repo")
     repo = "owner/repo"
@@ -293,6 +329,75 @@ def test_cmd_worktree_next_skips_runnable_issue_with_existing_worktree(monkeypat
     selected_issue = created["issue"]
     assert isinstance(selected_issue, worktree_issues.Issue)
     assert selected_issue.number == 35
+
+
+def test_cmd_worktree_next_shell_only_opens_shell_directly(monkeypatch):
+    root = Path("/tmp/repo")
+    repo = "owner/repo"
+    issue_33 = _issue(
+        number=33,
+        task_id="TASK-026",
+        seq=260,
+        labels=["type:task", "status:not-started", "ready"],
+    )
+    created: list[int] = []
+    opened: list[Path] = []
+
+    monkeypatch.setattr(worktree_issues, "repo_root", lambda: root)
+    monkeypatch.setattr(worktree_issues, "origin_repo_slug", lambda _root: repo)
+    monkeypatch.setattr(
+        worktree_issues,
+        "fetch_repo_issues",
+        lambda *_args, **_kwargs: [issue_33],
+    )
+    monkeypatch.setattr(
+        worktree_issues,
+        "build_queue",
+        lambda _issues, **_kwargs: worktree_issues.QueueSelection(
+            source_mode="open-task",
+            items=[worktree_issues.QueueItem(issue=issue_33, runnable=True)],
+        ),
+    )
+    monkeypatch.setattr(worktree_issues, "find_linked_worktree_for_issue", lambda *_args: None)
+    monkeypatch.setattr(
+        worktree_issues,
+        "create_worktree_for_issue",
+        lambda **kwargs: created.append(kwargs["issue"].number) or Path("/tmp/worktrees/wt33"),
+    )
+    monkeypatch.setattr(worktree_issues, "prepare_gitnexus_for_worktree", lambda _path: None)
+    monkeypatch.setattr(worktree_issues, "open_shell", lambda path: opened.append(path))
+    monkeypatch.setattr(
+        worktree_issues,
+        "handoff_to_agent_or_shell",
+        lambda **kwargs: pytest.fail("handoff_to_agent_or_shell should not be used"),
+    )
+
+    args = argparse.Namespace(
+        repo=None,
+        stream_label=None,
+        mode="auto",
+        choose=False,
+        allow_blocked=False,
+        base_dir=None,
+        base_ref=None,
+        scope=None,
+        slug=None,
+        name=None,
+        no_claim=False,
+        no_preflight=False,
+        dry_run=False,
+        open_shell=True,
+        shell_only=True,
+        agent=None,
+        agent_mode=None,
+        handoff=None,
+        print_only=False,
+    )
+    rc = worktree_issues.cmd_worktree_next(args)
+
+    assert rc == 0
+    assert created == [33]
+    assert opened == [Path("/tmp/worktrees/wt33")]
 
 
 def test_create_worktree_for_issue_attaches_existing_local_branch(monkeypatch, tmp_path):
@@ -554,6 +659,13 @@ def test_cmd_wt_batch_uses_single_tmux_session_for_multiple_worktrees(monkeypatc
         "build_agent_command",
         lambda agent, mode, prompt: f"{agent}:{mode}:{prompt}",
     )
+    monkeypatch.setattr(
+        worktree_issues,
+        "worktree_session_pair",
+        lambda label: worktree_issues.SessionPair(
+            label=label, session_name="worktrees-20260319-213333-000001"
+        ),
+    )
 
     def _launch(*, session_name, launches, attach, announce_windows=True):
         captured["session_name"] = session_name
@@ -580,16 +692,18 @@ def test_cmd_wt_batch_uses_single_tmux_session_for_multiple_worktrees(monkeypatc
 
     assert rc == 0
     assert created == [33, 35]
-    assert captured["session_name"] == "worktrees"
+    assert captured["session_name"] == "worktrees-20260319-213333-000001"
     assert captured["attach"] is True
     assert captured["announce_windows"] is False
     assert [tab for tab, _, _ in captured["launches"]] == ["wt33", "wt35"]
     assert "Batch session: 2 issue(s)" in out
+    assert "Session label: worktrees" in out
+    assert "Session name:  worktrees-20260319-213333-000001" in out
     assert "[1/2] #33 -> starting" in out
     assert "[1/2] #33 -> ready" in out
     assert "[2/2] #35 -> starting" in out
     assert "[2/2] #35 -> ready" in out
-    assert "Attach:  tmux a -t worktrees" in out
+    assert "Attach:  tmux a -t worktrees-20260319-213333-000001" in out
 
 
 def test_cmd_wt_batch_hello_world_e2e_two_issues(monkeypatch, capsys):
@@ -655,6 +769,13 @@ def test_cmd_wt_batch_hello_world_e2e_two_issues(monkeypatch, capsys):
     )
     monkeypatch.setattr(
         worktree_issues,
+        "worktree_session_pair",
+        lambda label: worktree_issues.SessionPair(
+            label=label, session_name="worktrees-20260319-213333-000002"
+        ),
+    )
+    monkeypatch.setattr(
+        worktree_issues,
         "launch_tmux_batch_session",
         lambda **kwargs: launched.update(kwargs),
     )
@@ -677,11 +798,13 @@ def test_cmd_wt_batch_hello_world_e2e_two_issues(monkeypatch, capsys):
     assert rc == 0
     assert created == [41, 42]
     assert prepared == [wt_paths[41], wt_paths[42]]
-    assert launched["session_name"] == "worktrees"
+    assert launched["session_name"] == "worktrees-20260319-213333-000002"
     assert launched["attach"] is True
     assert launched["announce_windows"] is False
     assert [tab for tab, _, _ in launched["launches"]] == ["wt41", "wt42"]
     assert "Batch session: 2 issue(s)" in out
+    assert "Session label: worktrees" in out
+    assert "Session name:  worktrees-20260319-213333-000002" in out
     assert "[1/2] #41 -> starting" in out
     assert "[1/2] #41 -> ready" in out
     assert "[2/2] #42 -> starting" in out
@@ -768,6 +891,13 @@ def test_launch_zellij_session_adds_layout_to_existing_session(monkeypatch, caps
 
     monkeypatch.setattr(worktree_issues, "zellij_bin", lambda: "/home/julesb/bin/zellij")
     monkeypatch.setattr(worktree_issues, "zellij_session_exists", lambda _name: True)
+    monkeypatch.setattr(
+        worktree_issues,
+        "worktree_session_pair",
+        lambda label: worktree_issues.SessionPair(
+            label=label, session_name="wt33-20260319-213333-000003"
+        ),
+    )
 
     def _execvp(bin_path, args):
         captured["bin_path"] = bin_path
@@ -784,7 +914,9 @@ def test_launch_zellij_session_adds_layout_to_existing_session(monkeypatch, caps
     out = capsys.readouterr().out
     assert "already exists — attaching." in out
     assert captured["bin_path"] == "/home/julesb/bin/zellij"
-    assert captured["args"] == ["/home/julesb/bin/zellij", "attach", "wt33"]
+    assert captured["args"] == ["/home/julesb/bin/zellij", "attach", "wt33-20260319-213333-000003"]
+    assert "Session label: wt33" in out
+    assert "Session name:  wt33-20260319-213333-000003" in out
 
 
 def test_launch_zellij_batch_session_adds_tabs_to_existing_session(monkeypatch, capsys):
@@ -1050,6 +1182,13 @@ def test_launch_zellij_session_adds_tab_to_existing_session(monkeypatch, tmp_pat
 
     monkeypatch.setattr(worktree_issues, "zellij_bin", lambda: "/home/julesb/bin/zellij")
     monkeypatch.setattr(worktree_issues, "zellij_session_exists", lambda _name: True)
+    monkeypatch.setattr(
+        worktree_issues,
+        "worktree_session_pair",
+        lambda label: worktree_issues.SessionPair(
+            label=label, session_name="wt123-20260319-213333-000004"
+        ),
+    )
 
     def _run(cmd, **kwargs):
         subprocess_calls.append(list(cmd))


### PR DESCRIPTION
## Summary
- replace `wt-batch` tmux startup with detached per-worktree agent launches
- persist canonical run manifests under the primary repo and local runtime state under each worktree
- make shell-only worktree menu flows open a shell even when the linked worktree already exists
- update help text and add regression tests for batch launch and shell-only paths

## Validation
- pytest tests/unit/test_worktree_issues.py -q
- make validate-local
- make preflight-session
- make pre-validate-session

Closes #354
