### PR TITLE
Clarify config ownership fallback boundaries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,6 +225,21 @@ when available, otherwise fall back to an empty policy that enables nothing.
 Kill switches override all rollout rules. Rollback of capability changes uses
 AppConfig version history rather than ad hoc DynamoDB edits.
 
+### Safe Defaults And Fallbacks
+
+- **AppConfig** is fail-closed for tenant capabilities. If a fetch fails, use the
+  last known good cached document; if none exists, use an empty policy that
+  enables nothing. Control-plane code must not reconstruct capability policy
+  from DynamoDB or SSM.
+- **SSM Parameter Store** is for operational inputs only. Missing or invalid SSM
+  values must never widen tenant capability access. Where a runtime-safe default
+  exists in code, it must be an explicitly approved operational default inside
+  the ADR-defined region policy, not an inferred tenant-policy value.
+- **DynamoDB** remains authoritative for tenant metadata and transactional state.
+  If required tenant or resource records are absent, handlers fail the specific
+  operation rather than rebuilding tenant state from AppConfig documents or SSM
+  parameters.
+
 ## Entity Lifecycle
 
 ![Entity state diagram: tenant, agent, invocation, job, and session lifecycle states and transitions](images/tf_acore_aas_entities_state_diagram.drawio.png)

--- a/docs/decisions/ADR-017-tenant-capability-configuration-model.md
+++ b/docs/decisions/ADR-017-tenant-capability-configuration-model.md
@@ -54,6 +54,18 @@ The platform splits configuration ownership across three stores:
 - Percentage rollout must be deterministic per tenant identifier so rollout
   membership stays stable across repeated reads.
 
+## Safe Defaults And Failure Boundaries
+- AppConfig failure is **fail-closed** for tenant capability policy. The control
+  plane must not rebuild capability decisions from DynamoDB tenant records or SSM
+  parameters.
+- SSM parameters are operational inputs, not tenant feature policy. Missing or
+  invalid SSM values must never widen tenant capability access. Where code uses a
+  built-in default for an SSM-backed parameter, that default must be an explicit,
+  approved operational default within existing ADR constraints.
+- DynamoDB remains authoritative for tenant metadata and transactional state. If
+  a required tenant or resource record is missing, the operation fails rather
+  than synthesizing tenant state from AppConfig or SSM.
+
 ## Rollout and Rollback
 - Capability changes are published through AppConfig deployment workflows.
 - Validators should reject malformed capability documents before rollout.


### PR DESCRIPTION
## Summary
- make the AppConfig, SSM Parameter Store, and DynamoDB ownership boundaries explicit in the architecture doc
- document fail-closed fallback rules so capability policy is never reconstructed from SSM or DynamoDB
- mirror the same safe-default and failure-boundary rules in ADR-017

Closes #309

## Validation
- `make preflight-session`
- `make pre-validate-session`
- enforced `pre-push` hook (`make validate-pre-push`)
