### PR TITLE
#361: allow unavoidable wildcard-resource actions in cfn-guard

### DIFF
--- a/infra/guard/platform-security.guard
+++ b/infra/guard/platform-security.guard
@@ -70,6 +70,12 @@ rule no_wildcard_iam_resource {
 
 rule check_resource_wildcard(res, act) {
     let exempted_actions = [
+        "cloudwatch:PutMetricData",
+        "bedrock-agentcore:CreateMemory",
+        "bedrock-agentcore:UpdateMemory",
+        "bedrock-agentcore:DeleteMemory",
+        "bedrock-agentcore:GetMemory",
+        "bedrock-agentcore:TagResource",
         "xray:PutTraceSegments",
         "xray:PutTelemetryRecords",
         "iam:CreateOpenIDConnectProvider",


### PR DESCRIPTION
## Summary
- exempt CloudWatch PutMetricData from the wildcard-resource guard
- exempt the current AgentCore memory actions that do not support resource scoping
- keep the guard narrow by listing only the exact unavoidable actions

## Testing
- make preflight-session
- make pre-validate-session

Closes #361