### PR TITLE
Implement agent release governance and rollback model

### DIFF
--- a/docs/decisions/ADR-015-agent-release-governance-and-rollback.md
+++ b/docs/decisions/ADR-015-agent-release-governance-and-rollback.md
@@ -1,0 +1,79 @@
+# ADR-015: Agent Release Governance and Rollback Model
+
+## Status: Proposed
+## Date: 2026-03-21
+
+## Context
+Currently, agent registration and rollback are performed by scripts that directly mutate the `platform-agents` DynamoDB table. The current rollback mechanism deletes the "bad" version from the database. 
+
+This model has several weaknesses:
+1.  **Auditability:** Deleting records destroys the audit trail of what was actually running at any given time.
+2.  **Governance:** Direct database access bypasses the Platform API's RBAC and audit logging.
+3.  **Safety:** There is no formal "Pending" state for new versions; registration immediately makes a version "live" if it has the highest semver.
+4.  **Compliance:** Production systems with compliance obligations must maintain immutable records of all software versions deployed.
+
+## Decision
+The platform will adopt a "Status-Based" release governance and rollback model.
+
+### 1. Agent Status Lifecycle
+Every `AgentRecord` in DynamoDB will include a `status` field:
+-   `PENDING`: Version is registered and artifacts are uploaded, but it is not yet invokable by tenants.
+-   `RELEASED`: Version is approved and invokable. The Bridge picks the highest semver version with this status.
+-   `ROLLBACK`: Version has been deactivated due to a reported issue. It is preserved for audit but never invoked.
+-   `DEPRECATED`: Version is old but still invokable if explicitly requested by version (future capability), but not the default.
+
+### 2. Immutability
+Agent versions are immutable. Once a version (e.g., `v1.2.3`) is registered, its associated S3 keys, hashes, and configuration cannot be modified. Only the `status` and governance metadata (`approved_by`, etc.) may change.
+
+### 3. Promotion Workflow
+-   **Registration:** New versions are registered via a Platform API endpoint. In `dev` environments, they may default to `RELEASED`. In `prod`, they must start as `PENDING`.
+-   **Approval:** An authorized operator (`Platform.Admin`) promotes a `PENDING` version to `RELEASED` via a PATCH operation.
+-   **Bridge Resolution:** The Bridge Lambda finds the "active" version by querying the `platform-agents` table for the highest semver where `status = RELEASED`.
+
+### 4. Rollback Mechanism
+Rollback is a "forward" metadata transition:
+1.  The operator identifies the bad version.
+2.  The operator updates the bad version's status to `ROLLBACK`.
+3.  The Bridge immediately stops using that version and falls back to the next-highest `RELEASED` version.
+4.  No records are deleted.
+
+### 5. Platform API Ownership
+Direct DynamoDB mutations for agent lifecycle are deprecated. All registration, promotion, and rollback operations must flow through the `tenant-api` (Northbound API) platform routes, ensuring:
+-   Entra-based RBAC enforcement.
+-   Consistent audit logging in the `platform-invocations` or a dedicated audit bus.
+-   Validation of agent manifests and artifact existence.
+
+## Detailed Rules
+
+### Data Model Updates
+Update `AgentRecord` to include:
+-   `status`: (enum)
+-   `approved_by`: (string) identity of the promoter
+-   `approved_at`: (iso8601)
+-   `release_notes`: (string, optional)
+
+### API Contract
+New routes in `openapi.yaml`:
+-   `POST /v1/platform/agents/register`: Register new version.
+-   `PATCH /v1/platform/agents/{agentName}/versions/{version}`: Update status (Promote/Rollback).
+-   `GET /v1/platform/agents`: List agents with full governance metadata.
+
+## Consequences
+
+### Positive
+-   **Full Audit Trail:** Every version ever deployed remains in the database.
+-   **Compliance:** Meets requirements for controlled releases and non-destructive rollbacks.
+-   **RBAC:** Leverages existing platform roles for release control.
+-   **Safety:** `PENDING` state allows smoke testing before broad release (if the Bridge supports it).
+
+### Negative
+-   **Storage:** Slightly higher DynamoDB storage (negligible for agent metadata).
+-   **Complexity:** Requires Bridge to filter by status.
+-   **Migration:** Existing `scripts/` need to be updated to call APIs instead of DDB.
+
+## Implementation Notes
+1.  Update `data-access-lib` models.
+2.  Update `tenant_api` with new routes.
+3.  Update `bridge` to filter for `status=RELEASED`.
+4.  Update `scripts/register_agent.py` and `scripts/rollback_agent.py`.
+5.  Perform a one-time backfill of `status=RELEASED` for existing agent records.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -770,6 +770,96 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /v1/platform/agents:
+    get:
+      tags: [Platform]
+      operationId: platformListAgents
+      summary: List all agents for operators
+      description: Returns all versions of all agents, including PENDING and ROLLBACK.
+      x-required-roles:
+        - Platform.Admin
+        - Platform.Operator
+      responses:
+        "200":
+          description: All agent versions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AgentRecord"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [Platform]
+      operationId: registerAgentVersion
+      summary: Register a new agent version
+      description: Registers a new version of an agent. Defaults to PENDING status.
+      x-required-roles:
+        - Platform.Admin
+        - Platform.Operator
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentRecord"
+      responses:
+        "201":
+          description: Version registered
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /v1/platform/agents/{agentName}/versions/{version}:
+    patch:
+      tags: [Platform]
+      operationId: updateAgentVersion
+      summary: Update agent version status
+      description: Promotes a version to RELEASED or marks it as ROLLBACK.
+      x-required-roles:
+        - Platform.Admin
+        - Platform.Operator
+      parameters:
+        - $ref: "#/components/parameters/AgentName"
+        - in: path
+          name: version
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  $ref: "#/components/schemas/AgentStatus"
+                releaseNotes:
+                  type: string
+      responses:
+        "200":
+          description: Status updated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /v1/platform/quota:
     get:
       tags: [Platform]
@@ -1108,6 +1198,9 @@ components:
     JobStatus:
       type: string
       enum: [pending, running, completed, failed]
+    AgentStatus:
+      type: string
+      enum: [pending, released, rollback, deprecated]
     SessionState:
       type: string
       enum: [active, completed, expired]
@@ -1218,6 +1311,53 @@ components:
                     $ref: "#/components/schemas/InvocationMode"
                   streamingEnabled:
                     type: boolean
+
+    AgentRecord:
+      type: object
+      required:
+        - agentName
+        - version
+        - ownerTeam
+        - tierMinimum
+        - layerHash
+        - layerS3Key
+        - scriptS3Key
+        - deployedAt
+        - invocationMode
+        - streamingEnabled
+      properties:
+        agentName:
+          type: string
+        version:
+          type: string
+        ownerTeam:
+          type: string
+        tierMinimum:
+          $ref: "#/components/schemas/TenantTier"
+        layerHash:
+          type: string
+        layerS3Key:
+          type: string
+        scriptS3Key:
+          type: string
+        deployedAt:
+          $ref: "#/components/schemas/UtcTimestamp"
+        invocationMode:
+          $ref: "#/components/schemas/InvocationMode"
+        streamingEnabled:
+          type: boolean
+        status:
+          $ref: "#/components/schemas/AgentStatus"
+        approvedBy:
+          type: string
+        approvedAt:
+          $ref: "#/components/schemas/UtcTimestamp"
+        releaseNotes:
+          type: string
+        runtimeArn:
+          type: string
+        estimatedDurationSeconds:
+          type: integer
 
     AgentInvokeRequest:
       type: object

--- a/docs/operations/RUNBOOK-007-deployment-rollback.md
+++ b/docs/operations/RUNBOOK-007-deployment-rollback.md
@@ -1,5 +1,18 @@
 # RUNBOOK-007: Deployment Rollback
 
+## Normal Agent Promotion
+Agent promotion is a control-plane metadata change against an already registered
+version. Do not rebuild or repackage the agent as part of promotion.
+
+1. Register the candidate version. In `prod` it must remain `pending`.
+2. Verify staging/integration evidence and evaluation results for that exact version.
+3. Promote the version to `released`.
+4. Record release notes or ticket evidence with the promotion action.
+
+Operational rule:
+- Promotion changes agent status metadata only. The active default version is the
+  highest `released` semver in the agent registry.
+
 ## Auto-Rollback (handled by pipeline)
 The canary deployment monitors error_rate_high alarm. If it fires within 30 minutes
 of a deployment, the Lambda alias automatically rolls back to the previous version.
@@ -33,9 +46,14 @@ npx cdk deploy --all --context env=prod --rollback
 ## Agent Rollback
 ```bash
 make agent-rollback AGENT={agentName} ENV=prod
-# Redeploys the previous agent version from the platform-agents DynamoDB registry
-# Does not require a pipeline run
+# Marks the current released version as rollback and re-points runtime metadata
+# to the next-highest released version in the agent registry
+# Does not require a rebuild or pipeline run
 ```
+
+Operational rule:
+- Never delete a bad agent version from the registry. Rollback is a forward metadata
+  transition that preserves audit history.
 
 ## Post-Rollback
 1. Verify error rate is recovering: make ops-error-rate ENV=prod MINUTES=5

--- a/scripts/backfill_agent_status.py
+++ b/scripts/backfill_agent_status.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Backfill agent status to RELEASED for existing records (ADR-015)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+from botocore.exceptions import ClientError
+
+DEFAULT_TABLE_NAME = "platform-agents"
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _scan_agent_rows(table: Any) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    scan_kwargs: dict[str, Any] = {}
+    while True:
+        response = table.scan(**scan_kwargs)
+        for item in response.get("Items", []):
+            if not isinstance(item, dict):
+                continue
+            rows.append(item)
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+        scan_kwargs["ExclusiveStartKey"] = last_evaluated_key
+    return rows
+
+
+def _apply_backfill(table: Any, *, item: dict[str, Any]) -> None:
+    table.update_item(
+        Key={"PK": item["PK"], "SK": item["SK"]},
+        UpdateExpression="SET #s = :s, #ua = :ua",
+        ExpressionAttributeNames={"#s": "status", "#ua": "updated_at"},
+        ExpressionAttributeValues={
+            ":s": "released",
+            ":ua": _utc_now(),
+        },
+        ConditionExpression=(
+            "attribute_exists(PK) AND attribute_exists(SK) AND attribute_not_exists(#s)"
+        ),
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    region = args.region or os.environ.get("AWS_REGION")
+    if not region:
+        print("AWS region is required. Set AWS_REGION or pass --region.")
+        return 2
+
+    session = boto3.session.Session(region_name=region)
+    ddb = session.resource("dynamodb")
+    table = ddb.Table(args.table_name)
+
+    rows = _scan_agent_rows(table)
+    if not rows:
+        print("No agent rows found")
+        return 0
+
+    to_backfill = [r for r in rows if "status" not in r]
+    print(f"Found {len(rows)} agent records, {len(to_backfill)} need backfill.")
+
+    if not to_backfill:
+        return 0
+
+    backfilled = 0
+    for row in to_backfill:
+        agent_name = row.get("agent_name", "unknown")
+        version = row.get("version", "unknown")
+        if args.apply:
+            try:
+                _apply_backfill(table, item=row)
+                backfilled += 1
+                print(f"[backfilled] agent={agent_name} version={version}")
+            except ClientError as e:
+                print(f"[failed] agent={agent_name} version={version} error={e}")
+        else:
+            print(f"[ready] agent={agent_name} version={version}")
+
+    print(f"Summary: scanned={len(rows)} to_backfill={len(to_backfill)} backfilled={backfilled}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill agent status.")
+    parser.add_argument("--region", help="AWS region")
+    parser.add_argument("--table-name", default=DEFAULT_TABLE_NAME, help="Agent table name")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write back status=released to agent records. Default is verify-only mode.",
+    )
+    args = parser.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/promote_agent.py
+++ b/scripts/promote_agent.py
@@ -1,0 +1,126 @@
+"""
+promote_agent.py — Promote an agent version to RELEASED status.
+
+Usage:
+    uv run python scripts/promote_agent.py <agent_name> <version> --env <env>
+    [--notes "Release notes"]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger("promote_agent")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def _semver_sort_key(version: str) -> tuple[int, ...]:
+    parts = version.split(".")
+    key: list[int] = []
+    for part in parts:
+        digits = "".join(ch for ch in part if ch.isdigit())
+        key.append(int(digits) if digits else 0)
+    return tuple(key)
+
+
+def require_aws_region() -> str:
+    region = os.environ.get("AWS_REGION", "").strip()
+    if not region:
+        raise RuntimeError("AWS_REGION must be set")
+    return region
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Promote agent version")
+    parser.add_argument("agent_name", help="Name of the agent")
+    parser.add_argument("version", help="Version to promote (semver)")
+    parser.add_argument("--env", required=True, choices=["dev", "staging", "prod"])
+    parser.add_argument("--notes", help="Release notes")
+    return parser.parse_args()
+
+
+def promote_agent(agent_name: str, version: str, env: str, notes: str | None) -> bool:
+    aws_region = require_aws_region()
+    dynamodb = boto3.resource("dynamodb", region_name=aws_region)
+    table = dynamodb.Table("platform-agents")
+
+    key = {"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{version}"}
+
+    logger.info(f"Promoting agent '{agent_name}' v{version} to RELEASED in {env}")
+
+    try:
+        # Check if version exists
+        response = table.get_item(Key=key)
+        if "Item" not in response:
+            logger.error(f"Agent version {agent_name}:{version} not found in registry.")
+            return False
+
+        item = response["Item"]
+        current_status = item.get("status", "released")
+        if current_status == "released":
+            logger.info(f"Agent version {agent_name}:{version} is already RELEASED.")
+            return True
+
+        # Update status
+        attrs = {
+            "status": "released",
+            "updated_at": datetime.now(UTC).isoformat(),
+            "approved_by": os.environ.get("USER", "cli-operator"),
+            "approved_at": datetime.now(UTC).isoformat(),
+        }
+        if notes:
+            attrs["release_notes"] = notes
+
+        update_parts = []
+        names = {}
+        values = {}
+        for i, (k, v) in enumerate(attrs.items()):
+            n = f"#n{i}"
+            val = f":v{i}"
+            update_parts.append(f"{n} = {val}")
+            names[n] = k
+            values[val] = v
+
+        table.update_item(
+            Key=key,
+            UpdateExpression="SET " + ", ".join(update_parts),
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+
+        versions = table.query(KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"))
+        released_versions = [
+            str(item.get("version", ""))
+            for item in versions.get("Items", [])
+            if item.get("status", "released") == "released"
+        ]
+        latest_released_version = max(released_versions, key=_semver_sort_key, default=version)
+
+        ssm = boto3.client("ssm", region_name=aws_region)
+        ssm.put_parameter(
+            Name=f"/platform/agents/{env}/{agent_name}/latest-version",
+            Value=latest_released_version,
+            Type="String",
+            Overwrite=True,
+        )
+
+    except ClientError as e:
+        logger.error(f"Failed to update DynamoDB or SSM: {e}")
+        return False
+
+    logger.info(f"Agent '{agent_name}' v{version} promoted successfully")
+    return True
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if not promote_agent(args.agent_name, args.version, args.env, args.notes):
+        sys.exit(1)

--- a/scripts/register_agent.py
+++ b/scripts/register_agent.py
@@ -1,5 +1,5 @@
 """
-register_agent.py — Register or update agent in the platform registry.
+register_agent.py — Register an immutable agent version in the platform registry.
 
 Writes agent metadata to DynamoDB platform-agents table and SSM.
 Reads [tool.agentcore] manifest from agent's pyproject.toml.
@@ -76,6 +76,9 @@ def register_agent(agent_name: str, env: str) -> bool:
 
     deployed_at = datetime.datetime.now(datetime.UTC).isoformat()
 
+    # Default status: PENDING for prod (requires approval), RELEASED for others
+    default_status = "pending" if env == "prod" else "released"
+
     # Get Runtime ARN from SSM if it exists (set by infra or previous deployment)
     runtime_arn = get_ssm_param(ssm, f"/platform/agents/{env}/{agent_name}/runtime-arn")
 
@@ -92,6 +95,7 @@ def register_agent(agent_name: str, env: str) -> bool:
         "deployed_at": deployed_at,
         "invocation_mode": manifest.get("invocation_mode", "sync"),
         "streaming_enabled": manifest.get("streaming_enabled", False),
+        "status": default_status,
         "runtime_arn": runtime_arn,
         "estimated_duration_seconds": manifest.get("estimated_duration_seconds", 5),
     }
@@ -102,14 +106,17 @@ def register_agent(agent_name: str, env: str) -> bool:
 
     logger.info(f"Registering agent '{agent_name}' v{version} in DynamoDB table '{table_name}'")
     try:
-        table.put_item(Item=item)
-        # Update latest-version in SSM
-        ssm.put_parameter(
-            Name=f"/platform/agents/{env}/{agent_name}/latest-version",
-            Value=version,
-            Type="String",
-            Overwrite=True,
+        table.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
         )
+        if default_status == "released":
+            ssm.put_parameter(
+                Name=f"/platform/agents/{env}/{agent_name}/latest-version",
+                Value=version,
+                Type="String",
+                Overwrite=True,
+            )
     except ClientError as e:
         logger.error(f"Failed to write to DynamoDB or SSM: {e}")
         return False

--- a/scripts/rollback_agent.py
+++ b/scripts/rollback_agent.py
@@ -32,6 +32,15 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _semver_sort_key(version: str) -> tuple[int, ...]:
+    parts = version.split(".")
+    key: list[int] = []
+    for part in parts:
+        digits = "".join(ch for ch in part if ch.isdigit())
+        key.append(int(digits) if digits else 0)
+    return tuple(key)
+
+
 def require_aws_region() -> str:
     region = os.environ.get("AWS_REGION", "").strip()
     if not region:
@@ -53,10 +62,7 @@ def get_agent_versions(table, agent_name: str) -> list[dict]:
             KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"),
             ScanIndexForward=False,  # Highest version SK first
         )
-        items = response.get("Items", [])
-        return sorted(
-            items, key=lambda x: (x.get("deployed_at", ""), x.get("version", "")), reverse=True
-        )
+        return response.get("Items", [])
     except ClientError as e:
         logger.error(f"Failed to query DynamoDB: {e}")
         return []
@@ -68,17 +74,36 @@ def rollback_agent(agent_name: str, env: str) -> bool:
     table = dynamodb.Table("platform-agents")
 
     versions = get_agent_versions(table, agent_name)
-    if len(versions) < 2:
-        logger.error(f"Rollback failed: No previous version found for agent '{agent_name}'.")
+    if not versions:
+        logger.error(f"No versions found for agent '{agent_name}'.")
         return False
 
-    current_version = versions[0]
-    previous_version = versions[1]
+    # 1. Identify current version (latest RELEASED one)
+    released_versions = [v for v in versions if v.get("status", "released") == "released"]
+    if not released_versions:
+        logger.error(f"No RELEASED versions found for agent '{agent_name}'.")
+        return False
+
+    released_versions.sort(
+        key=lambda item: _semver_sort_key(str(item.get("version", ""))),
+        reverse=True,
+    )
+    current_version = released_versions[0]
+
+    # 2. Identify previous RELEASED version
+    if len(released_versions) < 2:
+        logger.error(
+            f"Rollback failed: No previous RELEASED version found for agent '{agent_name}'. "
+            f"Current version is {current_version['version']}."
+        )
+        return False
+
+    previous_version = released_versions[1]
 
     logger.info(
         f"Rolling back agent '{agent_name}' from v{current_version['version']} "
-        f"(deployed {current_version.get('deployed_at')}) to v{previous_version['version']} "
-        f"(deployed {previous_version.get('deployed_at')})"
+        f"to v{previous_version['version']} "
+        f"(previously released at {previous_version.get('deployed_at')})"
     )
 
     bucket = resolve_layer_bucket(env, aws_region)
@@ -89,10 +114,10 @@ def rollback_agent(agent_name: str, env: str) -> bool:
 
     ssm = boto3.client("ssm", region_name=aws_region)
 
-    # 1. Update AgentCore Runtime
+    # 3. Update AgentCore Runtime (Point back to old artifacts)
     try:
         acore = boto3.client("bedrock-agentcore", region_name=aws_region)
-        logger.info(f"Updating AgentCore Runtime for '{agent_name}' to previous artifacts")
+        logger.info(f"Updating AgentCore Runtime for '{agent_name}' to artifacts from v{version}")
         response = acore.update_agent_code(
             agentName=agent_name,
             code={
@@ -114,8 +139,8 @@ def rollback_agent(agent_name: str, env: str) -> bool:
         if os.environ.get("CI"):
             logger.info("Continuing anyway because CI is set")
 
-    # 2. Update SSM Registry
-    logger.info("Updating SSM registry to previous version artifacts")
+    # 4. Update SSM Registry
+    logger.info("Updating SSM registry parameters")
     ssm_updates = {
         f"/platform/agents/{env}/{agent_name}/latest-version": version,
         f"/platform/agents/{env}/{agent_name}/script-s3-key": script_key,
@@ -130,12 +155,21 @@ def rollback_agent(agent_name: str, env: str) -> bool:
             logger.error(f"Failed to update SSM parameter {name}: {e}")
             return False
 
-    # 3. Delete the rolled-back version from DynamoDB
-    logger.info(f"Deleting rolled-back version v{current_version['version']} from DynamoDB")
+    # 5. Mark the bad version as ROLLBACK in DynamoDB
+    logger.info(f"Marking v{current_version['version']} as ROLLBACK in DynamoDB")
     try:
-        table.delete_item(Key={"PK": current_version["PK"], "SK": current_version["SK"]})
+        table.update_item(
+            Key={"PK": current_version["PK"], "SK": current_version["SK"]},
+            UpdateExpression="SET #s = :s, #ua = :ua, #rb = :rb",
+            ExpressionAttributeNames={"#s": "status", "#ua": "updated_at", "#rb": "rolled_back_by"},
+            ExpressionAttributeValues={
+                ":s": "rollback",
+                ":ua": datetime.now(UTC).isoformat(),
+                ":rb": "cli-operator",  # In a script, we don't always have the sub
+            },
+        )
     except ClientError as e:
-        logger.error(f"Failed to delete bad version from DynamoDB: {e}")
+        logger.error(f"Failed to update version status in DynamoDB: {e}")
         return False
 
     logger.info(f"Agent '{agent_name}' successfully rolled back to v{version}")

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -33,6 +33,7 @@ from botocore.exceptions import (
 from data_access import TenantScopedDynamoDB, TenantScopedS3
 from data_access.models import (
     AgentRecord,
+    AgentStatus,
     InvocationMode,
     InvocationRecord,
     InvocationStatus,
@@ -309,19 +310,30 @@ def get_agent_record(agent_name: str, version: str | None = None) -> AgentRecord
         table = ddb.Table(AGENTS_TABLE)
 
         if not version:
-            # Query for latest version
+            # Query for latest versions and find the highest semver that is RELEASED
             response = table.query(
                 KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"),
-                ScanIndexForward=False,
-                Limit=1,
+                ScanIndexForward=False,  # Highest version SK first
             )
             items = response.get("Items", [])
             if not items:
                 return None
-            item = items[0]
+
+            released_items = [i for i in items if i.get("status", "released") == "released"]
+            item = max(released_items, key=_agent_record_sort_key, default=None)
         else:
             response = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{version}"})
             item = response.get("Item")
+            if item and item.get("status", "released") != "released":
+                logger.warning(
+                    "Requested agent version is not RELEASED",
+                    extra={
+                        "agent_name": agent_name,
+                        "version": version,
+                        "status": item.get("status"),
+                    },
+                )
+                return None
 
         if not item:
             return None
@@ -337,6 +349,10 @@ def get_agent_record(agent_name: str, version: str | None = None) -> AgentRecord
             deployed_at=str(item["deployed_at"]),
             invocation_mode=InvocationMode(str(item["invocation_mode"])),
             streaming_enabled=bool(item.get("streaming_enabled", False)),
+            status=AgentStatus(str(item.get("status", "released"))),
+            approved_by=_coerce_optional_string(item.get("approved_by")),
+            approved_at=_coerce_optional_string(item.get("approved_at")),
+            release_notes=_coerce_optional_string(item.get("release_notes")),
             runtime_arn=str(item["runtime_arn"]) if item.get("runtime_arn") else None,
             estimated_duration_seconds=int(item["estimated_duration_seconds"])  # type: ignore
             if item.get("estimated_duration_seconds")
@@ -930,11 +946,23 @@ def _agent_summary_from_item(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def _is_newer_agent_record(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
-    candidate_deployed_at = str(candidate.get("deployed_at", ""))
-    current_deployed_at = str(current.get("deployed_at", ""))
-    if candidate_deployed_at != current_deployed_at:
-        return candidate_deployed_at > current_deployed_at
-    return str(candidate.get("version", "")) > str(current.get("version", ""))
+    return _agent_record_sort_key(candidate) > _agent_record_sort_key(current)
+
+
+def _semver_sort_key(version: str) -> tuple[int, ...]:
+    parts = version.split(".")
+    key: list[int] = []
+    for part in parts:
+        digits = "".join(ch for ch in part if ch.isdigit())
+        key.append(int(digits) if digits else 0)
+    return tuple(key)
+
+
+def _agent_record_sort_key(item: dict[str, Any]) -> tuple[tuple[int, ...], str]:
+    return (
+        _semver_sort_key(str(item.get("version", ""))),
+        str(item.get("deployed_at", "")),
+    )
 
 
 def list_agents(tenant_context: TenantContext) -> dict[str, Any]:
@@ -943,6 +971,10 @@ def list_agents(tenant_context: TenantContext) -> dict[str, Any]:
 
     latest_by_name: dict[str, dict[str, Any]] = {}
     for item in items:
+        # Filter: only RELEASED agents are visible/invokable
+        if item.get("status", "released") != "released":
+            continue
+
         agent_name = _coerce_optional_string(item.get("agent_name"))
         if agent_name is None:
             continue
@@ -981,14 +1013,13 @@ def get_agent_detail(path_params: dict[str, Any], request_id: str) -> dict[str, 
     table = ddb.Table(AGENTS_TABLE)
     response = table.query(KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"))
     items = response.get("Items", [])
-    if not items:
+
+    # Filter: only RELEASED versions are visible to tenants
+    released_items = [i for i in items if i.get("status", "released") == "released"]
+    if not released_items:
         return error_response(404, "NOT_FOUND", f"Agent '{agent_name}' not found", request_id)
 
-    sorted_items = sorted(
-        items,
-        key=lambda item: (str(item.get("deployed_at", "")), str(item.get("version", ""))),
-        reverse=True,
-    )
+    sorted_items = sorted(released_items, key=_agent_record_sort_key, reverse=True)
     latest = sorted_items[0]
     detail = _agent_summary_from_item(latest)
     detail["versions"] = [

--- a/src/data-access-lib/src/data_access/client.py
+++ b/src/data-access-lib/src/data_access/client.py
@@ -155,11 +155,20 @@ class TenantScopedDynamoDB:
         response = table.get_item(Key=key)
         return response.get("Item")
 
-    def put_item(self, table_name: str, item: dict[str, Any]) -> None:
+    def put_item(
+        self,
+        table_name: str,
+        item: dict[str, Any],
+        *,
+        condition_expression: str | None = None,
+    ) -> None:
         """Write an item, enforcing tenant partition on PK."""
         self._validate_pk(item)
         table = self._dynamodb.Table(table_name)
-        table.put_item(Item=item)
+        kwargs: dict[str, Any] = {"Item": item}
+        if condition_expression:
+            kwargs["ConditionExpression"] = condition_expression
+        table.put_item(**kwargs)
 
     def update_item(
         self,

--- a/src/data-access-lib/src/data_access/models.py
+++ b/src/data-access-lib/src/data_access/models.py
@@ -83,6 +83,13 @@ class WebhookStatus(StrEnum):
     DISABLED = "disabled"
 
 
+class AgentStatus(StrEnum):
+    PENDING = "pending"
+    RELEASED = "released"
+    ROLLBACK = "rollback"
+    DEPRECATED = "deprecated"
+
+
 class InviteStatus(StrEnum):
     PENDING = "pending"
     ACCEPTED = "accepted"
@@ -145,6 +152,7 @@ class AgentRecord:
 
     tier_minimum: the lowest tenant tier that may invoke this agent.
     invocation_mode: declared in pyproject.toml, never inferred at runtime.
+    status: release state (ADR-015).
     """
 
     agent_name: str
@@ -157,6 +165,10 @@ class AgentRecord:
     deployed_at: str  # ISO 8601 UTC
     invocation_mode: InvocationMode
     streaming_enabled: bool
+    status: AgentStatus = AgentStatus.RELEASED
+    approved_by: str | None = None
+    approved_at: str | None = None
+    release_notes: str | None = None
     runtime_arn: str | None = None
     estimated_duration_seconds: int | None = None
 

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -26,11 +26,12 @@ from aws_lambda_powertools import Logger
 from boto3.dynamodb.conditions import ConditionBase, Key
 from botocore.exceptions import ClientError
 from data_access import TenantContext, TenantScopedDynamoDB, TenantScopedS3
-from data_access.models import TenantStatus, TenantTier
+from data_access.models import AgentStatus, TenantStatus, TenantTier
 
 logger = Logger(service="tenant-api")
 
 _TENANTS_TABLE_ENV = "TENANTS_TABLE_NAME"
+_AGENTS_TABLE_ENV = "AGENTS_TABLE_NAME"
 _INVOCATIONS_TABLE_ENV = "INVOCATIONS_TABLE_NAME"
 _EVENT_BUS_ENV = "EVENT_BUS_NAME"
 _AUDIT_EXPORT_BUCKET_ENV = "AUDIT_EXPORT_BUCKET"
@@ -42,6 +43,13 @@ _FAILOVER_LOCK_NAME_ENV = "FAILOVER_LOCK_NAME"
 _DELETE_RETENTION_DAYS = 30
 _ADMIN_ROLES = {"Platform.Admin"}
 _SELF_SERVICE_ADMIN_ROLES = {"Platform.Admin", "Platform.Operator", "SelfService.Admin"}
+_REGISTERABLE_AGENT_STATUSES = {AgentStatus.PENDING, AgentStatus.RELEASED}
+_ALLOWED_AGENT_STATUS_TRANSITIONS: dict[AgentStatus, set[AgentStatus]] = {
+    AgentStatus.PENDING: {AgentStatus.RELEASED, AgentStatus.ROLLBACK},
+    AgentStatus.RELEASED: {AgentStatus.ROLLBACK, AgentStatus.DEPRECATED},
+    AgentStatus.DEPRECATED: {AgentStatus.RELEASED, AgentStatus.ROLLBACK},
+    AgentStatus.ROLLBACK: set(),
+}
 _ALLOWED_TENANT_INVITE_ROLES = {"Agent.Invoke"}
 _INVITE_EXPIRY_DAYS = 7
 _AUDIT_EXPORT_PREFIX = "audit-exports"
@@ -310,6 +318,10 @@ def _invocations_table_name() -> str:
     return os.environ.get(_INVOCATIONS_TABLE_ENV, "platform-invocations")
 
 
+def _agents_table_name() -> str:
+    return os.environ.get(_AGENTS_TABLE_ENV, "platform-agents")
+
+
 def _event_bus_name() -> str:
     return os.environ.get(_EVENT_BUS_ENV, "default")
 
@@ -514,6 +526,40 @@ def _normalize_status(value: Any) -> str:
         raise ValueError("status must be one of: active, suspended, deleted") from exc
 
 
+def _normalize_agent_status(value: Any) -> AgentStatus:
+    status_text = _str_or_none(value)
+    if status_text is None:
+        raise ValueError("status is required")
+    try:
+        return AgentStatus(status_text.lower())
+    except ValueError as exc:
+        allowed = ", ".join(status.value for status in AgentStatus)
+        raise ValueError(f"status must be one of: {allowed}") from exc
+
+
+def _agent_event_detail_type(status: AgentStatus) -> str | None:
+    if status is AgentStatus.RELEASED:
+        return "platform.agent_version.promoted"
+    if status is AgentStatus.ROLLBACK:
+        return "platform.agent_version.rolled_back"
+    return None
+
+
+def _validate_agent_status_transition(
+    current_status: AgentStatus,
+    new_status: AgentStatus,
+) -> None:
+    if new_status == current_status:
+        return
+    allowed = _ALLOWED_AGENT_STATUS_TRANSITIONS.get(current_status, set())
+    if new_status not in allowed:
+        allowed_text = ", ".join(status.value for status in sorted(allowed, key=lambda s: s.value))
+        raise ValueError(
+            f"Invalid agent status transition: {current_status.value} -> {new_status.value}. "
+            f"Allowed transitions: {allowed_text or 'none'}"
+        )
+
+
 def _as_float(value: Any, *, field: str) -> float:
     if isinstance(value, bool):
         raise ValueError(f"{field} must be a number")
@@ -564,7 +610,10 @@ def _read_tenant_record(
     return db.get_item(_tenants_table_name(), _tenant_key(tenant_id))
 
 
-def _read_failover_lock_record(caller: CallerIdentity) -> dict[str, Any] | None:
+def _read_failover_lock_record(
+    caller: CallerIdentity, deps: TenantApiDependencies
+) -> dict[str, Any] | None:
+    _ = deps
     db = _control_plane_db(caller)
     return db.get_item(
         _ops_locks_table_name(),
@@ -1461,7 +1510,7 @@ def _handle_platform_failover(
     if not target_region or not lock_id:
         raise ValueError("targetRegion and lockId are required")
 
-    lock_record = _read_failover_lock_record(caller)
+    lock_record = _read_failover_lock_record(caller, deps)
     if lock_record is None:
         logger.warning(
             "Platform failover rejected: lock missing",
@@ -1701,6 +1750,7 @@ def _handle_platform_billing_status(
     year_month = datetime.now(UTC).strftime("%Y-%m")
 
     # Use data-access-lib for admin scan
+    _ = deps
     db = _control_plane_db(caller)
     summaries = db.scan_all(
         _tenants_table_name(),
@@ -1986,6 +2036,168 @@ def _handle_ops_lambda_rollback(
         return _error(500, "INTERNAL_ERROR", f"AWS Error: {code}")
 
 
+def _handle_platform_list_agents(
+    event: dict[str, Any],
+    caller: CallerIdentity,
+    deps: TenantApiDependencies,
+) -> dict[str, Any]:
+    _ = event
+    _ = deps
+    _require_admin(caller)
+    db = _control_plane_db(caller)
+    items = db.scan_all(_agents_table_name())
+    # Return all versions of all agents for operator review
+    return _response(200, {"items": items})
+
+
+def _handle_platform_register_agent(
+    event: dict[str, Any],
+    caller: CallerIdentity,
+    deps: TenantApiDependencies,
+) -> dict[str, Any]:
+    _require_admin(caller)
+    body = _require_json_body(event)
+
+    agent_name = _str_or_none(body.get("agentName"))
+    version = _str_or_none(body.get("version"))
+
+    if not agent_name or not version:
+        raise ValueError("agentName and version are required")
+
+    # In prod, new versions must be PENDING. In dev, they may default to RELEASED.
+    current_fn = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "platform-tenant-api-dev")
+    env = current_fn.split("-")[-1]
+
+    default_status = AgentStatus.PENDING if env == "prod" else AgentStatus.RELEASED
+    status = (
+        default_status
+        if body.get("status") is None
+        else _normalize_agent_status(body.get("status"))
+    )
+    if status not in _REGISTERABLE_AGENT_STATUSES:
+        raise ValueError("New agent versions may only be registered as pending or released")
+    if env == "prod" and status is not AgentStatus.PENDING:
+        raise ValueError("Production agent registration must start as pending")
+
+    approved_at = _iso(_now_utc())
+
+    item = {
+        "PK": f"AGENT#{agent_name}",
+        "SK": f"VERSION#{version}",
+        "agent_name": agent_name,
+        "version": version,
+        "owner_team": str(body.get("ownerTeam", "unknown")),
+        "tier_minimum": str(body.get("tierMinimum", "basic")),
+        "layer_hash": str(body.get("layerHash", "")),
+        "layer_s3_key": str(body.get("layerS3Key", "")),
+        "script_s3_key": str(body.get("scriptS3Key", "")),
+        "deployed_at": str(body.get("deployedAt", _iso(_now_utc()))),
+        "invocation_mode": str(body.get("invocationMode", "sync")),
+        "streaming_enabled": bool(body.get("streamingEnabled", False)),
+        "status": status.value,
+        "runtime_arn": _str_or_none(body.get("runtimeArn")),
+        "estimated_duration_seconds": _coerce_positive_int(
+            body.get("estimatedDurationSeconds"), default=0
+        ),
+    }
+    if status is AgentStatus.RELEASED:
+        item["approved_by"] = caller.sub
+        item["approved_at"] = approved_at
+    if body.get("releaseNotes"):
+        item["release_notes"] = str(body["releaseNotes"])
+
+    _ = deps
+    db = _control_plane_db(caller)
+    try:
+        db.put_item(
+            _agents_table_name(),
+            item,
+            condition_expression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+        )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return _error(
+                409,
+                "CONFLICT",
+                f"Agent version {agent_name}:{version} already registered",
+            )
+        raise
+
+    return _response(201, {"status": "registered", "agentName": agent_name, "version": version})
+
+
+def _handle_platform_update_agent_version(
+    event: dict[str, Any],
+    caller: CallerIdentity,
+    deps: TenantApiDependencies,
+    agent_name: str,
+    version: str,
+) -> dict[str, Any]:
+    _require_admin(caller)
+    body = _require_json_body(event)
+
+    new_status = _str_or_none(body.get("status"))
+    if not new_status:
+        raise ValueError("status is required")
+
+    new_agent_status = _normalize_agent_status(new_status)
+    db = _control_plane_db(caller)
+    key = {"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{version}"}
+
+    existing = db.get_item(_agents_table_name(), key)
+    if not existing:
+        return _error(404, "NOT_FOUND", f"Agent version {agent_name}:{version} not found")
+
+    current_status = AgentStatus(str(existing.get("status", AgentStatus.RELEASED.value)))
+    _validate_agent_status_transition(current_status, new_agent_status)
+
+    attrs: dict[str, Any] = {
+        "status": new_agent_status.value,
+        "updated_at": _iso(_now_utc()),
+    }
+    if new_agent_status is AgentStatus.RELEASED:
+        attrs["approved_by"] = caller.sub
+        attrs["approved_at"] = _iso(_now_utc())
+    if body.get("releaseNotes") is not None:
+        attrs["release_notes"] = str(body["releaseNotes"])
+
+    update_expression, expr_names, expr_values = _build_update_expression(attrs)
+    db.update_item(
+        _agents_table_name(),
+        key=key,
+        update_expression=update_expression,
+        expression_attribute_values=expr_values,
+        expression_attribute_names=expr_names,
+        condition_expression="attribute_exists(PK) AND attribute_exists(SK)",
+    )
+
+    detail_type = _agent_event_detail_type(new_agent_status)
+    if detail_type is not None and new_agent_status != current_status:
+        _put_event(
+            deps,
+            detail_type=detail_type,
+            detail={
+                "agentName": agent_name,
+                "version": version,
+                "previousStatus": current_status.value,
+                "status": new_agent_status.value,
+                "approvedBy": caller.sub,
+                "approvedAt": attrs.get("approved_at"),
+                "releaseNotes": attrs.get("release_notes"),
+            },
+        )
+
+    return _response(
+        200,
+        {
+            "status": "updated",
+            "agentName": agent_name,
+            "version": version,
+            "newStatus": new_agent_status.value,
+        },
+    )
+
+
 def _handle_ops_page_security(
     event: dict[str, Any],
     caller: CallerIdentity,
@@ -2019,6 +2231,22 @@ def _dispatch_platform_routes(
         return _handle_platform_service_health(caller, deps)
     if path == "/v1/platform/billing/status" and method == "GET":
         return _handle_platform_billing_status(caller, deps)
+
+    if path == "/v1/platform/agents" and method == "GET":
+        return _handle_platform_list_agents(event, caller, deps)
+    if path == "/v1/platform/agents" and method == "POST":
+        return _handle_platform_register_agent(event, caller, deps)
+
+    if path.startswith("/v1/platform/agents/") and method == "PATCH":
+        # Expected: /v1/platform/agents/{agentName}/versions/{version} (len 7)
+        parts = path.split("/")
+        if len(parts) == 7 and parts[5].lower() == "versions":
+            agent_name = parts[4]
+            version = parts[6]
+            return _handle_platform_update_agent_version(
+                event, caller, deps, agent_name=agent_name, version=version
+            )
+
     return None
 
 

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -300,6 +300,86 @@ def test_get_agent_detail_returns_latest_version_and_versions(setup_data):
     assert body["versions"][0]["version"] == "1.1.0"
 
 
+def test_list_agents_ignores_pending_version_when_newer_semver_exists(setup_data):
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    table = ddb.Table("platform-agents")
+    table.put_item(
+        Item={
+            "PK": "AGENT#echo-agent",
+            "SK": "VERSION#1.2.0",
+            "agent_name": "echo-agent",
+            "version": "1.2.0",
+            "owner_team": "platform-test",
+            "tier_minimum": "basic",
+            "layer_hash": "3333",
+            "layer_s3_key": "k4",
+            "script_s3_key": "s4",
+            "deployed_at": "2026-01-04T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+            "status": "pending",
+        }
+    )
+
+    event = {
+        "httpMethod": "GET",
+        "path": "/v1/agents",
+        "pathParameters": {},
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+    }
+
+    response = handler(event, FakeLambdaContext())
+    body = json.loads(response["body"])
+    assert body["items"][0]["latestVersion"] == "1.0.0"
+
+
+def test_get_agent_detail_prefers_highest_released_semver(setup_data):
+    ddb = boto3.resource("dynamodb", region_name="eu-west-2")
+    table = ddb.Table("platform-agents")
+    table.put_item(
+        Item={
+            "PK": "AGENT#echo-agent",
+            "SK": "VERSION#1.10.0",
+            "agent_name": "echo-agent",
+            "version": "1.10.0",
+            "owner_team": "platform-test",
+            "tier_minimum": "basic",
+            "layer_hash": "1010",
+            "layer_s3_key": "k10",
+            "script_s3_key": "s10",
+            "deployed_at": "2026-01-02T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+            "status": "released",
+        }
+    )
+
+    event = {
+        "httpMethod": "GET",
+        "path": "/v1/agents/echo-agent",
+        "pathParameters": {"agentName": "echo-agent"},
+        "requestContext": {
+            "authorizer": {
+                "tenantid": "t-001",
+                "appid": "app-001",
+                "tier": "basic",
+                "sub": "user-1",
+            }
+        },
+    }
+
+    response = handler(event, FakeLambdaContext())
+    body = json.loads(response["body"])
+    assert body["latestVersion"] == "1.10.0"
+
+
 def test_handler_rejects_legacy_invoke_route(setup_data):
     event = {
         "path": "/v1/invoke",

--- a/tests/unit/test_rollback_agent.py
+++ b/tests/unit/test_rollback_agent.py
@@ -110,13 +110,15 @@ def test_rollback_agent_success(tmp_path, monkeypatch):
     success = rollback_agent.rollback_agent(agent_name, env)
     assert success is True
 
-    # Verify v1.1.0 is deleted
+    # Verify v1.1.0 is marked as rollback
     response = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": "VERSION#1.1.0"})
-    assert "Item" not in response
+    assert "Item" in response
+    assert response["Item"]["status"] == "rollback"
 
     # Verify v1.0.0 still exists
     response = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": "VERSION#1.0.0"})
     assert "Item" in response
+    # It should still be 'released' (default in test if not set)
 
     # Verify SSM points back to v1.0.0
     latest_version_param = ssm.get_parameter(

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -26,9 +26,24 @@ class FakeScopedDb:
             return None
         return dict(item)
 
-    def put_item(self, _table_name: str, item: dict[str, Any]) -> dict[str, Any]:
+    def put_item(
+        self,
+        _table_name: str,
+        item: dict[str, Any],
+        *,
+        condition_expression: str | None = None,
+    ) -> dict[str, Any]:
         pk = str(item["PK"])
         sk = str(item["SK"])
+        if (
+            condition_expression
+            and "attribute_not_exists" in condition_expression
+            and (pk, sk) in self.items
+        ):
+            raise tenant_api_handler.ClientError(
+                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "exists"}},
+                "PutItem",
+            )
         self.items[(pk, sk)] = dict(item)
         return {"Attributes": dict(item)}
 
@@ -498,6 +513,30 @@ def _seed_failover_lock(
         "lockId": lock_id,
         "acquiredBy": acquired_by,
         "ttl": expires_at,
+    }
+
+
+def _seed_agent_version(
+    fake_state: dict[str, Any],
+    *,
+    agent_name: str,
+    version: str,
+    status: str = "pending",
+) -> None:
+    fake_state["db"].items[(f"AGENT#{agent_name}", f"VERSION#{version}")] = {
+        "PK": f"AGENT#{agent_name}",
+        "SK": f"VERSION#{version}",
+        "agent_name": agent_name,
+        "version": version,
+        "owner_team": "platform",
+        "tier_minimum": "basic",
+        "layer_hash": f"hash-{version}",
+        "layer_s3_key": f"layers/{version}.zip",
+        "script_s3_key": f"scripts/{version}.zip",
+        "deployed_at": "2026-02-25T12:00:00Z",
+        "invocation_mode": "sync",
+        "streaming_enabled": False,
+        "status": status,
     }
 
 
@@ -1998,3 +2037,138 @@ def test_lambda_rollback_returns_404_on_missing_function(fake_state: dict[str, A
 
     response = _invoke(event)
     assert response["statusCode"] == 404
+
+
+def test_platform_register_agent_defaults_dev_to_released(fake_state: dict[str, Any]) -> None:
+    event = _event(
+        method="POST",
+        body={
+            "agentName": "echo-agent",
+            "version": "1.2.0",
+            "ownerTeam": "platform",
+            "tierMinimum": "basic",
+            "layerHash": "hash-120",
+            "layerS3Key": "layers/1.2.0.zip",
+            "scriptS3Key": "scripts/1.2.0.zip",
+            "invocationMode": "sync",
+        },
+        roles=["Platform.Admin"],
+    )
+    event["path"] = "/v1/platform/agents"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 201
+    item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]
+    assert item["status"] == "released"
+    assert item["approved_by"] == "user-123"
+
+
+def test_platform_register_agent_defaults_prod_to_pending(
+    fake_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "platform-tenant-api-prod")
+    event = _event(
+        method="POST",
+        body={
+            "agentName": "echo-agent",
+            "version": "1.2.1",
+            "ownerTeam": "platform",
+            "tierMinimum": "basic",
+            "layerHash": "hash-121",
+            "layerS3Key": "layers/1.2.1.zip",
+            "scriptS3Key": "scripts/1.2.1.zip",
+            "invocationMode": "sync",
+        },
+        roles=["Platform.Admin"],
+    )
+    event["path"] = "/v1/platform/agents"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 201
+    item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.1")]
+    assert item["status"] == "pending"
+    assert "approved_by" not in item
+
+
+def test_platform_register_agent_rejects_invalid_initial_status(
+    fake_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "platform-tenant-api-prod")
+    event = _event(
+        method="POST",
+        body={
+            "agentName": "echo-agent",
+            "version": "1.2.0",
+            "status": "released",
+        },
+        roles=["Platform.Admin"],
+    )
+    event["path"] = "/v1/platform/agents"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+    assert ("AGENT#echo-agent", "VERSION#1.2.0") not in fake_state["db"].items
+
+
+def test_platform_promote_agent_updates_metadata_and_emits_event(
+    fake_state: dict[str, Any],
+) -> None:
+    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="pending")
+    event = _event(
+        method="PATCH",
+        body={"status": "released", "releaseNotes": "integration verified"},
+        roles=["Platform.Admin"],
+    )
+    event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 200
+    item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]
+    assert item["status"] == "released"
+    assert item["approved_by"] == "user-123"
+    assert item["approved_at"] == "2026-02-25T12:00:00Z"
+    assert item["release_notes"] == "integration verified"
+    detail_type, detail = _last_event_detail(fake_state)
+    assert detail_type == "platform.agent_version.promoted"
+    assert detail["previousStatus"] == "pending"
+    assert detail["status"] == "released"
+
+
+def test_platform_rejects_invalid_agent_status_transition(fake_state: dict[str, Any]) -> None:
+    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="released")
+    event = _event(
+        method="PATCH",
+        body={"status": "pending"},
+        roles=["Platform.Admin"],
+    )
+    event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+    assert _body(response)["error"]["message"].startswith("Invalid agent status transition")
+    assert fake_state["deps"].events.calls == []
+
+
+def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None:
+    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="released")
+    event = _event(
+        method="PATCH",
+        body={"status": "rollback", "releaseNotes": "error rate spike"},
+        roles=["Platform.Admin"],
+    )
+    event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 200
+    item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]
+    assert item["status"] == "rollback"
+    detail_type, detail = _last_event_detail(fake_state)
+    assert detail_type == "platform.agent_version.rolled_back"
+    assert detail["previousStatus"] == "released"
+    assert detail["status"] == "rollback"


### PR DESCRIPTION
Closes #302

## Summary
- add agent release governance metadata and operator routes for register, promote, rollback, and listing
- make bridge resolution and rollback logic honor the highest released semver instead of destructive deletes
- document the promotion and rollback flow and cover it with tenant API, bridge, and script tests

## Validation
- make preflight-session
- make pre-validate-session
- pytest -q tests/unit/test_tenant_api_handler.py -k "platform_failover or lambda_rollback or platform_register_agent or platform_promote_agent or platform_rejects_invalid_agent_status_transition or platform_rollback_agent"
- pytest -q tests/unit/test_bridge_handler.py -k "list_agents or get_agent_detail"
- pytest -q tests/unit/test_agent_scripts.py tests/unit/test_rollback_agent.py
- pytest -q src/data-access-lib/tests/test_client.py