### PR TITLE
Clarify config ownership fallback boundaries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,6 +225,21 @@ when available, otherwise fall back to an empty policy that enables nothing.
 Kill switches override all rollout rules. Rollback of capability changes uses
 AppConfig version history rather than ad hoc DynamoDB edits.
 
+### Safe Defaults And Fallbacks
+
+- **AppConfig** is fail-closed for tenant capabilities. If a fetch fails, use the
+  last known good cached document; if none exists, use an empty policy that
+  enables nothing. Control-plane code must not reconstruct capability policy
+  from DynamoDB or SSM.
+- **SSM Parameter Store** is for operational inputs only. Missing or invalid SSM
+  values must never widen tenant capability access. Where a runtime-safe default
+  exists in code, it must be an explicitly approved operational default inside
+  the ADR-defined region policy, not an inferred tenant-policy value.
+- **DynamoDB** remains authoritative for tenant metadata and transactional state.
+  If required tenant or resource records are absent, handlers fail the specific
+  operation rather than rebuilding tenant state from AppConfig documents or SSM
+  parameters.
+
 ## Entity Lifecycle
 
 ![Entity state diagram: tenant, agent, invocation, job, and session lifecycle states and transitions](images/tf_acore_aas_entities_state_diagram.drawio.png)

--- a/docs/decisions/ADR-017-tenant-capability-configuration-model.md
+++ b/docs/decisions/ADR-017-tenant-capability-configuration-model.md
@@ -54,6 +54,18 @@ The platform splits configuration ownership across three stores:
 - Percentage rollout must be deterministic per tenant identifier so rollout
   membership stays stable across repeated reads.
 
+## Safe Defaults And Failure Boundaries
+- AppConfig failure is **fail-closed** for tenant capability policy. The control
+  plane must not rebuild capability decisions from DynamoDB tenant records or SSM
+  parameters.
+- SSM parameters are operational inputs, not tenant feature policy. Missing or
+  invalid SSM values must never widen tenant capability access. Where code uses a
+  built-in default for an SSM-backed parameter, that default must be an explicit,
+  approved operational default within existing ADR constraints.
+- DynamoDB remains authoritative for tenant metadata and transactional state. If
+  a required tenant or resource record is missing, the operation fails rather
+  than synthesizing tenant state from AppConfig or SSM.
+
 ## Rollout and Rollback
 - Capability changes are published through AppConfig deployment workflows.
 - Validators should reject malformed capability documents before rollout.


### PR DESCRIPTION
## Summary
- make the AppConfig, SSM Parameter Store, and DynamoDB ownership boundaries explicit in the architecture doc
- document fail-closed fallback rules so capability policy is never reconstructed from SSM or DynamoDB
- mirror the same safe-default and failure-boundary rules in ADR-017

Closes #309

## Validation
- make[5]: Entering directory '/mnt/c/Users/julia/worktrees/wt309'
uv run python scripts/worktree_issues.py preflight
Preflight context:
  repo:     /mnt/c/Users/julia/worktrees/wt309
  path:     /mnt/c/Users/julia/worktrees/wt309
  worktree: /mnt/c/Users/julia/worktrees/wt309
  primary:  /mnt/c/Users/julia/tf-acore-aas
  branch:   wt/task/309-define-config-ownership-boundaries-between-appconfig-ssm-and
Preflight result: PASS
make[5]: Leaving directory '/mnt/c/Users/julia/worktrees/wt309'
- make[5]: Entering directory '/mnt/c/Users/julia/worktrees/wt309'
uv run python scripts/worktree_issues.py pre-validate \
	--path "/mnt/c/Users/julia/worktrees/wt309"
make[6]: Entering directory '/mnt/c/Users/julia/worktrees/wt309'
==> Running pre-push validation (no cdk synth)
uv run ruff check .
All checks passed!
uv run ruff format --check .
98 files already formatted
cd infra/cdk && npx --no-install pyright --project ../../pyrightconfig.json
0 errors, 0 warnings, 0 informations
uv run pytest tests/unit/test_openapi_contract_routes.py
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/c/Users/julia/worktrees/wt309
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0
collected 5 items

tests/unit/test_openapi_contract_routes.py .....                         [100%]

============================== 5 passed in 5.44s ===============================
==> validate-cdk-ts: skipped (no CDK/TS files in commits-to-push)
==> detect-secrets (files in commits-to-push)
==> detect-secrets: no commits-to-push files detected; falling back to changed-files scan
==> detect-secrets (changed files only)
==> detect-secrets diff scan passed
==> Pre-push validation passed
make[6]: Leaving directory '/mnt/c/Users/julia/worktrees/wt309'
Running pre-push validation in /mnt/c/Users/julia/worktrees/wt309 (make validate-pre-push)
make[5]: Leaving directory '/mnt/c/Users/julia/worktrees/wt309'
- enforced  hook (make[5]: Entering directory '/mnt/c/Users/julia/worktrees/wt309'
==> Running pre-push validation (no cdk synth)
uv run ruff check .
All checks passed!
uv run ruff format --check .
98 files already formatted
cd infra/cdk && npx --no-install pyright --project ../../pyrightconfig.json
0 errors, 0 warnings, 0 informations
uv run pytest tests/unit/test_openapi_contract_routes.py
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/c/Users/julia/worktrees/wt309
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0
collected 5 items

tests/unit/test_openapi_contract_routes.py .....                         [100%]

============================== 5 passed in 5.64s ===============================
==> validate-cdk-ts: skipped (no CDK/TS files in commits-to-push)
==> detect-secrets (files in commits-to-push)
==> detect-secrets: no commits-to-push files detected; falling back to changed-files scan
==> detect-secrets (changed files only)
==> detect-secrets diff scan passed
==> Pre-push validation passed
make[5]: Leaving directory '/mnt/c/Users/julia/worktrees/wt309')
