### PR TITLE
CR-004: harden agent manifest contract

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ This file exists so tools that look for assistant instruction files can redirect
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **wt303** (2335 symbols, 6040 relationships, 189 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **wt305** (2394 symbols, 6222 relationships, 194 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -24,7 +24,7 @@ This project is indexed by GitNexus as **wt303** (2335 symbols, 6040 relationshi
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/wt303/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/wt305/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -63,10 +63,10 @@ This project is indexed by GitNexus as **wt303** (2335 symbols, 6040 relationshi
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/wt303/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/wt303/clusters` | All functional areas |
-| `gitnexus://repo/wt303/processes` | All execution flows |
-| `gitnexus://repo/wt303/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/wt305/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/wt305/clusters` | All functional areas |
+| `gitnexus://repo/wt305/processes` | All execution flows |
+| `gitnexus://repo/wt305/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/docs/development/AGENT-DEVELOPER-GUIDE.md
+++ b/docs/development/AGENT-DEVELOPER-GUIDE.md
@@ -53,6 +53,12 @@ agents/my-agent/
 
 ## The Agent Manifest (pyproject.toml)
 
+The manifest contract is explicit:
+- `[project]` owns packaging identity and versioning.
+- `[tool.agentcore]` owns platform metadata used by validation, deployment, registration, and evaluation.
+- Unknown keys under platform-owned manifest tables are rejected by `make validate-agent-manifest`.
+- Agent push automation validates this contract before any AWS API call.
+
 ```toml
 [project]
 name = "my-agent"
@@ -86,6 +92,25 @@ max_tokens = 4096
 [tool.agentcore.deployment]
 type = "zip"                   # zip (default) | container
 ```
+
+### Canonical Schema Boundary
+
+| Table | Fields | Required |
+|-------|--------|----------|
+| `[project]` | `name`, `version` | yes |
+| `[tool.agentcore]` | `name`, `owner_team`, `tier_minimum`, `handler`, `invocation_mode` | yes |
+| `[tool.agentcore]` | `streaming_enabled`, `estimated_duration_seconds` | no |
+| `[tool.agentcore.llm]` | `model_id`, `max_tokens` | no |
+| `[tool.agentcore.deployment]` | `type` (`zip` or `container`) | no |
+| `[tool.agentcore.evaluations]` | `threshold`, `evaluation_region` | no |
+
+Validation rules:
+- `project.name`, `tool.agentcore.name`, and the agent directory name must match.
+- `handler` must use `module:function` form.
+- `tier_minimum` must be `basic`, `standard`, or `premium`.
+- `invocation_mode` must be `sync`, `streaming`, or `async`.
+- `estimated_duration_seconds` and `max_tokens` must be positive integers.
+- `threshold` must be between `0.0` and `1.0`.
 
 ## Invocation Modes
 

--- a/scripts/agent_manifest.py
+++ b/scripts/agent_manifest.py
@@ -1,0 +1,381 @@
+"""
+agent_manifest.py — Canonical agent manifest loader and validator.
+
+The platform's agent contract lives in agents/<name>/pyproject.toml and is split
+across the [project] table for packaging metadata and the [tool.agentcore] tables
+for platform-owned metadata.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from data_access.models import InvocationMode, TenantTier
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EVALUATION_REGION = "eu-central-1"
+VALID_DEPLOYMENT_TYPES = frozenset({"zip", "container"})
+
+_PROJECT_KEYS = frozenset({"name", "version"})
+_MANIFEST_KEYS = frozenset(
+    {
+        "name",
+        "owner_team",
+        "tier_minimum",
+        "handler",
+        "invocation_mode",
+        "streaming_enabled",
+        "estimated_duration_seconds",
+        "llm",
+        "deployment",
+        "evaluations",
+    }
+)
+_LLM_KEYS = frozenset({"model_id", "max_tokens"})
+_DEPLOYMENT_KEYS = frozenset({"type"})
+_EVALUATIONS_KEYS = frozenset({"threshold", "evaluation_region"})
+
+
+class ManifestValidationError(ValueError):
+    """Raised when an agent manifest violates the contract."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("\n".join(errors))
+
+
+@dataclass(frozen=True)
+class AgentDeploymentConfig:
+    type: str = "zip"
+
+
+@dataclass(frozen=True)
+class AgentLlmConfig:
+    model_id: str | None = None
+    max_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class AgentEvaluationsConfig:
+    threshold: float = 0.8
+    evaluation_region: str = DEFAULT_EVALUATION_REGION
+
+
+@dataclass(frozen=True)
+class AgentManifest:
+    project_name: str
+    version: str
+    name: str
+    owner_team: str
+    tier_minimum: TenantTier
+    handler: str
+    invocation_mode: InvocationMode
+    streaming_enabled: bool = False
+    estimated_duration_seconds: int = 5
+    deployment: AgentDeploymentConfig = AgentDeploymentConfig()
+    llm: AgentLlmConfig = AgentLlmConfig()
+    evaluations: AgentEvaluationsConfig = AgentEvaluationsConfig()
+
+
+def load_agent_manifest(agent_name: str, repo_root: Path | None = None) -> AgentManifest:
+    if repo_root is None:
+        repo_root = REPO_ROOT
+    toml_path = repo_root / "agents" / agent_name / "pyproject.toml"
+    if not toml_path.exists():
+        raise ManifestValidationError(
+            [f"pyproject.toml not found for agent '{agent_name}' at {toml_path}"]
+        )
+
+    try:
+        with toml_path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:
+        raise ManifestValidationError([f"Failed to parse {toml_path}: {exc}"]) from exc
+
+    errors: list[str] = []
+
+    project_raw = _require_table(data, "project", errors)
+    tool_raw = _require_table(data, "tool", errors)
+    manifest_raw = _require_table(tool_raw, "agentcore", errors, label="[tool.agentcore]")
+
+    project_name = _required_string(project_raw, "name", errors, table="[project]")
+    version = _required_string(project_raw, "version", errors, table="[project]")
+    _check_unknown_keys(project_raw, _PROJECT_KEYS, errors, table="[project]")
+    _check_unknown_keys(manifest_raw, _MANIFEST_KEYS, errors, table="[tool.agentcore]")
+
+    name = _required_string(manifest_raw, "name", errors, table="[tool.agentcore]")
+    owner_team = _required_string(manifest_raw, "owner_team", errors, table="[tool.agentcore]")
+    handler = _required_string(manifest_raw, "handler", errors, table="[tool.agentcore]")
+    tier_minimum = _required_enum(
+        manifest_raw, "tier_minimum", TenantTier, errors, table="[tool.agentcore]"
+    )
+    invocation_mode = _required_enum(
+        manifest_raw, "invocation_mode", InvocationMode, errors, table="[tool.agentcore]"
+    )
+    streaming_enabled = _optional_bool(
+        manifest_raw,
+        "streaming_enabled",
+        default=False,
+        errors=errors,
+        table="[tool.agentcore]",
+    )
+    estimated_duration_seconds = _optional_int(
+        manifest_raw,
+        "estimated_duration_seconds",
+        default=5,
+        errors=errors,
+        table="[tool.agentcore]",
+    )
+
+    if project_name and project_name != agent_name:
+        errors.append(
+            f"Project name mismatch: [project].name '{project_name}' does not match directory "
+            f"name '{agent_name}'"
+        )
+    if name and name != agent_name:
+        errors.append(
+            f"Agent name mismatch: manifest name '{name}' does not match directory name "
+            f"'{agent_name}'"
+        )
+    if project_name and name and project_name != name:
+        errors.append(
+            f"Name mismatch: [project].name '{project_name}' does not match "
+            f"[tool.agentcore].name '{name}'"
+        )
+    if handler and ":" not in handler:
+        errors.append("Invalid handler: [tool.agentcore].handler must be in 'module:function' form")
+    if estimated_duration_seconds is not None and estimated_duration_seconds <= 0:
+        errors.append(
+            "Invalid estimated_duration_seconds: [tool.agentcore].estimated_duration_seconds "
+            "must be greater than 0"
+        )
+
+    llm_raw = _optional_table(manifest_raw, "llm", errors, table="[tool.agentcore.llm]")
+    _check_unknown_keys(llm_raw, _LLM_KEYS, errors, table="[tool.agentcore.llm]")
+    model_id = _optional_string(llm_raw, "model_id", errors=errors, table="[tool.agentcore.llm]")
+    max_tokens = _optional_int(
+        llm_raw,
+        "max_tokens",
+        default=None,
+        errors=errors,
+        table="[tool.agentcore.llm]",
+    )
+    if max_tokens is not None and max_tokens <= 0:
+        errors.append("Invalid max_tokens: [tool.agentcore.llm].max_tokens must be greater than 0")
+
+    deployment_raw = _optional_table(
+        manifest_raw,
+        "deployment",
+        errors,
+        table="[tool.agentcore.deployment]",
+    )
+    _check_unknown_keys(
+        deployment_raw,
+        _DEPLOYMENT_KEYS,
+        errors,
+        table="[tool.agentcore.deployment]",
+    )
+    deployment_type = _optional_string(
+        deployment_raw,
+        "type",
+        default="zip",
+        errors=errors,
+        table="[tool.agentcore.deployment]",
+    )
+    if deployment_type not in VALID_DEPLOYMENT_TYPES:
+        options = ", ".join(sorted(VALID_DEPLOYMENT_TYPES))
+        errors.append(f"Invalid deployment type: '{deployment_type}'. Must be one of: {options}")
+
+    evaluations_raw = _optional_table(
+        manifest_raw,
+        "evaluations",
+        errors,
+        table="[tool.agentcore.evaluations]",
+    )
+    _check_unknown_keys(
+        evaluations_raw,
+        _EVALUATIONS_KEYS,
+        errors,
+        table="[tool.agentcore.evaluations]",
+    )
+    threshold = _optional_float(
+        evaluations_raw,
+        "threshold",
+        default=0.8,
+        errors=errors,
+        table="[tool.agentcore.evaluations]",
+    )
+    evaluation_region = _optional_string(
+        evaluations_raw,
+        "evaluation_region",
+        default=DEFAULT_EVALUATION_REGION,
+        errors=errors,
+        table="[tool.agentcore.evaluations]",
+    )
+    if threshold is not None and not 0.0 <= threshold <= 1.0:
+        errors.append("Invalid threshold: [tool.agentcore.evaluations].threshold must be 0.0-1.0")
+
+    if errors:
+        raise ManifestValidationError(errors)
+
+    return AgentManifest(
+        project_name=project_name,
+        version=version,
+        name=name,
+        owner_team=owner_team,
+        tier_minimum=cast(TenantTier, tier_minimum),
+        handler=handler,
+        invocation_mode=cast(InvocationMode, invocation_mode),
+        streaming_enabled=streaming_enabled,
+        estimated_duration_seconds=estimated_duration_seconds or 5,
+        deployment=AgentDeploymentConfig(type=deployment_type or "zip"),
+        llm=AgentLlmConfig(model_id=model_id, max_tokens=max_tokens),
+        evaluations=AgentEvaluationsConfig(
+            threshold=threshold,
+            evaluation_region=evaluation_region or DEFAULT_EVALUATION_REGION,
+        ),
+    )
+
+
+def _require_table(
+    data: dict[str, Any],
+    key: str,
+    errors: list[str],
+    *,
+    label: str | None = None,
+) -> dict[str, Any]:
+    table_label = label or f"[{key}]"
+    value = data.get(key)
+    if not isinstance(value, dict):
+        errors.append(f"Missing {table_label} section")
+        return {}
+    return value
+
+
+def _optional_table(
+    data: dict[str, Any],
+    key: str,
+    errors: list[str],
+    *,
+    table: str,
+) -> dict[str, Any]:
+    value = data.get(key, {})
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"Invalid {table}: expected table, got {type(value).__name__}")
+        return {}
+    return value
+
+
+def _required_string(
+    data: dict[str, Any],
+    key: str,
+    errors: list[str],
+    *,
+    table: str,
+) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"Missing required field: {table}.{key}")
+        return ""
+    return value.strip()
+
+
+def _optional_string(
+    data: dict[str, Any],
+    key: str,
+    *,
+    default: str | None = None,
+    errors: list[str],
+    table: str,
+) -> str | None:
+    value = data.get(key, default)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"Invalid {table}.{key}: expected non-empty string")
+        return default
+    return value.strip()
+
+
+def _optional_bool(
+    data: dict[str, Any],
+    key: str,
+    *,
+    default: bool,
+    errors: list[str],
+    table: str,
+) -> bool:
+    value = data.get(key, default)
+    if not isinstance(value, bool):
+        errors.append(f"Invalid {table}.{key}: expected bool, got {type(value).__name__}")
+        return default
+    return value
+
+
+def _optional_int(
+    data: dict[str, Any],
+    key: str,
+    *,
+    default: int | None,
+    errors: list[str],
+    table: str,
+) -> int | None:
+    value = data.get(key, default)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        errors.append(f"Invalid {table}.{key}: expected int, got {type(value).__name__}")
+        return default
+    return value
+
+
+def _optional_float(
+    data: dict[str, Any],
+    key: str,
+    *,
+    default: float,
+    errors: list[str],
+    table: str,
+) -> float:
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        errors.append(f"Invalid {table}.{key}: expected number, got {type(value).__name__}")
+        return default
+    return float(value)
+
+
+def _required_enum(
+    data: dict[str, Any],
+    key: str,
+    enum_type: type[TenantTier] | type[InvocationMode],
+    errors: list[str],
+    *,
+    table: str,
+) -> TenantTier | InvocationMode:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"Missing required field: {table}.{key}")
+        return next(iter(enum_type))
+    try:
+        return enum_type(value.strip())
+    except ValueError:
+        options = ", ".join(member.value for member in enum_type)
+        errors.append(f"Invalid {table}.{key}: '{value}'. Must be one of: {options}")
+        return next(iter(enum_type))
+
+
+def _check_unknown_keys(
+    data: dict[str, Any],
+    allowed_keys: frozenset[str],
+    errors: list[str],
+    *,
+    table: str,
+) -> None:
+    unknown_keys = sorted(set(data) - allowed_keys)
+    if unknown_keys:
+        errors.append(f"Unknown keys in {table}: {', '.join(unknown_keys)}")

--- a/scripts/deploy_agent.py
+++ b/scripts/deploy_agent.py
@@ -15,6 +15,11 @@ from pathlib import Path
 import boto3
 from botocore.exceptions import ClientError
 
+try:
+    from agent_manifest import ManifestValidationError, load_agent_manifest
+except ImportError:
+    from scripts.agent_manifest import ManifestValidationError, load_agent_manifest
+
 logger = logging.getLogger("deploy_agent")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
@@ -65,20 +70,19 @@ def update_agentcore_runtime(
 
 
 def deploy_agent(agent_name: str, env: str) -> bool:
+    try:
+        manifest = load_agent_manifest(agent_name, REPO_ROOT)
+    except ManifestValidationError as exc:
+        for error in exc.errors:
+            logger.error(error)
+        return False
+
     aws_region = require_aws_region()
 
     # Resolve bucket (same as build_layer)
     from build_layer import resolve_layer_bucket
 
     bucket = resolve_layer_bucket(env, aws_region)
-
-    # Read version from pyproject.toml
-    import tomllib
-
-    toml_path = REPO_ROOT / "agents" / agent_name / "pyproject.toml"
-    with open(toml_path, "rb") as f:
-        data = tomllib.load(f)
-    version = data.get("project", {}).get("version", "1.0.0")
 
     ssm = boto3.client("ssm", region_name=aws_region)
     deps_key = get_ssm_param(ssm, f"/platform/layers/{env}/{agent_name}/s3-key")
@@ -93,7 +97,7 @@ def deploy_agent(agent_name: str, env: str) -> bool:
         logger.error(f"Agent code zip not found: {code_zip}. Run package_agent first.")
         return False
 
-    script_key = f"scripts/{agent_name}/{version}.zip"
+    script_key = f"scripts/{agent_name}/{manifest.version}.zip"
     s3 = boto3.client("s3", region_name=aws_region)
     logger.info(f"Uploading agent code to s3://{bucket}/{script_key}")
     s3.upload_file(str(code_zip), bucket, script_key)

--- a/scripts/evaluate_agent.py
+++ b/scripts/evaluate_agent.py
@@ -17,20 +17,21 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any
 
 import boto3
-from botocore.exceptions import ClientError
+
+try:
+    from agent_manifest import ManifestValidationError, load_agent_manifest
+except ImportError:
+    from scripts.agent_manifest import ManifestValidationError, load_agent_manifest
 
 logger = logging.getLogger("evaluate_agent")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_EVALUATION_REGION = "eu-central-1"
 
 
 def parse_args() -> argparse.Namespace:
@@ -59,30 +60,34 @@ def load_golden_cases(agent_dir: Path) -> list[dict[str, Any]]:
 
 
 def evaluate_agent(agent_name: str, env: str) -> bool:
+    del env
     agent_dir = REPO_ROOT / "agents" / agent_name
-    toml_path = agent_dir / "pyproject.toml"
-    if not toml_path.exists():
-        logger.error(f"pyproject.toml not found for agent '{agent_name}'")
+    try:
+        manifest = load_agent_manifest(agent_name, REPO_ROOT)
+    except ManifestValidationError as exc:
+        for error in exc.errors:
+            logger.error(error)
         return False
-
-    with open(toml_path, "rb") as f:
-        data = tomllib.load(f)
-
-    eval_config = data.get("tool", {}).get("agentcore", {}).get("evaluations", {})
-    threshold = float(eval_config.get("threshold", 0.8))
-    eval_region = eval_config.get("evaluation_region", DEFAULT_EVALUATION_REGION)
 
     golden_cases = load_golden_cases(agent_dir)
     if not golden_cases:
         logger.error(f"No golden cases found for agent '{agent_name}'")
         return False
 
-    logger.info(f"Evaluating agent '{agent_name}' in {eval_region} with {len(golden_cases)} cases")
-    logger.info(f"Threshold: {threshold}")
+    logger.info(
+        "Evaluating agent '%s' in %s with %s cases",
+        agent_name,
+        manifest.evaluations.evaluation_region,
+        len(golden_cases),
+    )
+    logger.info("Threshold: %s", manifest.evaluations.threshold)
 
     try:
         # AgentCore Evaluations service is always in eu-central-1 (Frankfurt)
-        acore = boto3.client("bedrock-agentcore", region_name=eval_region)
+        acore = boto3.client(
+            "bedrock-agentcore",
+            region_name=manifest.evaluations.evaluation_region,
+        )
 
         # Call the evaluation service
         # ADR-009: AgentCore Evaluations is the source of truth for promotion quality
@@ -92,12 +97,20 @@ def evaluate_agent(agent_name: str, env: str) -> bool:
         )
 
         score = float(response.get("score", 0.0))
-        passed = score >= threshold
+        passed = score >= manifest.evaluations.threshold
 
         if passed:
-            logger.info(f"Evaluation PASSED: score={score:.2f} (threshold={threshold:.2f})")
+            logger.info(
+                "Evaluation PASSED: score=%.2f (threshold=%.2f)",
+                score,
+                manifest.evaluations.threshold,
+            )
         else:
-            logger.error(f"Evaluation FAILED: score={score:.2f} (threshold={threshold:.2f})")
+            logger.error(
+                "Evaluation FAILED: score=%.2f (threshold=%.2f)",
+                score,
+                manifest.evaluations.threshold,
+            )
             return False
 
         return True

--- a/scripts/register_agent.py
+++ b/scripts/register_agent.py
@@ -14,11 +14,15 @@ import argparse
 import datetime
 import logging
 import os
-import tomllib
 from pathlib import Path
 
 import boto3
 from botocore.exceptions import ClientError
+
+try:
+    from agent_manifest import ManifestValidationError, load_agent_manifest
+except ImportError:
+    from scripts.agent_manifest import ManifestValidationError, load_agent_manifest
 
 logger = logging.getLogger("register_agent")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -53,14 +57,14 @@ def get_ssm_param(ssm, name: str) -> str | None:
 
 
 def register_agent(agent_name: str, env: str) -> bool:
-    aws_region = require_aws_region()
-    toml_path = REPO_ROOT / "agents" / agent_name / "pyproject.toml"
-    with open(toml_path, "rb") as f:
-        data = tomllib.load(f)
+    try:
+        manifest = load_agent_manifest(agent_name, REPO_ROOT)
+    except ManifestValidationError as exc:
+        for error in exc.errors:
+            logger.error(error)
+        return False
 
-    project = data.get("project", {})
-    version = project.get("version", "1.0.0")
-    manifest = data.get("tool", {}).get("agentcore", {})
+    aws_region = require_aws_region()
 
     ssm = boto3.client("ssm", region_name=aws_region)
     layer_hash = get_ssm_param(ssm, f"/platform/layers/{env}/{agent_name}/hash")
@@ -84,27 +88,32 @@ def register_agent(agent_name: str, env: str) -> bool:
 
     item = {
         "PK": f"AGENT#{agent_name}",
-        "SK": f"VERSION#{version}",
+        "SK": f"VERSION#{manifest.version}",
         "agent_name": agent_name,
-        "version": version,
-        "owner_team": manifest.get("owner_team", "unknown"),
-        "tier_minimum": manifest.get("tier_minimum", "basic"),
+        "version": manifest.version,
+        "owner_team": manifest.owner_team,
+        "tier_minimum": manifest.tier_minimum.value,
         "layer_hash": layer_hash,
         "layer_s3_key": layer_s3_key,
         "script_s3_key": script_s3_key,
         "deployed_at": deployed_at,
-        "invocation_mode": manifest.get("invocation_mode", "sync"),
-        "streaming_enabled": manifest.get("streaming_enabled", False),
+        "invocation_mode": manifest.invocation_mode.value,
+        "streaming_enabled": manifest.streaming_enabled,
         "status": default_status,
         "runtime_arn": runtime_arn,
-        "estimated_duration_seconds": manifest.get("estimated_duration_seconds", 5),
+        "estimated_duration_seconds": manifest.estimated_duration_seconds,
     }
 
     table_name = "platform-agents"
     dynamodb = boto3.resource("dynamodb", region_name=aws_region)
     table = dynamodb.Table(table_name)
 
-    logger.info(f"Registering agent '{agent_name}' v{version} in DynamoDB table '{table_name}'")
+    logger.info(
+        "Registering agent '%s' v%s in DynamoDB table '%s'",
+        agent_name,
+        manifest.version,
+        table_name,
+    )
     try:
         table.put_item(
             Item=item,
@@ -113,7 +122,7 @@ def register_agent(agent_name: str, env: str) -> bool:
         if default_status == "released":
             ssm.put_parameter(
                 Name=f"/platform/agents/{env}/{agent_name}/latest-version",
-                Value=version,
+                Value=manifest.version,
                 Type="String",
                 Overwrite=True,
             )

--- a/scripts/validate_agent_manifest.py
+++ b/scripts/validate_agent_manifest.py
@@ -13,27 +13,20 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-import tomllib
 from pathlib import Path
-from typing import Any
 
-# Add src/data-access-lib/src to path to import models if needed,
-# but for simple validation we can just define the expected fields here
-# to avoid dependency issues in the validation stage.
+from data_access.models import InvocationMode, TenantTier
 
-REQUIRED_FIELDS = {
-    "name": str,
-    "owner_team": str,
-    "tier_minimum": str,
-    "invocation_mode": str,
-}
-
-VALID_TIERS = {"basic", "standard", "premium"}
-VALID_INVOCATION_MODES = {"sync", "streaming", "async"}
+try:
+    from agent_manifest import ManifestValidationError, load_agent_manifest
+except ImportError:
+    from scripts.agent_manifest import ManifestValidationError, load_agent_manifest
 
 logger = logging.getLogger("validate_manifest")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
+VALID_TIERS = {tier.value for tier in TenantTier}
+VALID_INVOCATION_MODES = {mode.value for mode in InvocationMode}
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -44,61 +37,14 @@ def parse_args() -> argparse.Namespace:
 
 
 def validate_manifest(agent_name: str) -> bool:
-    toml_path = REPO_ROOT / "agents" / agent_name / "pyproject.toml"
-    if not toml_path.exists():
-        logger.error(f"pyproject.toml not found for agent '{agent_name}' at {toml_path}")
-        return False
-
-    with open(toml_path, "rb") as f:
-        try:
-            data = tomllib.load(f)
-        except Exception as e:
-            logger.error(f"Failed to parse pyproject.toml: {e}")
-            return False
-
-    if "tool" not in data or "agentcore" not in data["tool"]:
-        logger.error(f"Missing [tool.agentcore] section in {toml_path}")
-        return False
-
-    manifest = data["tool"]["agentcore"]
-    errors = []
-
-    # Check required fields and types
-    for field, expected_type in REQUIRED_FIELDS.items():
-        if field not in manifest:
-            errors.append(f"Missing required field: '{field}'")
-        elif not isinstance(manifest[field], expected_type):
-            errors.append(
-                f"Invalid type for '{field}': expected {expected_type.__name__}, "
-                f"got {type(manifest[field]).__name__}"
-            )
-
-    # Check enum values
-    if "tier_minimum" in manifest and manifest["tier_minimum"] not in VALID_TIERS:
-        errors.append(
-            f"Invalid tier_minimum: '{manifest['tier_minimum']}'. "
-            f"Must be one of: {', '.join(sorted(VALID_TIERS))}"
-        )
-
-    if "invocation_mode" in manifest and manifest["invocation_mode"] not in VALID_INVOCATION_MODES:
-        errors.append(
-            f"Invalid invocation_mode: '{manifest['invocation_mode']}'. "
-            f"Must be one of: {', '.join(sorted(VALID_INVOCATION_MODES))}"
-        )
-
-    # Check name match
-    if "name" in manifest and manifest["name"] != agent_name:
-        errors.append(
-            f"Agent name mismatch: manifest name '{manifest['name']}' "
-            f"does not match directory name '{agent_name}'"
-        )
-
-    if errors:
-        for error in errors:
+    try:
+        load_agent_manifest(agent_name, REPO_ROOT)
+    except ManifestValidationError as exc:
+        for error in exc.errors:
             logger.error(error)
         return False
 
-    logger.info(f"Manifest for agent '{agent_name}' is valid.")
+    logger.info("Manifest for agent '%s' is valid.", agent_name)
     return True
 
 

--- a/tests/unit/test_agent_scripts.py
+++ b/tests/unit/test_agent_scripts.py
@@ -32,6 +32,7 @@ package_agent = _load_module("package_agent")
 build_layer = _load_module("build_layer")
 deploy_agent = _load_module("deploy_agent")
 register_agent = _load_module("register_agent")
+evaluate_agent = _load_module("evaluate_agent")
 
 _REGION = "eu-west-2"
 
@@ -163,6 +164,13 @@ def _prepare_deploy_agent_fixture(tmp_path, monkeypatch) -> tuple[str, str, str]
 name = "echo-agent"
 version = "1.2.3"
 
+[tool.agentcore]
+name = "echo-agent"
+owner_team = "platform"
+tier_minimum = "basic"
+handler = "handler:invoke"
+invocation_mode = "sync"
+
 [tool.agentcore.deployment]
 type = "zip"
 """)
@@ -238,8 +246,10 @@ name = "echo-agent"
 version = "1.2.3"
 
 [tool.agentcore]
+name = "echo-agent"
 owner_team = "platform"
 tier_minimum = "basic"
+handler = "handler:invoke"
 invocation_mode = "sync"
 """)
     stored_items: list[dict[str, object]] = []
@@ -308,8 +318,10 @@ name = "echo-agent"
 version = "1.2.3"
 
 [tool.agentcore]
+name = "echo-agent"
 owner_team = "platform"
 tier_minimum = "basic"
+handler = "handler:invoke"
 invocation_mode = "sync"
 """)
 
@@ -360,8 +372,10 @@ name = "echo-agent"
 version = "1.2.3"
 
 [tool.agentcore]
+name = "echo-agent"
 owner_team = "platform"
 tier_minimum = "basic"
+handler = "handler:invoke"
 invocation_mode = "sync"
 """)
     put_item_calls: list[dict[str, object]] = []
@@ -399,3 +413,78 @@ invocation_mode = "sync"
 
     assert register_agent.register_agent(agent_name, env) is False
     assert len(put_item_calls) == 1
+
+
+def test_register_agent_returns_false_when_manifest_invalid_before_aws(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    monkeypatch.setattr(register_agent, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(register_agent, "boto3", types.SimpleNamespace(client=None, resource=None))
+
+    agent_dir = tmp_path / "agents" / "echo-agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "pyproject.toml").write_text("""
+[project]
+name = "echo-agent"
+version = "1.2.3"
+
+[tool.agentcore]
+name = "echo-agent"
+owner_team = "platform"
+tier_minimum = "basic"
+invocation_mode = "sync"
+""")
+
+    assert register_agent.register_agent("echo-agent", "dev") is False
+
+
+def test_deploy_agent_returns_false_when_manifest_invalid_before_aws(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    monkeypatch.setattr(deploy_agent, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(deploy_agent, "BUILD_DIR", tmp_path / ".build")
+
+    agent_dir = tmp_path / "agents" / "echo-agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "pyproject.toml").write_text("""
+[project]
+name = "echo-agent"
+version = "1.2.3"
+
+[tool.agentcore]
+name = "echo-agent"
+owner_team = "platform"
+tier_minimum = "basic"
+invocation_mode = "sync"
+""")
+
+    def _unexpected_client(*_args, **_kwargs):
+        raise AssertionError("AWS client should not be created for invalid manifests")
+
+    monkeypatch.setattr(deploy_agent, "boto3", types.SimpleNamespace(client=_unexpected_client))
+
+    assert deploy_agent.deploy_agent("echo-agent", "dev") is False
+
+
+def test_evaluate_agent_returns_false_when_manifest_invalid_before_aws(tmp_path, monkeypatch):
+    monkeypatch.setattr(evaluate_agent, "REPO_ROOT", tmp_path)
+
+    agent_dir = tmp_path / "agents" / "echo-agent"
+    (agent_dir / "tests" / "golden").mkdir(parents=True)
+    (agent_dir / "tests" / "golden" / "invoke_cases.json").write_text('{"sync": []}')
+    (agent_dir / "pyproject.toml").write_text("""
+[project]
+name = "echo-agent"
+version = "1.2.3"
+
+[tool.agentcore]
+name = "echo-agent"
+owner_team = "platform"
+tier_minimum = "basic"
+invocation_mode = "sync"
+""")
+
+    def _unexpected_client(*_args, **_kwargs):
+        raise AssertionError("AWS client should not be created for invalid manifests")
+
+    monkeypatch.setattr(evaluate_agent, "boto3", types.SimpleNamespace(client=_unexpected_client))
+
+    assert evaluate_agent.evaluate_agent("echo-agent", "dev") is False

--- a/tests/unit/test_validate_agent_manifest.py
+++ b/tests/unit/test_validate_agent_manifest.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/validate_agent_manifest.py — tier and invocation mode validation."""
+"""Tests for scripts/validate_agent_manifest.py and the shared manifest contract."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from scripts.agent_manifest import load_agent_manifest
 from scripts.validate_agent_manifest import VALID_INVOCATION_MODES, VALID_TIERS, validate_manifest
 
 
@@ -19,11 +20,6 @@ def _write_manifest(tmp_path: Path, agent_name: str, toml_content: str) -> None:
     agent_dir = tmp_path / "agents" / agent_name
     agent_dir.mkdir(parents=True, exist_ok=True)
     (agent_dir / "pyproject.toml").write_text(textwrap.dedent(toml_content))
-
-
-# ---------------------------------------------------------------------------
-# Tier enum: canonical set is {basic, standard, premium}
-# ---------------------------------------------------------------------------
 
 
 class TestTierEnum:
@@ -41,10 +37,15 @@ class TestTierEnum:
             tmp_path,
             "test-agent",
             f"""\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+
             [tool.agentcore]
             name = "test-agent"
             owner_team = "team-test"
             tier_minimum = "{tier}"
+            handler = "handler:invoke"
             invocation_mode = "sync"
         """,
         )
@@ -57,20 +58,20 @@ class TestTierEnum:
             tmp_path,
             "test-agent",
             f"""\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+
             [tool.agentcore]
             name = "test-agent"
             owner_team = "team-test"
             tier_minimum = "{tier}"
+            handler = "handler:invoke"
             invocation_mode = "sync"
         """,
         )
         with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
             assert validate_manifest("test-agent") is False
-
-
-# ---------------------------------------------------------------------------
-# Invocation mode enum
-# ---------------------------------------------------------------------------
 
 
 class TestInvocationModeEnum:
@@ -85,10 +86,15 @@ class TestInvocationModeEnum:
             tmp_path,
             "test-agent",
             f"""\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+
             [tool.agentcore]
             name = "test-agent"
             owner_team = "team-test"
             tier_minimum = "basic"
+            handler = "handler:invoke"
             invocation_mode = "{mode}"
         """,
         )
@@ -100,20 +106,20 @@ class TestInvocationModeEnum:
             tmp_path,
             "test-agent",
             """\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+
             [tool.agentcore]
             name = "test-agent"
             owner_team = "team-test"
             tier_minimum = "basic"
+            handler = "handler:invoke"
             invocation_mode = "batch"
         """,
         )
         with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
             assert validate_manifest("test-agent") is False
-
-
-# ---------------------------------------------------------------------------
-# Required fields
-# ---------------------------------------------------------------------------
 
 
 class TestRequiredFields:
@@ -124,6 +130,7 @@ class TestRequiredFields:
             """\
             [project]
             name = "test-agent"
+            version = "1.0.0"
         """,
         )
         with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
@@ -134,6 +141,10 @@ class TestRequiredFields:
             tmp_path,
             "test-agent",
             """\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+
             [tool.agentcore]
             name = "test-agent"
             owner_team = "team-test"
@@ -148,10 +159,15 @@ class TestRequiredFields:
             tmp_path,
             "test-agent",
             """\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+
             [tool.agentcore]
             name = "different-agent"
             owner_team = "team-test"
             tier_minimum = "basic"
+            handler = "handler:invoke"
             invocation_mode = "sync"
         """,
         )
@@ -161,3 +177,87 @@ class TestRequiredFields:
     def test_nonexistent_agent(self, tmp_path: Path) -> None:
         with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
             assert validate_manifest("no-such-agent") is False
+
+    def test_project_name_mismatch(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            "test-agent",
+            """\
+            [project]
+            name = "different-agent"
+            version = "1.0.0"
+
+            [tool.agentcore]
+            name = "test-agent"
+            owner_team = "team-test"
+            tier_minimum = "basic"
+            handler = "handler:invoke"
+            invocation_mode = "sync"
+        """,
+        )
+        with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
+            assert validate_manifest("test-agent") is False
+
+    def test_unknown_manifest_key_rejected(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            "test-agent",
+            """\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+
+            [tool.agentcore]
+            name = "test-agent"
+            owner_team = "team-test"
+            tier_minimum = "basic"
+            handler = "handler:invoke"
+            invocation_mode = "sync"
+            release_channel = "beta"
+        """,
+        )
+        with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
+            assert validate_manifest("test-agent") is False
+
+    def test_loader_reads_optional_sections(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            "test-agent",
+            """\
+            [project]
+            name = "test-agent"
+            version = "1.2.3"
+
+            [tool.agentcore]
+            name = "test-agent"
+            owner_team = "team-test"
+            tier_minimum = "premium"
+            handler = "handler:invoke"
+            invocation_mode = "async"
+            streaming_enabled = true
+            estimated_duration_seconds = 42
+
+            [tool.agentcore.llm]
+            model_id = "anthropic.claude-sonnet-4-6"
+            max_tokens = 2048
+
+            [tool.agentcore.deployment]
+            type = "container"
+
+            [tool.agentcore.evaluations]
+            threshold = 0.9
+            evaluation_region = "eu-west-1"
+        """,
+        )
+
+        manifest = load_agent_manifest("test-agent", tmp_path)
+        assert manifest.version == "1.2.3"
+        assert manifest.tier_minimum.value == "premium"
+        assert manifest.invocation_mode.value == "async"
+        assert manifest.streaming_enabled is True
+        assert manifest.estimated_duration_seconds == 42
+        assert manifest.deployment.type == "container"
+        assert manifest.llm.model_id == "anthropic.claude-sonnet-4-6"
+        assert manifest.llm.max_tokens == 2048
+        assert manifest.evaluations.threshold == pytest.approx(0.9)
+        assert manifest.evaluations.evaluation_region == "eu-west-1"


### PR DESCRIPTION
## Summary
- add a shared agent manifest loader/validator so packaging and platform metadata are read through one contract
- validate the manifest before deploy/register/evaluate scripts make any AWS API calls
- document the canonical pyproject manifest boundary and extend unit coverage for schema drift

## Validation
- `uv run pytest tests/unit/test_validate_agent_manifest.py tests/unit/test_agent_scripts.py`
- `make preflight-session`
- `make pre-validate-session`

## Notes
- `make validate-local` still hits an existing CDK synth issue in this worktree: `infra/cdk/lib/platform-stack.ts` expects `infra/cdk/cdk.out/platform-tenant-stub-dev.template.json` before synth can generate it. This is outside #305 and unchanged by this branch.

Closes #305