### PR TITLE
Define explicit agent release state model and transition rules

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,16 +133,16 @@
         "filename": "tests/unit/test_models.py",
         "hashed_secret": "783c030365a37a432b13863d83a01320f8a8ea4d",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 120
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/unit/test_models.py",
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
-        "line_number": 250
+        "line_number": 256
       }
     ]
   },
-  "generated_at": "2026-03-21T02:28:43Z"
+  "generated_at": "2026-03-22T04:05:46Z"
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,8 +253,25 @@ See [ADR-012](decisions/ADR-012-dynamodb-capacity.md) for capacity mode rational
 - PK: `AGENT#{agentName}`, SK: `VERSION#{semver}`
 - Attributes: agentName, version, ownerTeam, tierMinimum, layerHash,
   layerS3Key, scriptS3Key, runtimeArn, deployedAt, invocationMode,
-  streamingEnabled, estimatedDurationSeconds
+  streamingEnabled, estimatedDurationSeconds, status, approvedBy,
+  approvedAt, releaseNotes
 - Capacity: provisioned, auto-scaling
+
+### Agent Release State Source Of Truth
+
+The release state of an immutable built agent version is owned by
+`platform-agents.status` in DynamoDB. The canonical lifecycle is:
+
+`built -> deployed_staging -> integration_verified -> evaluation_passed -> approved -> promoted`
+
+Terminal branches:
+- `failed` from any pre-promoted gate
+- `rolled_back` from `promoted`
+
+Only `promoted` versions are tenant-invokable. The Bridge resolves the active
+version as the highest semver record for an agent where `status=promoted`.
+Rollback is a forward metadata transition on the bad version; the Bridge then
+falls back to the next-highest promoted version without rebuilding artifacts.
 
 **platform-invocations** — invocation audit log
 - PK: `TENANT#{tenantId}`, SK: `INV#{timestamp}#{invocationId}`

--- a/docs/decisions/ADR-015-agent-release-governance-and-rollback.md
+++ b/docs/decisions/ADR-015-agent-release-governance-and-rollback.md
@@ -9,32 +9,50 @@ Currently, agent registration and rollback are performed by scripts that directl
 This model has several weaknesses:
 1.  **Auditability:** Deleting records destroys the audit trail of what was actually running at any given time.
 2.  **Governance:** Direct database access bypasses the Platform API's RBAC and audit logging.
-3.  **Safety:** There is no formal "Pending" state for new versions; registration immediately makes a version "live" if it has the highest semver.
+3.  **Safety:** There is no explicit gated lifecycle between artifact registration and tenant-visible promotion.
 4.  **Compliance:** Production systems with compliance obligations must maintain immutable records of all software versions deployed.
 
 ## Decision
 The platform will adopt a "Status-Based" release governance and rollback model.
 
-### 1. Agent Status Lifecycle
-Every `AgentRecord` in DynamoDB will include a `status` field:
--   `PENDING`: Version is registered and artifacts are uploaded, but it is not yet invokable by tenants.
--   `RELEASED`: Version is approved and invokable. The Bridge picks the highest semver version with this status.
--   `ROLLBACK`: Version has been deactivated due to a reported issue. It is preserved for audit but never invoked.
--   `DEPRECATED`: Version is old but still invokable if explicitly requested by version (future capability), but not the default.
+### 1. Agent Release Status Lifecycle
+`platform-agents` is the source of truth for the release state of an immutable built version.
+Every `AgentRecord` in DynamoDB includes a `status` field with the canonical lifecycle:
+
+-   `BUILT`: Artifacts are registered and immutable, but not yet deployed to staging.
+-   `DEPLOYED_STAGING`: The built version is deployed to staging for verification.
+-   `INTEGRATION_VERIFIED`: Staging integration checks passed.
+-   `EVALUATION_PASSED`: Required evaluation gates passed.
+-   `APPROVED`: An authorized operator recorded approval evidence for promotion.
+-   `PROMOTED`: The version is tenant-invokable. The Bridge picks the highest semver version with this status.
+-   `ROLLED_BACK`: A previously promoted version was withdrawn by operator action. It is preserved for audit and never invoked again.
+-   `FAILED`: A pre-promotion gate failed. The version remains immutable and is not revived; a replacement must register as a new version.
+
+Valid transitions are:
+
+-   `BUILT -> DEPLOYED_STAGING | FAILED`
+-   `DEPLOYED_STAGING -> INTEGRATION_VERIFIED | FAILED`
+-   `INTEGRATION_VERIFIED -> EVALUATION_PASSED | FAILED`
+-   `EVALUATION_PASSED -> APPROVED | FAILED`
+-   `APPROVED -> PROMOTED | FAILED`
+-   `PROMOTED -> ROLLED_BACK`
+
+All other transitions are invalid.
 
 ### 2. Immutability
 Agent versions are immutable. Once a version (e.g., `v1.2.3`) is registered, its associated S3 keys, hashes, and configuration cannot be modified. Only the `status` and governance metadata (`approved_by`, etc.) may change.
 
 ### 3. Promotion Workflow
--   **Registration:** New versions are registered via a Platform API endpoint. In `dev` environments, they may default to `RELEASED`. In `prod`, they must start as `PENDING`.
--   **Approval:** An authorized operator (`Platform.Admin`) promotes a `PENDING` version to `RELEASED` via a PATCH operation.
--   **Bridge Resolution:** The Bridge Lambda finds the "active" version by querying the `platform-agents` table for the highest semver where `status = RELEASED`.
+-   **Registration:** New versions are registered via a Platform API endpoint in `BUILT` state after artifact upload/manifest validation.
+-   **Verification Gates:** Platform operations advance the version through staging deploy, integration verification, evaluation, and approval states.
+-   **Promotion:** An authorized operator (`Platform.Admin`) promotes an `APPROVED` version to `PROMOTED` via a PATCH operation. Promotion is a control-plane status change against the already-built version; it is never an implicit rebuild.
+-   **Bridge Resolution:** The Bridge Lambda finds the active version by querying the `platform-agents` table for the highest semver where `status = PROMOTED`.
 
 ### 4. Rollback Mechanism
 Rollback is a "forward" metadata transition:
 1.  The operator identifies the bad version.
-2.  The operator updates the bad version's status to `ROLLBACK`.
-3.  The Bridge immediately stops using that version and falls back to the next-highest `RELEASED` version.
+2.  The operator updates the bad version's status from `PROMOTED` to `ROLLED_BACK`.
+3.  The Bridge immediately stops using that version and falls back to the next-highest `PROMOTED` version.
 4.  No records are deleted.
 
 ### 5. Platform API Ownership
@@ -64,7 +82,7 @@ New routes in `openapi.yaml`:
 -   **Full Audit Trail:** Every version ever deployed remains in the database.
 -   **Compliance:** Meets requirements for controlled releases and non-destructive rollbacks.
 -   **RBAC:** Leverages existing platform roles for release control.
--   **Safety:** `PENDING` state allows smoke testing before broad release (if the Bridge supports it).
+-   **Safety:** Explicit pre-promotion states allow staging, integration, evaluation, and approval evidence before tenant exposure.
 
 ### Negative
 -   **Storage:** Slightly higher DynamoDB storage (negligible for agent metadata).
@@ -73,7 +91,7 @@ New routes in `openapi.yaml`:
 
 ## Implementation Notes
 1.  Update `data-access-lib` models.
-2.  Update `tenant_api` with new routes.
-3.  Update `bridge` to filter for `status=RELEASED`.
+2.  Update `tenant_api` with new routes and transition validation.
+3.  Update `bridge` to filter for `status=PROMOTED`.
 4.  Update `scripts/register_agent.py` and `scripts/rollback_agent.py`.
-5.  Perform a one-time backfill of `status=RELEASED` for existing agent records.
+5.  Perform a one-time backfill of legacy `released/pending/rollback` statuses into the canonical model.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -775,7 +775,7 @@ paths:
       tags: [Platform]
       operationId: platformListAgents
       summary: List all agents for operators
-      description: Returns all versions of all agents, including PENDING and ROLLBACK.
+      description: Returns all registered agent versions with canonical release state and governance metadata.
       x-required-roles:
         - Platform.Admin
         - Platform.Operator
@@ -799,7 +799,7 @@ paths:
       tags: [Platform]
       operationId: registerAgentVersion
       summary: Register a new agent version
-      description: Registers a new version of an agent. Defaults to PENDING status.
+      description: Registers an immutable built version. New versions enter the release lifecycle in `built` state.
       x-required-roles:
         - Platform.Admin
         - Platform.Operator
@@ -826,7 +826,7 @@ paths:
       tags: [Platform]
       operationId: updateAgentVersion
       summary: Update agent version status
-      description: Promotes a version to RELEASED or marks it as ROLLBACK.
+      description: Advances a version through the canonical release lifecycle or marks the currently promoted version as `rolled_back`.
       x-required-roles:
         - Platform.Admin
         - Platform.Operator
@@ -1200,7 +1200,8 @@ components:
       enum: [pending, running, completed, failed]
     AgentStatus:
       type: string
-      enum: [pending, released, rollback, deprecated]
+      description: Canonical release state stored in `platform-agents`. Valid transitions are `built -> deployed_staging -> integration_verified -> evaluation_passed -> approved -> promoted`, with `failed` reachable from any pre-promoted gate and `rolled_back` reachable only from `promoted`.
+      enum: [built, deployed_staging, integration_verified, evaluation_passed, approved, promoted, rolled_back, failed]
     SessionState:
       type: string
       enum: [active, completed, expired]
@@ -1350,10 +1351,12 @@ components:
           $ref: "#/components/schemas/AgentStatus"
         approvedBy:
           type: string
+          description: Identity that recorded approval or promotion evidence for this version.
         approvedAt:
           $ref: "#/components/schemas/UtcTimestamp"
         releaseNotes:
           type: string
+          description: Operator-supplied release or rollback evidence.
         runtimeArn:
           type: string
         estimatedDurationSeconds:

--- a/docs/operations/RUNBOOK-007-deployment-rollback.md
+++ b/docs/operations/RUNBOOK-007-deployment-rollback.md
@@ -4,14 +4,15 @@
 Agent promotion is a control-plane metadata change against an already registered
 version. Do not rebuild or repackage the agent as part of promotion.
 
-1. Register the candidate version. In `prod` it must remain `pending`.
-2. Verify staging/integration evidence and evaluation results for that exact version.
-3. Promote the version to `released`.
+1. Register the candidate version. New versions enter the registry in `built` state.
+2. Advance the exact version through `deployed_staging`, `integration_verified`,
+   `evaluation_passed`, and `approved`.
+3. Promote the version to `promoted`.
 4. Record release notes or ticket evidence with the promotion action.
 
 Operational rule:
 - Promotion changes agent status metadata only. The active default version is the
-  highest `released` semver in the agent registry.
+  highest `promoted` semver in the agent registry.
 
 ## Auto-Rollback (handled by pipeline)
 The canary deployment monitors error_rate_high alarm. If it fires within 30 minutes
@@ -46,8 +47,8 @@ npx cdk deploy --all --context env=prod --rollback
 ## Agent Rollback
 ```bash
 make agent-rollback AGENT={agentName} ENV=prod
-# Marks the current released version as rollback and re-points runtime metadata
-# to the next-highest released version in the agent registry
+# Marks the current promoted version as rolled_back and re-points runtime metadata
+# to the next-highest promoted version in the agent registry
 # Does not require a rebuild or pipeline run
 ```
 

--- a/scripts/rollback_agent.py
+++ b/scripts/rollback_agent.py
@@ -25,6 +25,7 @@ from botocore.exceptions import ClientError
 
 # Reuse bucket resolution from build_layer
 from build_layer import resolve_layer_bucket
+from data_access.models import AgentStatus, is_invokable_agent_status, normalize_agent_status
 
 logger = logging.getLogger("rollback_agent")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -78,32 +79,32 @@ def rollback_agent(agent_name: str, env: str) -> bool:
         logger.error(f"No versions found for agent '{agent_name}'.")
         return False
 
-    # 1. Identify current version (latest RELEASED one)
-    released_versions = [v for v in versions if v.get("status", "released") == "released"]
-    if not released_versions:
-        logger.error(f"No RELEASED versions found for agent '{agent_name}'.")
+    # 1. Identify current promoted version.
+    promoted_versions = [v for v in versions if is_invokable_agent_status(v.get("status"))]
+    if not promoted_versions:
+        logger.error(f"No PROMOTED versions found for agent '{agent_name}'.")
         return False
 
-    released_versions.sort(
+    promoted_versions.sort(
         key=lambda item: _semver_sort_key(str(item.get("version", ""))),
         reverse=True,
     )
-    current_version = released_versions[0]
+    current_version = promoted_versions[0]
 
-    # 2. Identify previous RELEASED version
-    if len(released_versions) < 2:
+    # 2. Identify previous promoted version
+    if len(promoted_versions) < 2:
         logger.error(
-            f"Rollback failed: No previous RELEASED version found for agent '{agent_name}'. "
+            f"Rollback failed: No previous PROMOTED version found for agent '{agent_name}'. "
             f"Current version is {current_version['version']}."
         )
         return False
 
-    previous_version = released_versions[1]
+    previous_version = promoted_versions[1]
 
     logger.info(
         f"Rolling back agent '{agent_name}' from v{current_version['version']} "
         f"to v{previous_version['version']} "
-        f"(previously released at {previous_version.get('deployed_at')})"
+        f"(previously promoted at {previous_version.get('deployed_at')})"
     )
 
     bucket = resolve_layer_bucket(env, aws_region)
@@ -155,18 +156,25 @@ def rollback_agent(agent_name: str, env: str) -> bool:
             logger.error(f"Failed to update SSM parameter {name}: {e}")
             return False
 
-    # 5. Mark the bad version as ROLLBACK in DynamoDB
-    logger.info(f"Marking v{current_version['version']} as ROLLBACK in DynamoDB")
+    # 5. Mark the bad version as rolled_back in DynamoDB
+    current_status = normalize_agent_status(
+        current_version.get("status"), default=AgentStatus.PROMOTED
+    )
+    logger.info(
+        f"Marking v{current_version['version']} as {AgentStatus.ROLLED_BACK.value} in DynamoDB"
+    )
     try:
         table.update_item(
             Key={"PK": current_version["PK"], "SK": current_version["SK"]},
             UpdateExpression="SET #s = :s, #ua = :ua, #rb = :rb",
             ExpressionAttributeNames={"#s": "status", "#ua": "updated_at", "#rb": "rolled_back_by"},
             ExpressionAttributeValues={
-                ":s": "rollback",
+                ":s": AgentStatus.ROLLED_BACK.value,
                 ":ua": datetime.now(UTC).isoformat(),
                 ":rb": "cli-operator",  # In a script, we don't always have the sub
+                ":current_status": current_status.value,
             },
+            ConditionExpression="#s = :current_status OR attribute_not_exists(#s)",
         )
     except ClientError as e:
         logger.error(f"Failed to update version status in DynamoDB: {e}")

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -41,6 +41,8 @@ from data_access.models import (
     JobStatus,
     TenantContext,
     TenantTier,
+    is_invokable_agent_status,
+    normalize_agent_status,
 )
 
 logger = Logger(service="bridge")
@@ -310,7 +312,7 @@ def get_agent_record(agent_name: str, version: str | None = None) -> AgentRecord
         table = ddb.Table(AGENTS_TABLE)
 
         if not version:
-            # Query for latest versions and find the highest semver that is RELEASED
+            # Query for latest versions and find the highest semver that is tenant-invokable.
             response = table.query(
                 KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"),
                 ScanIndexForward=False,  # Highest version SK first
@@ -319,18 +321,26 @@ def get_agent_record(agent_name: str, version: str | None = None) -> AgentRecord
             if not items:
                 return None
 
-            released_items = [i for i in items if i.get("status", "released") == "released"]
-            item = max(released_items, key=_agent_record_sort_key, default=None)
+            invokable_items = [
+                i
+                for i in items
+                if is_invokable_agent_status(_coerce_optional_string(i.get("status")))
+            ]
+            item = max(invokable_items, key=_agent_record_sort_key, default=None)
         else:
             response = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{version}"})
             item = response.get("Item")
-            if item and item.get("status", "released") != "released":
+            item_status = _coerce_optional_string(item.get("status")) if item else None
+            if item and not is_invokable_agent_status(item_status):
                 logger.warning(
-                    "Requested agent version is not RELEASED",
+                    "Requested agent version is not invokable",
                     extra={
                         "agent_name": agent_name,
                         "version": version,
-                        "status": item.get("status"),
+                        "status": normalize_agent_status(
+                            item_status,
+                            default=AgentStatus.PROMOTED,
+                        ).value,
                     },
                 )
                 return None
@@ -349,7 +359,10 @@ def get_agent_record(agent_name: str, version: str | None = None) -> AgentRecord
             deployed_at=str(item["deployed_at"]),
             invocation_mode=InvocationMode(str(item["invocation_mode"])),
             streaming_enabled=bool(item.get("streaming_enabled", False)),
-            status=AgentStatus(str(item.get("status", "released"))),
+            status=normalize_agent_status(
+                _coerce_optional_string(item.get("status")),
+                default=AgentStatus.PROMOTED,
+            ),
             approved_by=_coerce_optional_string(item.get("approved_by")),
             approved_at=_coerce_optional_string(item.get("approved_at")),
             release_notes=_coerce_optional_string(item.get("release_notes")),
@@ -971,8 +984,8 @@ def list_agents(tenant_context: TenantContext) -> dict[str, Any]:
 
     latest_by_name: dict[str, dict[str, Any]] = {}
     for item in items:
-        # Filter: only RELEASED agents are visible/invokable
-        if item.get("status", "released") != "released":
+        # Filter: only promoted agents are visible/invokable.
+        if not is_invokable_agent_status(_coerce_optional_string(item.get("status"))):
             continue
 
         agent_name = _coerce_optional_string(item.get("agent_name"))
@@ -1014,12 +1027,14 @@ def get_agent_detail(path_params: dict[str, Any], request_id: str) -> dict[str, 
     response = table.query(KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"))
     items = response.get("Items", [])
 
-    # Filter: only RELEASED versions are visible to tenants
-    released_items = [i for i in items if i.get("status", "released") == "released"]
-    if not released_items:
+    # Filter: only promoted versions are visible to tenants.
+    promoted_items = [
+        i for i in items if is_invokable_agent_status(_coerce_optional_string(i.get("status")))
+    ]
+    if not promoted_items:
         return error_response(404, "NOT_FOUND", f"Agent '{agent_name}' not found", request_id)
 
-    sorted_items = sorted(released_items, key=_agent_record_sort_key, reverse=True)
+    sorted_items = sorted(promoted_items, key=_agent_record_sort_key, reverse=True)
     latest = sorted_items[0]
     detail = _agent_summary_from_item(latest)
     detail["versions"] = [

--- a/src/data-access-lib/src/data_access/models.py
+++ b/src/data-access-lib/src/data_access/models.py
@@ -85,10 +85,14 @@ class WebhookStatus(StrEnum):
 
 
 class AgentStatus(StrEnum):
-    PENDING = "pending"
-    RELEASED = "released"
-    ROLLBACK = "rollback"
-    DEPRECATED = "deprecated"
+    BUILT = "built"
+    DEPLOYED_STAGING = "deployed_staging"
+    INTEGRATION_VERIFIED = "integration_verified"
+    EVALUATION_PASSED = "evaluation_passed"
+    APPROVED = "approved"
+    PROMOTED = "promoted"
+    ROLLED_BACK = "rolled_back"
+    FAILED = "failed"
 
 
 class InviteStatus(StrEnum):
@@ -134,6 +138,26 @@ DYNAMODB_TENANT_METADATA_AREAS = frozenset(
     }
 )
 
+LEGACY_AGENT_STATUS_ALIASES: dict[str, AgentStatus] = {
+    "pending": AgentStatus.BUILT,
+    "released": AgentStatus.PROMOTED,
+    "rollback": AgentStatus.ROLLED_BACK,
+}
+REGISTERABLE_AGENT_STATUSES = frozenset({AgentStatus.BUILT})
+INVOKABLE_AGENT_STATUSES = frozenset({AgentStatus.PROMOTED})
+AGENT_STATUS_TRANSITIONS: dict[AgentStatus, frozenset[AgentStatus]] = {
+    AgentStatus.BUILT: frozenset({AgentStatus.DEPLOYED_STAGING, AgentStatus.FAILED}),
+    AgentStatus.DEPLOYED_STAGING: frozenset({AgentStatus.INTEGRATION_VERIFIED, AgentStatus.FAILED}),
+    AgentStatus.INTEGRATION_VERIFIED: frozenset(
+        {AgentStatus.EVALUATION_PASSED, AgentStatus.FAILED}
+    ),
+    AgentStatus.EVALUATION_PASSED: frozenset({AgentStatus.APPROVED, AgentStatus.FAILED}),
+    AgentStatus.APPROVED: frozenset({AgentStatus.PROMOTED, AgentStatus.FAILED}),
+    AgentStatus.PROMOTED: frozenset({AgentStatus.ROLLED_BACK}),
+    AgentStatus.ROLLED_BACK: frozenset(),
+    AgentStatus.FAILED: frozenset(),
+}
+
 
 def configuration_store_for(area: str) -> ConfigurationStore:
     """Return the owning config store for a platform configuration concern.
@@ -151,6 +175,40 @@ def configuration_store_for(area: str) -> ConfigurationStore:
     if normalized in DYNAMODB_TENANT_METADATA_AREAS:
         return ConfigurationStore.DYNAMODB
     raise ValueError(f"Unknown configuration area: {area!r}")
+
+
+def normalize_agent_status(
+    value: AgentStatus | str | None,
+    *,
+    default: AgentStatus | None = None,
+) -> AgentStatus:
+    """Normalize canonical and legacy agent release states.
+
+    Legacy aliases preserve compatibility with older registry records while the
+    canonical lifecycle now models release governance explicitly.
+    """
+
+    if isinstance(value, AgentStatus):
+        return value
+    if value is None:
+        if default is not None:
+            return default
+        raise ValueError("status is required")
+
+    normalized = str(value).strip().lower()
+    if not normalized:
+        if default is not None:
+            return default
+        raise ValueError("status is required")
+    if normalized in LEGACY_AGENT_STATUS_ALIASES:
+        return LEGACY_AGENT_STATUS_ALIASES[normalized]
+    return AgentStatus(normalized)
+
+
+def is_invokable_agent_status(value: AgentStatus | str | None) -> bool:
+    """Return True when the release state is tenant-invokable."""
+
+    return normalize_agent_status(value, default=AgentStatus.PROMOTED) in INVOKABLE_AGENT_STATUSES
 
 
 @dataclass(frozen=True)
@@ -291,7 +349,7 @@ class AgentRecord:
 
     tier_minimum: the lowest tenant tier that may invoke this agent.
     invocation_mode: declared in pyproject.toml, never inferred at runtime.
-    status: release state (ADR-015).
+    status: canonical release state for an immutable built version (ADR-015).
     """
 
     agent_name: str
@@ -304,7 +362,7 @@ class AgentRecord:
     deployed_at: str  # ISO 8601 UTC
     invocation_mode: InvocationMode
     streaming_enabled: bool
-    status: AgentStatus = AgentStatus.RELEASED
+    status: AgentStatus = AgentStatus.BUILT
     approved_by: str | None = None
     approved_at: str | None = None
     release_notes: str | None = None

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -26,7 +26,14 @@ from aws_lambda_powertools import Logger
 from boto3.dynamodb.conditions import ConditionBase, Key
 from botocore.exceptions import ClientError
 from data_access import TenantContext, TenantScopedDynamoDB, TenantScopedS3
-from data_access.models import AgentStatus, TenantStatus, TenantTier
+from data_access.models import (
+    AGENT_STATUS_TRANSITIONS,
+    REGISTERABLE_AGENT_STATUSES,
+    AgentStatus,
+    TenantStatus,
+    TenantTier,
+    normalize_agent_status,
+)
 
 logger = Logger(service="tenant-api")
 
@@ -43,13 +50,6 @@ _FAILOVER_LOCK_NAME_ENV = "FAILOVER_LOCK_NAME"
 _DELETE_RETENTION_DAYS = 30
 _ADMIN_ROLES = {"Platform.Admin"}
 _SELF_SERVICE_ADMIN_ROLES = {"Platform.Admin", "Platform.Operator", "SelfService.Admin"}
-_REGISTERABLE_AGENT_STATUSES = {AgentStatus.PENDING, AgentStatus.RELEASED}
-_ALLOWED_AGENT_STATUS_TRANSITIONS: dict[AgentStatus, set[AgentStatus]] = {
-    AgentStatus.PENDING: {AgentStatus.RELEASED, AgentStatus.ROLLBACK},
-    AgentStatus.RELEASED: {AgentStatus.ROLLBACK, AgentStatus.DEPRECATED},
-    AgentStatus.DEPRECATED: {AgentStatus.RELEASED, AgentStatus.ROLLBACK},
-    AgentStatus.ROLLBACK: set(),
-}
 _ALLOWED_TENANT_INVITE_ROLES = {"Agent.Invoke"}
 _INVITE_EXPIRY_DAYS = 7
 _AUDIT_EXPORT_PREFIX = "audit-exports"
@@ -527,20 +527,17 @@ def _normalize_status(value: Any) -> str:
 
 
 def _normalize_agent_status(value: Any) -> AgentStatus:
-    status_text = _str_or_none(value)
-    if status_text is None:
-        raise ValueError("status is required")
     try:
-        return AgentStatus(status_text.lower())
+        return normalize_agent_status(_str_or_none(value))
     except ValueError as exc:
         allowed = ", ".join(status.value for status in AgentStatus)
         raise ValueError(f"status must be one of: {allowed}") from exc
 
 
 def _agent_event_detail_type(status: AgentStatus) -> str | None:
-    if status is AgentStatus.RELEASED:
+    if status is AgentStatus.PROMOTED:
         return "platform.agent_version.promoted"
-    if status is AgentStatus.ROLLBACK:
+    if status is AgentStatus.ROLLED_BACK:
         return "platform.agent_version.rolled_back"
     return None
 
@@ -551,7 +548,7 @@ def _validate_agent_status_transition(
 ) -> None:
     if new_status == current_status:
         return
-    allowed = _ALLOWED_AGENT_STATUS_TRANSITIONS.get(current_status, set())
+    allowed = AGENT_STATUS_TRANSITIONS.get(current_status, frozenset())
     if new_status not in allowed:
         allowed_text = ", ".join(status.value for status in sorted(allowed, key=lambda s: s.value))
         raise ValueError(
@@ -2064,22 +2061,13 @@ def _handle_platform_register_agent(
     if not agent_name or not version:
         raise ValueError("agentName and version are required")
 
-    # In prod, new versions must be PENDING. In dev, they may default to RELEASED.
-    current_fn = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "platform-tenant-api-dev")
-    env = current_fn.split("-")[-1]
-
-    default_status = AgentStatus.PENDING if env == "prod" else AgentStatus.RELEASED
     status = (
-        default_status
+        AgentStatus.BUILT
         if body.get("status") is None
         else _normalize_agent_status(body.get("status"))
     )
-    if status not in _REGISTERABLE_AGENT_STATUSES:
-        raise ValueError("New agent versions may only be registered as pending or released")
-    if env == "prod" and status is not AgentStatus.PENDING:
-        raise ValueError("Production agent registration must start as pending")
-
-    approved_at = _iso(_now_utc())
+    if status not in REGISTERABLE_AGENT_STATUSES:
+        raise ValueError("New agent versions may only be registered as built")
 
     item = {
         "PK": f"AGENT#{agent_name}",
@@ -2100,9 +2088,9 @@ def _handle_platform_register_agent(
             body.get("estimatedDurationSeconds"), default=0
         ),
     }
-    if status is AgentStatus.RELEASED:
+    if status in {AgentStatus.APPROVED, AgentStatus.PROMOTED}:
         item["approved_by"] = caller.sub
-        item["approved_at"] = approved_at
+        item["approved_at"] = _iso(_now_utc())
     if body.get("releaseNotes"):
         item["release_notes"] = str(body["releaseNotes"])
 
@@ -2148,14 +2136,14 @@ def _handle_platform_update_agent_version(
     if not existing:
         return _error(404, "NOT_FOUND", f"Agent version {agent_name}:{version} not found")
 
-    current_status = AgentStatus(str(existing.get("status", AgentStatus.RELEASED.value)))
+    current_status = normalize_agent_status(existing.get("status"), default=AgentStatus.PROMOTED)
     _validate_agent_status_transition(current_status, new_agent_status)
 
     attrs: dict[str, Any] = {
         "status": new_agent_status.value,
         "updated_at": _iso(_now_utc()),
     }
-    if new_agent_status is AgentStatus.RELEASED:
+    if new_agent_status in {AgentStatus.APPROVED, AgentStatus.PROMOTED}:
         attrs["approved_by"] = caller.sub
         attrs["approved_at"] = _iso(_now_utc())
     if body.get("releaseNotes") is not None:

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -300,7 +300,7 @@ def test_get_agent_detail_returns_latest_version_and_versions(setup_data):
     assert body["versions"][0]["version"] == "1.1.0"
 
 
-def test_list_agents_ignores_pending_version_when_newer_semver_exists(setup_data):
+def test_list_agents_ignores_built_version_when_newer_semver_exists(setup_data):
     ddb = boto3.resource("dynamodb", region_name="eu-west-2")
     table = ddb.Table("platform-agents")
     table.put_item(
@@ -317,7 +317,7 @@ def test_list_agents_ignores_pending_version_when_newer_semver_exists(setup_data
             "deployed_at": "2026-01-04T00:00:00Z",
             "invocation_mode": "sync",
             "streaming_enabled": False,
-            "status": "pending",
+            "status": "built",
         }
     )
 
@@ -340,7 +340,7 @@ def test_list_agents_ignores_pending_version_when_newer_semver_exists(setup_data
     assert body["items"][0]["latestVersion"] == "1.0.0"
 
 
-def test_get_agent_detail_prefers_highest_released_semver(setup_data):
+def test_get_agent_detail_prefers_highest_promoted_semver(setup_data):
     ddb = boto3.resource("dynamodb", region_name="eu-west-2")
     table = ddb.Table("platform-agents")
     table.put_item(
@@ -357,7 +357,7 @@ def test_get_agent_detail_prefers_highest_released_semver(setup_data):
             "deployed_at": "2026-01-02T00:00:00Z",
             "invocation_mode": "sync",
             "streaming_enabled": False,
-            "status": "released",
+            "status": "promoted",
         }
     )
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -15,15 +15,19 @@ import time
 
 import pytest
 from data_access.models import (
+    AGENT_STATUS_TRANSITIONS,
     APPCONFIG_DYNAMIC_CAPABILITY_AREAS,
     DYNAMODB_TENANT_METADATA_AREAS,
     INVOCATION_TTL_SECONDS,
+    INVOKABLE_AGENT_STATUSES,
     JITTER_LENGTH,
     JOB_TTL_SECONDS,
     OPS_LOCK_TTL_SECONDS,
+    REGISTERABLE_AGENT_STATUSES,
     SESSION_TTL_SECONDS,
     SSM_PLATFORM_PARAMETER_AREAS,
     AgentRecord,
+    AgentStatus,
     CapabilityRollout,
     ConfigurationStore,
     InvocationMode,
@@ -40,6 +44,8 @@ from data_access.models import (
     TenantTier,
     ToolRecord,
     configuration_store_for,
+    is_invokable_agent_status,
+    normalize_agent_status,
 )
 
 # ---------------------------------------------------------------------------
@@ -287,6 +293,41 @@ class TestAgentRecord:
         agent = _make_agent()
         with pytest.raises((dataclasses.FrozenInstanceError, TypeError)):
             agent.version = "9.9.9"  # type: ignore[misc]
+
+    def test_default_status_is_built(self):
+        assert _make_agent().status is AgentStatus.BUILT
+
+    def test_all_agent_statuses_accepted(self):
+        for status in AgentStatus:
+            agent = _make_agent(status=status)
+            assert agent.status == status
+
+
+class TestAgentReleaseStatusHelpers:
+    def test_registerable_status_is_built_only(self):
+        assert REGISTERABLE_AGENT_STATUSES == frozenset({AgentStatus.BUILT})
+
+    def test_promoted_is_only_invokable_status(self):
+        assert INVOKABLE_AGENT_STATUSES == frozenset({AgentStatus.PROMOTED})
+        assert is_invokable_agent_status(AgentStatus.PROMOTED) is True
+        assert is_invokable_agent_status(AgentStatus.APPROVED) is False
+
+    def test_legacy_status_aliases_normalize_to_canonical_states(self):
+        assert normalize_agent_status("pending") is AgentStatus.BUILT
+        assert normalize_agent_status("released") is AgentStatus.PROMOTED
+        assert normalize_agent_status("rollback") is AgentStatus.ROLLED_BACK
+
+    def test_agent_status_transition_map_matches_release_flow(self):
+        assert AGENT_STATUS_TRANSITIONS[AgentStatus.BUILT] == frozenset(
+            {AgentStatus.DEPLOYED_STAGING, AgentStatus.FAILED}
+        )
+        assert AGENT_STATUS_TRANSITIONS[AgentStatus.APPROVED] == frozenset(
+            {AgentStatus.PROMOTED, AgentStatus.FAILED}
+        )
+        assert AGENT_STATUS_TRANSITIONS[AgentStatus.PROMOTED] == frozenset(
+            {AgentStatus.ROLLED_BACK}
+        )
+        assert AGENT_STATUS_TRANSITIONS[AgentStatus.ROLLED_BACK] == frozenset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rollback_agent.py
+++ b/tests/unit/test_rollback_agent.py
@@ -110,15 +110,15 @@ def test_rollback_agent_success(tmp_path, monkeypatch):
     success = rollback_agent.rollback_agent(agent_name, env)
     assert success is True
 
-    # Verify v1.1.0 is marked as rollback
+    # Verify v1.1.0 is marked as rolled_back
     response = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": "VERSION#1.1.0"})
     assert "Item" in response
-    assert response["Item"]["status"] == "rollback"
+    assert response["Item"]["status"] == "rolled_back"
 
     # Verify v1.0.0 still exists
     response = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": "VERSION#1.0.0"})
     assert "Item" in response
-    # It should still be 'released' (default in test if not set)
+    # It should still be tenant-invokable via the legacy default path used by the script.
 
     # Verify SSM points back to v1.0.0
     latest_version_param = ssm.get_parameter(

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -521,7 +521,7 @@ def _seed_agent_version(
     *,
     agent_name: str,
     version: str,
-    status: str = "pending",
+    status: str = "built",
 ) -> None:
     fake_state["db"].items[(f"AGENT#{agent_name}", f"VERSION#{version}")] = {
         "PK": f"AGENT#{agent_name}",
@@ -2039,7 +2039,7 @@ def test_lambda_rollback_returns_404_on_missing_function(fake_state: dict[str, A
     assert response["statusCode"] == 404
 
 
-def test_platform_register_agent_defaults_dev_to_released(fake_state: dict[str, Any]) -> None:
+def test_platform_register_agent_defaults_to_built(fake_state: dict[str, Any]) -> None:
     event = _event(
         method="POST",
         body={
@@ -2060,19 +2060,19 @@ def test_platform_register_agent_defaults_dev_to_released(fake_state: dict[str, 
 
     assert response["statusCode"] == 201
     item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]
-    assert item["status"] == "released"
-    assert item["approved_by"] == "user-123"
+    assert item["status"] == "built"
+    assert "approved_by" not in item
 
 
-def test_platform_register_agent_defaults_prod_to_pending(
-    fake_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+def test_platform_register_agent_rejects_non_built_initial_status(
+    fake_state: dict[str, Any],
 ) -> None:
-    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "platform-tenant-api-prod")
     event = _event(
         method="POST",
         body={
             "agentName": "echo-agent",
             "version": "1.2.1",
+            "status": "promoted",
             "ownerTeam": "platform",
             "tierMinimum": "basic",
             "layerHash": "hash-121",
@@ -2086,40 +2086,17 @@ def test_platform_register_agent_defaults_prod_to_pending(
 
     response = _invoke(event)
 
-    assert response["statusCode"] == 201
-    item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.1")]
-    assert item["status"] == "pending"
-    assert "approved_by" not in item
-
-
-def test_platform_register_agent_rejects_invalid_initial_status(
-    fake_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "platform-tenant-api-prod")
-    event = _event(
-        method="POST",
-        body={
-            "agentName": "echo-agent",
-            "version": "1.2.0",
-            "status": "released",
-        },
-        roles=["Platform.Admin"],
-    )
-    event["path"] = "/v1/platform/agents"
-
-    response = _invoke(event)
-
     assert response["statusCode"] == 400
-    assert ("AGENT#echo-agent", "VERSION#1.2.0") not in fake_state["db"].items
+    assert ("AGENT#echo-agent", "VERSION#1.2.1") not in fake_state["db"].items
 
 
 def test_platform_promote_agent_updates_metadata_and_emits_event(
     fake_state: dict[str, Any],
 ) -> None:
-    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="pending")
+    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="approved")
     event = _event(
         method="PATCH",
-        body={"status": "released", "releaseNotes": "integration verified"},
+        body={"status": "promoted", "releaseNotes": "approved release evidence recorded"},
         roles=["Platform.Admin"],
     )
     event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
@@ -2128,21 +2105,21 @@ def test_platform_promote_agent_updates_metadata_and_emits_event(
 
     assert response["statusCode"] == 200
     item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]
-    assert item["status"] == "released"
+    assert item["status"] == "promoted"
     assert item["approved_by"] == "user-123"
     assert item["approved_at"] == "2026-02-25T12:00:00Z"
-    assert item["release_notes"] == "integration verified"
+    assert item["release_notes"] == "approved release evidence recorded"
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.promoted"
-    assert detail["previousStatus"] == "pending"
-    assert detail["status"] == "released"
+    assert detail["previousStatus"] == "approved"
+    assert detail["status"] == "promoted"
 
 
 def test_platform_rejects_invalid_agent_status_transition(fake_state: dict[str, Any]) -> None:
-    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="released")
+    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="promoted")
     event = _event(
         method="PATCH",
-        body={"status": "pending"},
+        body={"status": "built"},
         roles=["Platform.Admin"],
     )
     event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
@@ -2155,10 +2132,10 @@ def test_platform_rejects_invalid_agent_status_transition(fake_state: dict[str, 
 
 
 def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None:
-    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="released")
+    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="promoted")
     event = _event(
         method="PATCH",
-        body={"status": "rollback", "releaseNotes": "error rate spike"},
+        body={"status": "rolled_back", "releaseNotes": "error rate spike"},
         roles=["Platform.Admin"],
     )
     event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
@@ -2167,8 +2144,8 @@ def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None
 
     assert response["statusCode"] == 200
     item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]
-    assert item["status"] == "rollback"
+    assert item["status"] == "rolled_back"
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.rolled_back"
-    assert detail["previousStatus"] == "released"
-    assert detail["status"] == "rollback"
+    assert detail["previousStatus"] == "promoted"
+    assert detail["status"] == "rolled_back"


### PR DESCRIPTION
Closes #306

## Summary
- define the canonical agent release lifecycle and transition rules around immutable built versions
- make `platform-agents.status` the explicit source of truth for promotion and rollback semantics
- update platform routes, bridge resolution, rollback tooling, and docs to use the canonical model

## Validation
- `pytest tests/unit/test_models.py tests/unit/test_tenant_api_handler.py tests/unit/test_bridge_handler.py tests/unit/test_rollback_agent.py -q`
  - `183 passed in 661.56s (0:11:01)`
- `pytest tests/unit/test_bridge_handler.py -q -k 'list_agents or get_agent_detail or handler_agent_not_found or handler_tier_insufficient or handler_async_accepted'`
  - `10 passed, 14 deselected in 254.43s (0:04:14)`
- `make preflight-session`
  - PASS
- `make pre-validate-session`
  - PASS
- `make worktree-push-issue`
  - PASS

## Notes
- `.secrets.baseline` refreshed only for updated line references during detect-secrets.
