### PR TITLE
CR-002: Tenant capability configuration model

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,16 +133,16 @@
         "filename": "tests/unit/test_models.py",
         "hashed_secret": "783c030365a37a432b13863d83a01320f8a8ea4d",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 114
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/unit/test_models.py",
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 250
       }
     ]
   },
-  "generated_at": "2026-02-24T16:06:50Z"
+  "generated_at": "2026-03-21T02:28:43Z"
 }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,14 +8,101 @@ This file exists so tools that look for assistant instruction files can redirect
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-GitNexus context is stored in `.gitnexus/ai-context.md`.
-Read that file for the current repository guidance, generated skills references, and safety rules.
+This project is indexed by GitNexus as **wt303** (2335 symbols, 6040 relationships, 189 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
-## Loader Contract
+## Always Do
 
-- Keep this file as a stable pointer.
-- Update `.gitnexus/ai-context.md` for generated GitNexus content.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/wt303/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/wt303/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/wt303/clusters` | All functional areas |
+| `gitnexus://repo/wt303/processes` | All execution flows |
+| `gitnexus://repo/wt303/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Platform Lambda source directories use `snake_case`. The shared `src/data-access
 | CDK testing | Jest and cdk-assertions |
 | Python testing | pytest and LocalStack |
 | Secrets | AWS Secrets Manager |
-| Configuration | AWS SSM Parameter Store |
+| Configuration | AWS AppConfig for dynamic capability policy; AWS SSM Parameter Store for runtime/platform parameters |
 | Async agents | AgentCore `add_async_task` and `complete_async_task` SDK |
 | Observability | AgentCore Observability and Amazon CloudWatch |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,7 @@ eu-west-2 London (HOME — owns everything)
 ├── All S3 buckets
 ├── Secrets Manager
 ├── SSM Parameter Store
+├── AppConfig
 ├── EventBridge
 ├── SQS (webhook delivery retry queue only, not async invocation routing)
 ├── Bridge Lambda
@@ -72,6 +73,11 @@ platform. Additional policy tuning remains an ongoing platform task.
 Failover: Dublin → Frankfurt on `ServiceUnavailableException`
 ([RUNBOOK-001](operations/RUNBOOK-001-runtime-region-failover.md)).
 Failover controlled by SSM `/platform/config/runtime-region` with DynamoDB distributed lock.
+
+Dynamic tenant capability policy uses AppConfig in the home region. AppConfig is
+reserved for rollout-sensitive capability policy only; runtime parameters remain
+in SSM and tenant/resource metadata remains in DynamoDB. See
+[ADR-017](decisions/ADR-017-tenant-capability-configuration-model.md).
 
 ## Request Lifecycle (Synchronous)
 
@@ -202,6 +208,23 @@ Operator
 Design rule: platform agents assist and orchestrate control-plane operations; they do
 not bypass the control plane.
 
+## Configuration Ownership Model
+
+The platform splits configuration ownership by change semantics rather than by
+team preference:
+
+| Store | Owns | Does not own |
+|-------|------|--------------|
+| **AppConfig** | Dynamic tenant capability policy: tier feature enablement, capability flags, kill switches, model/tool availability, rollout controls | Tenant state, resource inventory, execution-role ARNs, memory-store ARNs |
+| **SSM Parameter Store** | Platform/runtime parameters: active runtime region, failover parameters, stable service endpoints, AppConfig bootstrap identifiers | Tenant feature policy, invocation state |
+| **DynamoDB** | Tenant metadata and transactional state: status, budgets, execution-role ARN, memory-store ARN, audit/job/session records | Rollout-managed capability toggles |
+
+Control-plane Lambdas cache capability policy locally and evaluate it with
+deny-by-default fallback semantics: use the last known good AppConfig document
+when available, otherwise fall back to an empty policy that enables nothing.
+Kill switches override all rollout rules. Rollback of capability changes uses
+AppConfig version history rather than ad hoc DynamoDB edits.
+
 ## Entity Lifecycle
 
 ![Entity state diagram: tenant, agent, invocation, job, and session lifecycle states and transitions](images/tf_acore_aas_entities_state_diagram.drawio.png)
@@ -215,6 +238,8 @@ See [ADR-012](decisions/ADR-012-dynamodb-capacity.md) for capacity mode rational
 - Attributes: tenantId, appId, displayName, tier, status, createdAt, updatedAt,
   ownerEmail, ownerTeam, memoryStoreArn, runtimeRegion, fallbackRegion,
   apiKeySecretArn, monthlyBudgetUsd, accountId
+- Excludes dynamic capability policy. Capability flags, kill switches, and
+  rollout-managed model/tool availability live in AppConfig, not in this table.
 - Capacity: provisioned, auto-scaling, 5 RCU/WCU minimum
 - Tenant ID policy (create boundary):
   - Canonicalized to lowercase before persistence

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Every significant design choice is documented with context, decision, and reject
 | [ADR-013](decisions/ADR-013-entra-rbac-roles-claim.md) | Entra group membership as JWT roles claim for RBAC |
 | [ADR-014](decisions/ADR-014-minimise-vpc-bound-services.md) | Default non-VPC control plane; VPC attachment only for genuine private dependencies |
 | [ADR-016](decisions/ADR-016-platform-internal-tenant.md) | Reserved `platform` tenant for operator-controlled agents without super-tenant bypass |
+| [ADR-017](decisions/ADR-017-tenant-capability-configuration-model.md) | AppConfig for dynamic capability policy; SSM and DynamoDB retain operational parameters and tenant metadata |
 
 ## Operator Runbooks
 

--- a/docs/decisions/ADR-017-tenant-capability-configuration-model.md
+++ b/docs/decisions/ADR-017-tenant-capability-configuration-model.md
@@ -1,0 +1,78 @@
+# ADR-017: Tenant Capability Configuration Model
+
+## Status: Accepted
+## Date: 2026-03-21
+
+## Context
+The platform currently uses DynamoDB tenant records and SSM parameters for most
+configuration reads. That is sufficient for resource inventory and static runtime
+parameters, but it is a poor fit for dynamic capability policy such as:
+- per-tier feature enablement
+- emergency kill switches
+- controlled rollout of tool or model access
+- progressive enablement of new tenant-facing capabilities
+
+Those concerns need staged rollout, validation, and rollback semantics. At the
+same time, AppConfig is not a substitute for transactional tenant data or
+resource inventory.
+
+## Decision
+The platform splits configuration ownership across three stores:
+
+1. **AWS AppConfig** owns dynamic tenant capability policy only.
+   This includes:
+   - tier feature enablement
+   - capability flags
+   - kill switches
+   - model availability policy
+   - tool availability policy
+   - rollout controls
+
+2. **AWS SSM Parameter Store** remains the store for platform and runtime
+   parameters whose values are operational inputs rather than tenant policy.
+   This includes:
+   - active runtime region and failover parameters
+   - stable service endpoint and bootstrap parameters
+   - AppConfig bootstrap identifiers when needed by Lambdas
+
+3. **DynamoDB** remains the source of truth for tenant state, resource metadata,
+   and transactional records.
+   This includes:
+   - tenant identity and lifecycle status
+   - execution-role ARNs
+   - memory-store ARNs
+   - API key secret references
+   - budget contracts and billing state
+   - invocation, job, and session records
+
+## Capability Policy Semantics
+- Capability policy is evaluated with **deny-by-default** fallback semantics.
+- If an AppConfig fetch fails, the control plane must use the last known good
+  cached document when available; otherwise it falls back to an empty policy that
+  enables nothing.
+- Emergency kill switches must override all rollout or allow-list rules.
+- Percentage rollout must be deterministic per tenant identifier so rollout
+  membership stays stable across repeated reads.
+
+## Rollout and Rollback
+- Capability changes are published through AppConfig deployment workflows.
+- Validators should reject malformed capability documents before rollout.
+- Rollout should start with bounded percentage exposure or explicit allow-lists.
+- Rollback uses AppConfig environment version history; reverting to the previous
+  known good configuration must not require DynamoDB record edits.
+
+## Consequences
+- Dynamic tenant capability policy gains first-class rollout and rollback support.
+- Resource inventory stays out of AppConfig, preserving DynamoDB as the source of
+  truth for tenant metadata.
+- Operational runtime parameters stay in SSM, avoiding unnecessary AppConfig
+  coupling for non-policy values.
+- Control-plane Lambdas keep simple public-endpoint reads consistent with ADR-014.
+
+## Alternatives Rejected
+- **Keep all configuration in DynamoDB and SSM**: simple at first, but weak for
+  staged rollout, validation, and rollback of dynamic capability policy.
+- **Move tenant metadata into AppConfig**: breaks source-of-truth boundaries and
+  treats resource inventory like mutable feature policy.
+- **Use AppConfig for every parameter**: adds deployment workflow overhead to
+  static operational parameters that are better served by SSM.

--- a/src/data-access-lib/src/data_access/models.py
+++ b/src/data-access-lib/src/data_access/models.py
@@ -19,8 +19,9 @@ Implemented in TASK-011.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
+from hashlib import sha256
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -88,6 +89,144 @@ class InviteStatus(StrEnum):
     ACCEPTED = "accepted"
     EXPIRED = "expired"
     REVOKED = "revoked"
+
+
+class ConfigurationStore(StrEnum):
+    APPCONFIG = "appconfig"
+    SSM = "ssm"
+    DYNAMODB = "dynamodb"
+
+
+APPCONFIG_DYNAMIC_CAPABILITY_AREAS = frozenset(
+    {
+        "tier_feature_enablement",
+        "capability_flags",
+        "kill_switches",
+        "model_availability",
+        "tool_availability",
+        "rollout_controls",
+    }
+)
+SSM_PLATFORM_PARAMETER_AREAS = frozenset(
+    {
+        "runtime_region_parameters",
+        "operational_failover_parameters",
+        "service_endpoints",
+        "appconfig_bootstrap",
+    }
+)
+DYNAMODB_TENANT_METADATA_AREAS = frozenset(
+    {
+        "tenant_state",
+        "tenant_resource_inventory",
+        "tenant_identity_metadata",
+        "tenant_budget_contracts",
+        "invocation_audit",
+        "job_tracking",
+        "session_tracking",
+    }
+)
+
+
+def configuration_store_for(area: str) -> ConfigurationStore:
+    """Return the owning config store for a platform configuration concern.
+
+    The mapping is intentionally coarse-grained. It documents the architectural
+    ownership split for issue #303 instead of binding callers to individual
+    attribute names, which may evolve independently of the store boundary.
+    """
+
+    normalized = area.strip().lower()
+    if normalized in APPCONFIG_DYNAMIC_CAPABILITY_AREAS:
+        return ConfigurationStore.APPCONFIG
+    if normalized in SSM_PLATFORM_PARAMETER_AREAS:
+        return ConfigurationStore.SSM
+    if normalized in DYNAMODB_TENANT_METADATA_AREAS:
+        return ConfigurationStore.DYNAMODB
+    raise ValueError(f"Unknown configuration area: {area!r}")
+
+
+@dataclass(frozen=True)
+class CapabilityRollout:
+    """Dynamic capability policy with deterministic tenant targeting.
+
+    The control plane loads these rules from AppConfig. Missing or malformed
+    policy must degrade safely to disabled capability state.
+    """
+
+    enabled: bool = False
+    rollout_percentage: int = 100
+    tier_allow_list: frozenset[TenantTier] = field(default_factory=frozenset)
+    tenant_allow_list: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.rollout_percentage <= 100:
+            raise ValueError("rollout_percentage must be between 0 and 100")
+
+    def is_enabled_for(self, *, tenant_id: str, tenant_tier: TenantTier) -> bool:
+        """Evaluate the rollout using tenant-safe defaults.
+
+        Rules:
+        - disabled rollout returns False immediately
+        - explicit tenant allow-list overrides all other targeting
+        - tier allow-list gates eligibility before percentage rollout
+        - percentage targeting is deterministic per tenant ID for stable rollout
+        """
+
+        if not self.enabled:
+            return False
+
+        normalized_tenant_id = tenant_id.strip().lower()
+        if normalized_tenant_id in self.tenant_allow_list:
+            return True
+        if self.tier_allow_list and tenant_tier not in self.tier_allow_list:
+            return False
+        if self.rollout_percentage == 0:
+            return False
+        if self.rollout_percentage == 100:
+            return True
+
+        bucket = (
+            int.from_bytes(
+                sha256(normalized_tenant_id.encode("utf-8")).digest()[:4],
+                byteorder="big",
+            )
+            % 100
+        )
+        return bucket < self.rollout_percentage
+
+
+@dataclass(frozen=True)
+class TenantCapabilityPolicy:
+    """AppConfig-backed dynamic capability policy.
+
+    This model is intentionally separate from TenantRecord. TenantRecord remains
+    the source of truth for resource inventory, contractual tenant metadata, and
+    transactional state. Dynamic capability policy uses deny-by-default fallback
+    semantics so a failed AppConfig read does not accidentally enable access.
+    """
+
+    schema_version: str = "2026-03-21"
+    capabilities: dict[str, CapabilityRollout] = field(default_factory=dict)
+    killed_capabilities: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def safe_fallback(cls) -> TenantCapabilityPolicy:
+        """Return the deny-by-default fallback policy used on read failure."""
+
+        return cls()
+
+    def is_enabled(self, capability: str, *, tenant_id: str, tenant_tier: TenantTier) -> bool:
+        normalized_capability = capability.strip().lower()
+        if not normalized_capability:
+            return False
+        if normalized_capability in self.killed_capabilities:
+            return False
+
+        rollout = self.capabilities.get(normalized_capability)
+        if rollout is None:
+            return False
+        return rollout.is_enabled_for(tenant_id=tenant_id, tenant_tier=tenant_tier)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -15,12 +15,17 @@ import time
 
 import pytest
 from data_access.models import (
+    APPCONFIG_DYNAMIC_CAPABILITY_AREAS,
+    DYNAMODB_TENANT_METADATA_AREAS,
     INVOCATION_TTL_SECONDS,
     JITTER_LENGTH,
     JOB_TTL_SECONDS,
     OPS_LOCK_TTL_SECONDS,
     SESSION_TTL_SECONDS,
+    SSM_PLATFORM_PARAMETER_AREAS,
     AgentRecord,
+    CapabilityRollout,
+    ConfigurationStore,
     InvocationMode,
     InvocationRecord,
     InvocationStatus,
@@ -29,10 +34,12 @@ from data_access.models import (
     OpsLockRecord,
     SessionRecord,
     SessionStatus,
+    TenantCapabilityPolicy,
     TenantRecord,
     TenantStatus,
     TenantTier,
     ToolRecord,
+    configuration_store_for,
 )
 
 # ---------------------------------------------------------------------------
@@ -132,6 +139,101 @@ class TestTenantRecord:
         for status in TenantStatus:
             tenant = _make_tenant(status=status)
             assert tenant.status == status
+
+
+class TestConfigurationOwnership:
+    def test_appconfig_owns_dynamic_capability_policy(self):
+        assert configuration_store_for("kill_switches") == ConfigurationStore.APPCONFIG
+        assert configuration_store_for("tool_availability") == ConfigurationStore.APPCONFIG
+
+    def test_ssm_owns_platform_runtime_parameters(self):
+        assert configuration_store_for("runtime_region_parameters") == ConfigurationStore.SSM
+        assert configuration_store_for("appconfig_bootstrap") == ConfigurationStore.SSM
+
+    def test_dynamodb_retains_tenant_metadata_and_state(self):
+        assert configuration_store_for("tenant_resource_inventory") == ConfigurationStore.DYNAMODB
+        assert configuration_store_for("tenant_state") == ConfigurationStore.DYNAMODB
+
+    def test_resource_metadata_not_moved_into_appconfig(self):
+        assert "tenant_resource_inventory" in DYNAMODB_TENANT_METADATA_AREAS
+        assert "tenant_resource_inventory" not in APPCONFIG_DYNAMIC_CAPABILITY_AREAS
+        assert "tenant_resource_inventory" not in SSM_PLATFORM_PARAMETER_AREAS
+
+    def test_unknown_configuration_area_is_rejected(self):
+        with pytest.raises(ValueError):
+            configuration_store_for("surprise_bucket")
+
+
+class TestCapabilityRollout:
+    def test_rejects_invalid_rollout_percentage(self):
+        with pytest.raises(ValueError):
+            CapabilityRollout(enabled=True, rollout_percentage=101)
+
+    def test_disabled_rollout_always_denies(self):
+        rollout = CapabilityRollout(
+            enabled=False,
+            rollout_percentage=100,
+            tenant_allow_list=frozenset({"t-acme"}),
+        )
+        assert not rollout.is_enabled_for(tenant_id="t-acme", tenant_tier=TenantTier.PREMIUM)
+
+    def test_tenant_allow_list_overrides_percentage(self):
+        rollout = CapabilityRollout(
+            enabled=True,
+            rollout_percentage=0,
+            tenant_allow_list=frozenset({"t-acme"}),
+        )
+        assert rollout.is_enabled_for(tenant_id="t-acme", tenant_tier=TenantTier.BASIC)
+
+    def test_tier_allow_list_gates_capability(self):
+        rollout = CapabilityRollout(
+            enabled=True,
+            rollout_percentage=100,
+            tier_allow_list=frozenset({TenantTier.PREMIUM}),
+        )
+        assert rollout.is_enabled_for(tenant_id="t-premium", tenant_tier=TenantTier.PREMIUM)
+        assert not rollout.is_enabled_for(tenant_id="t-basic", tenant_tier=TenantTier.BASIC)
+
+    def test_percentage_targeting_is_deterministic(self):
+        rollout = CapabilityRollout(enabled=True, rollout_percentage=25)
+        first = rollout.is_enabled_for(tenant_id="t-acme", tenant_tier=TenantTier.STANDARD)
+        second = rollout.is_enabled_for(tenant_id="t-acme", tenant_tier=TenantTier.STANDARD)
+        assert first is second
+
+
+class TestTenantCapabilityPolicy:
+    def test_safe_fallback_denies_unknown_capability(self):
+        policy = TenantCapabilityPolicy.safe_fallback()
+        assert not policy.is_enabled(
+            "tools.browser",
+            tenant_id="t-acme",
+            tenant_tier=TenantTier.PREMIUM,
+        )
+
+    def test_kill_switch_overrides_rollout(self):
+        policy = TenantCapabilityPolicy(
+            capabilities={
+                "tools.browser": CapabilityRollout(enabled=True, rollout_percentage=100),
+            },
+            killed_capabilities=frozenset({"tools.browser"}),
+        )
+        assert not policy.is_enabled(
+            "tools.browser",
+            tenant_id="t-acme",
+            tenant_tier=TenantTier.PREMIUM,
+        )
+
+    def test_capability_lookup_is_case_insensitive(self):
+        policy = TenantCapabilityPolicy(
+            capabilities={
+                "models.sonnet": CapabilityRollout(enabled=True, rollout_percentage=100),
+            }
+        )
+        assert policy.is_enabled(
+            "MODELS.SONNET",
+            tenant_id="t-acme",
+            tenant_tier=TenantTier.STANDARD,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #303

## Summary
- add ADR-017 to split tenant capability policy ownership across AppConfig, SSM, and DynamoDB
- document the configuration ownership model in the architecture and README docs
- add typed capability policy models and tests for ownership boundaries, rollout semantics, kill switches, and deny-by-default fallback

## Validation
- `PYTHONPATH=. uv run pytest tests/unit/test_models.py`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

## Notes
- `make validate-local` is currently blocked by an existing CDK synth contract outside this issue scope: `infra/cdk/lib/platform-stack.ts` expects `infra/cdk/cdk.out/platform-tenant-stub-dev.template.json` to exist before synth starts.