### PR TITLE
#359: avoid wt-batch GitNexus refresh hangs

### DIFF
--- a/scripts/worktree_issues.py
+++ b/scripts/worktree_issues.py
@@ -1040,7 +1040,11 @@ def gitnexus_cli_path() -> Path | None:
         candidate = Path(override).expanduser()
         if candidate.exists():
             return candidate
-
+    which = shutil_which("gitnexus")
+    if which:
+        candidate = Path(which).expanduser()
+        if candidate.exists():
+            return candidate
     return None
 
 
@@ -1049,23 +1053,36 @@ def run_gitnexus_command(
     args: list[str],
     *,
     check: bool,
+    timeout_seconds: float = 30.0,
 ) -> subprocess.CompletedProcess[str]:
     cli_path = gitnexus_cli_path()
     node = shutil_which("node")
     if cli_path is not None and node is not None:
-        cmd = [node, str(cli_path), *args]
+        if cli_path.suffix == ".js":
+            cmd = [node, str(cli_path), *args]
+        else:
+            cmd = [str(cli_path), *args]
     else:
-        cmd = ["npx", "gitnexus", *args]
+        cmd = ["npx", "--yes", "gitnexus", *args]
     attempts = 0
     while True:
         attempts += 1
-        proc = subprocess.run(
-            cmd,
-            cwd=path,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=path,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise subprocess.CalledProcessError(
+                124,
+                cmd,
+                output=exc.stdout,
+                stderr=exc.stderr,
+            ) from exc
         combined_output = "\n".join(
             part.strip() for part in (proc.stdout or "", proc.stderr or "") if part.strip()
         )
@@ -1091,8 +1108,8 @@ def prepare_gitnexus_for_worktree(path: Path) -> None:
     if not gitnexus_refresh_enabled():
         print("GitNexus: refresh disabled by WORKTREE_GITNEXUS_REFRESH=0")
         return
-    if shutil_which("npx") is None:
-        eprint("WARNING: npx not found; skipping GitNexus refresh")
+    if gitnexus_cli_path() is None and shutil_which("npx") is None:
+        eprint("WARNING: gitnexus CLI and npx not found; skipping GitNexus refresh")
         return
 
     print(f"GitNexus: checking local index in {path}")

--- a/tests/unit/test_worktree_issues.py
+++ b/tests/unit/test_worktree_issues.py
@@ -624,7 +624,7 @@ def test_run_gitnexus_command_clears_corrupt_npx_cache_and_retries(monkeypatch, 
     proc = worktree_issues.run_gitnexus_command(Path("/tmp/repo"), ["status"], check=False)
 
     assert proc.returncode == 0
-    assert calls == [["npx", "gitnexus", "status"], ["npx", "gitnexus", "status"]]
+    assert calls == [["npx", "--yes", "gitnexus", "status"], ["npx", "--yes", "gitnexus", "status"]]
     assert removed == [Path("/home/julesb/.npm/_npx")]
     assert "clearing corrupt npx cache" in capsys.readouterr().out
 
@@ -675,7 +675,10 @@ def test_prepare_gitnexus_for_worktree_warns_when_npm_cache_path_unavailable(mon
     worktree_issues.prepare_gitnexus_for_worktree(Path("/tmp/repo"))
 
     captured = capsys.readouterr()
-    assert calls == [["npx", "gitnexus", "status"], ["npx", "gitnexus", "analyze"]]
+    assert calls == [
+        ["npx", "--yes", "gitnexus", "status"],
+        ["npx", "--yes", "gitnexus", "analyze"],
+    ]
     assert "npm cache path unavailable" in captured.err
     assert "rebuilding local index" in captured.out
 


### PR DESCRIPTION
## Summary
- prefer the installed gitnexus CLI before falling back to npx
- add a timeout to GitNexus command execution so batch setup cannot hang indefinitely
- keep the fallback path explicit with npx --yes

## Testing
- pytest tests/unit/test_worktree_issues.py -q
- uv run ruff check scripts/worktree_issues.py tests/unit/test_worktree_issues.py
- uv run ruff format --check scripts/worktree_issues.py tests/unit/test_worktree_issues.py
- make preflight-session
- make pre-validate-session

Closes #359