### PR TITLE
feat: emit auditable release lifecycle events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ override.tf.json
 *_override.tf.json
 terraform/.terraform/
 infra/cdk/cdk.out/
+infra/cdk/generated/
 infra/cdk/dist/
 
 # Environment / secrets

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -288,6 +288,42 @@ version as the highest semver record for an agent where `status=promoted`.
 Rollback is a forward metadata transition on the bad version; the Bridge then
 falls back to the next-highest promoted version without rebuilding artifacts.
 
+### Release Lifecycle Audit Events
+
+Promotion and rollback are control-plane mutations owned by `tenant-api`. After
+the `platform-agents` record is updated successfully, `tenant-api` emits one
+EventBridge event on the platform event bus with detail type:
+
+- `platform.agent_version.promoted`
+- `platform.agent_version.rolled_back`
+
+Event detail schema:
+
+| Field | Meaning |
+|-------|---------|
+| `schemaVersion` | Payload schema version for downstream consumers |
+| `operation` | `promotion` or `rollback` |
+| `occurredAt` | ISO 8601 UTC timestamp for the persisted transition |
+| `actorTenantId` / `actorAppId` / `actorSub` | Control-plane actor identity; platform-operated routes should carry `tenantid=platform` |
+| `releaseId` | Stable immutable release identifier: `{agentName}:{version}` |
+| `agentRecordPk` / `agentRecordSk` | Stable DynamoDB identifiers for the release record |
+| `agentName` / `version` | Human-readable release identifiers |
+| `previousStatus` / `status` | Canonical lifecycle transition |
+| `approvedBy` / `approvedAt` | Approval evidence attached to the release, when present |
+| `releaseNotes` | Operator-supplied promotion or rollback evidence |
+| `evaluationScore` / `evaluationReportUrl` | Evaluation evidence recorded on promotion, when supplied |
+| `rolledBackBy` / `rolledBackAt` | Rollback actor and timestamp, when the transition is `rolled_back` |
+
+Semantics:
+- emitted only for the auditable terminal control-plane transitions covered by ADR-015: `approved -> promoted` and `promoted -> rolled_back`
+- emitted after the DynamoDB update succeeds, so consumers never observe a promotion or rollback that failed persistence
+- one event per successful transition; consumers should treat `releaseId` plus `status` as the stable release transition identity and may also use the EventBridge envelope `id` for delivery-level deduplication
+
+Operational consumers:
+- operator-facing release dashboards and timelines
+- compliance/audit export pipelines that need immutable release history
+- downstream release automation that reacts to confirmed promotion or rollback state changes
+
 **platform-invocations** — invocation audit log
 - PK: `TENANT#{tenantId}`, SK: `INV#{timestamp}#{invocationId}`
 - Attributes: invocationId, tenantId, appId, agentName, agentVersion,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -826,7 +826,7 @@ paths:
       tags: [Platform]
       operationId: updateAgentVersion
       summary: Update agent version status
-      description: Advances a version through the canonical release lifecycle or marks the currently promoted version as `rolled_back`.
+      description: Advances a version through the canonical release lifecycle or marks the currently promoted version as `rolled_back`. Successful promotion and rollback transitions emit the `AgentReleaseLifecycleEvent` detail payload on the platform EventBridge bus using detail types `platform.agent_version.promoted` and `platform.agent_version.rolled_back`.
       x-required-roles:
         - Platform.Admin
         - Platform.Operator
@@ -1361,6 +1361,76 @@ components:
           type: string
         estimatedDurationSeconds:
           type: integer
+
+    AgentReleaseLifecycleEvent:
+      type: object
+      description: EventBridge detail payload emitted after a promotion or rollback status write succeeds in `platform-agents`.
+      required:
+        - schemaVersion
+        - operation
+        - occurredAt
+        - actorTenantId
+        - releaseId
+        - agentRecordPk
+        - agentRecordSk
+        - agentName
+        - version
+        - previousStatus
+        - status
+      properties:
+        schemaVersion:
+          type: integer
+          description: Detail payload schema version.
+        operation:
+          type: string
+          enum: [promotion, rollback]
+        occurredAt:
+          $ref: "#/components/schemas/UtcTimestamp"
+        actorTenantId:
+          type: string
+          description: Control-plane tenant context. Platform-operated release routes should emit `platform`.
+        actorAppId:
+          type: string
+        actorSub:
+          type: string
+        releaseId:
+          type: string
+          description: Stable immutable release identifier in `{agentName}:{version}` form.
+        agentRecordPk:
+          type: string
+          description: Stable DynamoDB partition key for the release record.
+        agentRecordSk:
+          type: string
+          description: Stable DynamoDB sort key for the release record.
+        agentName:
+          type: string
+        version:
+          type: string
+        previousStatus:
+          $ref: "#/components/schemas/AgentStatus"
+        status:
+          $ref: "#/components/schemas/AgentStatus"
+        approvedBy:
+          type: string
+          description: Approval identity already attached to the release record, when present.
+        approvedAt:
+          $ref: "#/components/schemas/UtcTimestamp"
+        releaseNotes:
+          type: string
+          description: Operator-supplied evidence for promotion or rollback.
+        evaluationScore:
+          type: number
+          format: float
+          description: Evaluation score captured with promotion evidence, when supplied.
+        evaluationReportUrl:
+          type: string
+          format: uri
+          description: Evaluation report link captured with promotion evidence, when supplied.
+        rolledBackBy:
+          type: string
+          description: Actor identity that performed the rollback, when the transition is `rolled_back`.
+        rolledBackAt:
+          $ref: "#/components/schemas/UtcTimestamp"
 
     AgentInvokeRequest:
       type: object

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -31,9 +31,14 @@ import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
 import * as s3assets from 'aws-cdk-lib/aws-s3-assets';
+import { Template } from 'aws-cdk-lib/assertions';
 import { Construct } from 'constructs';
+import * as fs from 'fs';
 import * as path from 'path';
 import { resolveEntraConfiguration } from './entra-config';
+import { TenantStack } from './tenant-stack';
+
+const TENANT_AUTHORIZED_RUNTIME_REGIONS = ['eu-west-1', 'eu-central-1'] as const;
 
 type PythonLambdaProps = {
   assetPath: string;
@@ -59,6 +64,44 @@ export interface PlatformStackProps extends cdk.StackProps {
   readonly vpc: ec2.IVpc;
   readonly tenantDataKey: kms.IKey;
   readonly platformConfigKey: kms.IKey;
+}
+
+function ensureTenantStubTemplate(
+  env: string,
+  stackEnv: cdk.Environment,
+  authorizedRuntimeRegions: readonly string[],
+): string {
+  const generatedDir = path.join(__dirname, '../generated');
+  const stackId = `platform-tenant-stub-${env}`;
+  const templatePath = path.join(generatedDir, `${stackId}.template.json`);
+
+  if (fs.existsSync(templatePath)) {
+    return templatePath;
+  }
+
+  fs.mkdirSync(generatedDir, { recursive: true });
+
+  const tempApp = new cdk.App({
+    outdir: generatedDir,
+    context: {
+      env,
+    },
+  });
+
+  const tenantStubStack = new TenantStack(tempApp, stackId, {
+    env: stackEnv,
+    description: `Platform per-tenant resources stub — ${env}`,
+    authorizedRuntimeRegions,
+  });
+
+  const tenantTemplate = Template.fromStack(tenantStubStack).toJSON();
+  fs.writeFileSync(templatePath, JSON.stringify(tenantTemplate, null, 2));
+
+  if (!fs.existsSync(templatePath)) {
+    throw new Error(`Failed to synthesize tenant stub template at ${templatePath}`);
+  }
+
+  return templatePath;
 }
 
 export class PlatformStack extends cdk.Stack {
@@ -468,8 +511,13 @@ export class PlatformStack extends cdk.Stack {
     // The TenantStack template is synthesized during 'cdk synth' and needs to be
     // available to the provisioner Lambda via S3.
     // NOTE: This assumes 'cdk synth' has run and populated cdk.out.
+    const tenantStackTemplatePath = ensureTenantStubTemplate(
+      env,
+      this.env,
+      TENANT_AUTHORIZED_RUNTIME_REGIONS,
+    );
     const tenantStackTemplateAsset = new s3assets.Asset(this, 'TenantStackTemplateAsset', {
-      path: path.join(__dirname, `../cdk.out/platform-tenant-stub-${env}.template.json`),
+      path: tenantStackTemplatePath,
     });
 
     const tenantProvisionerFn = this.createPythonLambda({

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -542,6 +542,54 @@ def _agent_event_detail_type(status: AgentStatus) -> str | None:
     return None
 
 
+def _agent_release_operation(status: AgentStatus) -> str | None:
+    if status is AgentStatus.PROMOTED:
+        return "promotion"
+    if status is AgentStatus.ROLLED_BACK:
+        return "rollback"
+    return None
+
+
+def _build_agent_release_lifecycle_event_detail(
+    *,
+    caller: CallerIdentity,
+    agent_name: str,
+    version: str,
+    previous_status: AgentStatus,
+    new_status: AgentStatus,
+    occurred_at: str,
+    approved_by: str | None,
+    approved_at: str | None,
+    release_notes: str | None,
+    evaluation_score: float | None,
+    evaluation_report_url: str | None,
+    rolled_back_by: str | None,
+    rolled_back_at: str | None,
+) -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "operation": _agent_release_operation(new_status),
+        "occurredAt": occurred_at,
+        "actorTenantId": caller.tenant_id or "platform",
+        "actorAppId": caller.app_id,
+        "actorSub": caller.sub,
+        "releaseId": f"{agent_name}:{version}",
+        "agentRecordPk": f"AGENT#{agent_name}",
+        "agentRecordSk": f"VERSION#{version}",
+        "agentName": agent_name,
+        "version": version,
+        "previousStatus": previous_status.value,
+        "status": new_status.value,
+        "approvedBy": approved_by,
+        "approvedAt": approved_at,
+        "releaseNotes": release_notes,
+        "evaluationScore": evaluation_score,
+        "evaluationReportUrl": evaluation_report_url,
+        "rolledBackBy": rolled_back_by,
+        "rolledBackAt": rolled_back_at,
+    }
+
+
 def _validate_agent_status_transition(
     current_status: AgentStatus,
     new_status: AgentStatus,
@@ -2142,16 +2190,17 @@ def _handle_platform_update_agent_version(
     current_status = normalize_agent_status(existing.get("status"), default=AgentStatus.PROMOTED)
     _validate_agent_status_transition(current_status, new_agent_status)
 
+    updated_at = _iso(_now_utc())
     attrs: dict[str, Any] = {
         "status": new_agent_status.value,
-        "updated_at": _iso(_now_utc()),
+        "updated_at": updated_at,
     }
     if new_agent_status in {AgentStatus.APPROVED, AgentStatus.PROMOTED}:
         attrs["approved_by"] = caller.sub
-        attrs["approved_at"] = _iso(_now_utc())
+        attrs["approved_at"] = updated_at
     if new_agent_status is AgentStatus.ROLLED_BACK:
         attrs["rolled_back_by"] = caller.sub
-        attrs["rolled_back_at"] = _iso(_now_utc())
+        attrs["rolled_back_at"] = updated_at
     if body.get("releaseNotes") is not None:
         attrs["release_notes"] = str(body["releaseNotes"])
     if body.get("evaluationScore") is not None:
@@ -2171,22 +2220,32 @@ def _handle_platform_update_agent_version(
 
     detail_type = _agent_event_detail_type(new_agent_status)
     if detail_type is not None and new_agent_status != current_status:
+        approved_by = _str_or_none(attrs.get("approved_by") or existing.get("approved_by"))
+        approved_at = _str_or_none(attrs.get("approved_at") or existing.get("approved_at"))
+        release_notes = _str_or_none(attrs.get("release_notes"))
+        evaluation_score_raw = attrs.get("evaluation_score")
+        evaluation_score = float(evaluation_score_raw) if evaluation_score_raw is not None else None
+        evaluation_report_url = _str_or_none(attrs.get("evaluation_report_url"))
+        rolled_back_by = _str_or_none(attrs.get("rolled_back_by"))
+        rolled_back_at = _str_or_none(attrs.get("rolled_back_at"))
         _put_event(
             deps,
             detail_type=detail_type,
-            detail={
-                "agentName": agent_name,
-                "version": version,
-                "previousStatus": current_status.value,
-                "status": new_agent_status.value,
-                "approvedBy": caller.sub,
-                "approvedAt": attrs.get("approved_at"),
-                "releaseNotes": attrs.get("release_notes"),
-                "evaluationScore": attrs.get("evaluation_score"),
-                "evaluationReportUrl": attrs.get("evaluation_report_url"),
-                "rolledBackBy": attrs.get("rolled_back_by"),
-                "rolledBackAt": attrs.get("rolled_back_at"),
-            },
+            detail=_build_agent_release_lifecycle_event_detail(
+                caller=caller,
+                agent_name=agent_name,
+                version=version,
+                previous_status=current_status,
+                new_status=new_agent_status,
+                occurred_at=updated_at,
+                approved_by=approved_by,
+                approved_at=approved_at,
+                release_notes=release_notes,
+                evaluation_score=evaluation_score,
+                evaluation_report_url=evaluation_report_url,
+                rolled_back_by=rolled_back_by,
+                rolled_back_at=rolled_back_at,
+            ),
         )
 
     return _response(

--- a/tests/unit/test_bridge_streaming.py
+++ b/tests/unit/test_bridge_streaming.py
@@ -1,17 +1,16 @@
 import json
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from data_access.models import AgentRecord, InvocationMode, TenantContext
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
 
-
 from src.bridge.handler import _send_streaming_response, handle_streaming_invocation, handler
-from data_access.models import AgentRecord, InvocationMode, TenantContext
 
 
 class FakeLambdaContext:
@@ -144,7 +143,9 @@ def test_handler_handles_streaming_agent_result_none(mock_invoke, mock_get_agent
 
 @patch("src.bridge.handler.log_invocation")
 @patch("src.bridge.handler.requests")
-def test_handle_streaming_invocation_streams_lines(mock_requests, mock_log, fake_agent, fake_tenant):
+def test_handle_streaming_invocation_streams_lines(
+    mock_requests, mock_log, fake_agent, fake_tenant
+):
     """Each non-empty SSE line from the runtime is forwarded to the response stream."""
     mock_stream = MagicMock()
     mock_response = MagicMock()
@@ -228,7 +229,9 @@ def test_handle_streaming_invocation_no_response_stream_returns_error(fake_agent
     assert result["statusCode"] == 500
     body = json.loads(result["body"])
     error = body.get("error", body)
-    assert "INTERNAL_ERROR" in error.get("code", "") or "streaming" in error.get("message", "").lower()
+    assert (
+        "INTERNAL_ERROR" in error.get("code", "") or "streaming" in error.get("message", "").lower()
+    )
 
 
 @patch("src.bridge.handler.log_invocation")
@@ -237,7 +240,6 @@ def test_handle_streaming_invocation_http_error_propagates(
     mock_requests, mock_log, fake_agent, fake_tenant
 ):
     """An HTTP error from the runtime (4xx/5xx) propagates as an exception."""
-    from unittest.mock import MagicMock as _MM
 
     http_error_cls = type("HTTPError", (Exception,), {})
     mock_response = MagicMock()

--- a/tests/unit/test_request_interceptor.py
+++ b/tests/unit/test_request_interceptor.py
@@ -434,7 +434,9 @@ def test_request_interceptor_non_tools_call_passes_through(
 
 
 @patch("gateway.interceptors.request_interceptor.get_jwk_client")
-def test_request_interceptor_expired_token_returns_401(mock_get_jwk_client, mock_env, lambda_context):
+def test_request_interceptor_expired_token_returns_401(
+    mock_get_jwk_client, mock_env, lambda_context
+):
     """An expired JWT → 401 with 'expired' message."""
     event = _base_event()
     mock_get_jwk_client.return_value = MagicMock(
@@ -483,7 +485,11 @@ def test_get_scoped_token_signing_key_prod_without_config_raises(mock_env):
     """In non-local PLATFORM_ENV, missing both signing key and ARN must raise RuntimeError."""
     with patch.dict(
         os.environ,
-        {"PLATFORM_ENV": "prod", "SCOPED_TOKEN_SIGNING_KEY": "", "SCOPED_TOKEN_SIGNING_KEY_SECRET_ARN": ""},
+        {
+            "PLATFORM_ENV": "prod",
+            "SCOPED_TOKEN_SIGNING_KEY": "",
+            "SCOPED_TOKEN_SIGNING_KEY_SECRET_ARN": "",
+        },
         clear=False,
     ):
         request_interceptor._scoped_token_signing_key_cache = None

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -2104,6 +2104,7 @@ def test_platform_promote_agent_updates_metadata_and_emits_event(
     event = _event(
         method="PATCH",
         body={"status": "promoted", "releaseNotes": "approved release evidence recorded"},
+        caller_tenant_id="platform",
         roles=["Platform.Admin"],
     )
     event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
@@ -2118,8 +2119,22 @@ def test_platform_promote_agent_updates_metadata_and_emits_event(
     assert item["release_notes"] == "approved release evidence recorded"
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.promoted"
+    assert detail["schemaVersion"] == 1
+    assert detail["operation"] == "promotion"
+    assert detail["occurredAt"] == "2026-02-25T12:00:00Z"
+    assert detail["actorTenantId"] == "platform"
+    assert detail["actorAppId"] == "app-admin"
+    assert detail["actorSub"] == "user-123"
+    assert detail["releaseId"] == "echo-agent:1.2.0"
+    assert detail["agentRecordPk"] == "AGENT#echo-agent"
+    assert detail["agentRecordSk"] == "VERSION#1.2.0"
+    assert detail["agentName"] == "echo-agent"
+    assert detail["version"] == "1.2.0"
     assert detail["previousStatus"] == "approved"
     assert detail["status"] == "promoted"
+    assert detail["approvedBy"] == "user-123"
+    assert detail["approvedAt"] == "2026-02-25T12:00:00Z"
+    assert detail["releaseNotes"] == "approved release evidence recorded"
 
 
 def test_platform_rejects_invalid_agent_status_transition(fake_state: dict[str, Any]) -> None:
@@ -2232,9 +2247,14 @@ def test_platform_rollback_with_metadata(fake_state: dict[str, Any]) -> None:
 
 def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None:
     _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="promoted")
+    fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]["approved_by"] = "release-admin"
+    fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]["approved_at"] = (
+        "2026-02-24T18:30:00Z"
+    )
     event = _event(
         method="PATCH",
         body={"status": "rolled_back", "releaseNotes": "error rate spike"},
+        caller_tenant_id="platform",
         roles=["Platform.Admin"],
     )
     event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
@@ -2246,5 +2266,19 @@ def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None
     assert item["status"] == "rolled_back"
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.rolled_back"
+    assert detail["schemaVersion"] == 1
+    assert detail["operation"] == "rollback"
+    assert detail["occurredAt"] == "2026-02-25T12:00:00Z"
+    assert detail["actorTenantId"] == "platform"
+    assert detail["actorAppId"] == "app-admin"
+    assert detail["actorSub"] == "user-123"
+    assert detail["releaseId"] == "echo-agent:1.2.0"
+    assert detail["agentRecordPk"] == "AGENT#echo-agent"
+    assert detail["agentRecordSk"] == "VERSION#1.2.0"
+    assert detail["agentName"] == "echo-agent"
+    assert detail["version"] == "1.2.0"
     assert detail["previousStatus"] == "promoted"
     assert detail["status"] == "rolled_back"
+    assert detail["approvedBy"] == "release-admin"
+    assert detail["approvedAt"] == "2026-02-24T18:30:00Z"
+    assert detail["releaseNotes"] == "error rate spike"

--- a/tests/unit/test_tenant_provisioner_handler.py
+++ b/tests/unit/test_tenant_provisioner_handler.py
@@ -123,7 +123,6 @@ class TestTenantProvisioner(unittest.TestCase):
         self.assertEqual(result["status"], "SUCCESS")
         mock_cfn.update_stack.assert_called_once()
 
-
     @patch("boto3.client")
     @patch("boto3.resource")
     @patch("time.sleep", return_value=None)
@@ -153,9 +152,7 @@ class TestTenantProvisioner(unittest.TestCase):
                 {"Error": {"Code": "ValidationError", "Message": "Stack does not exist"}},
                 "DescribeStacks",
             ),
-            {
-                "Stacks": [{"StackStatus": "CREATE_FAILED", "Outputs": []}]
-            },
+            {"Stacks": [{"StackStatus": "CREATE_FAILED", "Outputs": []}]},
         ]
 
         event = {"detail": {"tenantId": "t-fail-001", "tier": "basic"}}
@@ -170,9 +167,7 @@ class TestTenantProvisioner(unittest.TestCase):
     @patch("boto3.client")
     @patch("boto3.resource")
     @patch("time.sleep", return_value=None)
-    def test_lambda_handler_rollback_complete_raises(
-        self, mock_sleep, mock_resource, mock_client
-    ):
+    def test_lambda_handler_rollback_complete_raises(self, mock_sleep, mock_resource, mock_client):
         mock_cfn = MagicMock()
         mock_client.return_value = mock_cfn
 
@@ -181,9 +176,7 @@ class TestTenantProvisioner(unittest.TestCase):
                 {"Error": {"Code": "ValidationError", "Message": "Stack does not exist"}},
                 "DescribeStacks",
             ),
-            {
-                "Stacks": [{"StackStatus": "ROLLBACK_COMPLETE", "Outputs": []}]
-            },
+            {"Stacks": [{"StackStatus": "ROLLBACK_COMPLETE", "Outputs": []}]},
         ]
 
         event = {"detail": {"tenantId": "t-rollback-001", "tier": "basic"}}
@@ -198,17 +191,13 @@ class TestTenantProvisioner(unittest.TestCase):
     @patch("boto3.client")
     @patch("boto3.resource")
     @patch("time.sleep", return_value=None)
-    def test_lambda_handler_update_rollback_raises(
-        self, mock_sleep, mock_resource, mock_client
-    ):
+    def test_lambda_handler_update_rollback_raises(self, mock_sleep, mock_resource, mock_client):
         mock_cfn = MagicMock()
         mock_client.return_value = mock_cfn
 
         mock_cfn.describe_stacks.side_effect = [
             {"Stacks": [{"StackStatus": "UPDATE_COMPLETE"}]},  # stack exists
-            {
-                "Stacks": [{"StackStatus": "UPDATE_ROLLBACK_COMPLETE", "Outputs": []}]
-            },
+            {"Stacks": [{"StackStatus": "UPDATE_ROLLBACK_COMPLETE", "Outputs": []}]},
         ]
 
         event = {"detail": {"tenantId": "t-urollback-001", "tier": "premium"}}
@@ -226,7 +215,10 @@ class TestTenantProvisioner(unittest.TestCase):
     def test_lambda_handler_completes_with_no_outputs_raises(
         self, mock_sleep, mock_resource, mock_client
     ):
-        """Stack reaches CREATE_COMPLETE but has no outputs → RuntimeError (same 'no outputs' path)."""
+        """Stack reaches CREATE_COMPLETE but has no outputs.
+
+        This should raise the same RuntimeError "no outputs" path.
+        """
         mock_cfn = MagicMock()
         mock_client.return_value = mock_cfn
 
@@ -369,7 +361,7 @@ class TestTenantProvisioner(unittest.TestCase):
     def test_lambda_handler_non_validation_cfn_error_on_describe_propagates(
         self, mock_sleep, mock_resource, mock_client
     ):
-        """ClientError with a code other than ValidationError during initial describe is re-raised."""
+        """Re-raise non-ValidationError ClientError during initial describe."""
         mock_cfn = MagicMock()
         mock_client.return_value = mock_cfn
 

--- a/tests/unit/test_validate_agent_manifest.py
+++ b/tests/unit/test_validate_agent_manifest.py
@@ -282,9 +282,9 @@ class TestHandlerFormat:
         _write_manifest(
             tmp_path,
             "my-agent",
-            _MINIMAL_TOML.replace('handler = "handler:invoke"', 'handler = "handler_invoke"').format(
-                name="my-agent"
-            ),
+            _MINIMAL_TOML.replace(
+                'handler = "handler:invoke"', 'handler = "handler_invoke"'
+            ).format(name="my-agent"),
         )
         from scripts.agent_manifest import ManifestValidationError
 
@@ -327,7 +327,7 @@ class TestEstimatedDurationValidation:
 class TestLlmSectionValidation:
     def test_max_tokens_zero_rejected(self, tmp_path: Path) -> None:
         toml = _MINIMAL_TOML.format(name="my-agent") + (
-            "\n[tool.agentcore.llm]\nmodel_id = \"claude-3\"\nmax_tokens = 0\n"
+            '\n[tool.agentcore.llm]\nmodel_id = "claude-3"\nmax_tokens = 0\n'
         )
         _write_manifest(tmp_path, "my-agent", toml)
         from scripts.agent_manifest import ManifestValidationError
@@ -338,7 +338,7 @@ class TestLlmSectionValidation:
 
     def test_max_tokens_positive_accepted(self, tmp_path: Path) -> None:
         toml = _MINIMAL_TOML.format(name="my-agent") + (
-            "\n[tool.agentcore.llm]\nmodel_id = \"claude-3\"\nmax_tokens = 1024\n"
+            '\n[tool.agentcore.llm]\nmodel_id = "claude-3"\nmax_tokens = 1024\n'
         )
         _write_manifest(tmp_path, "my-agent", toml)
         manifest = load_agent_manifest("my-agent", tmp_path)
@@ -346,7 +346,7 @@ class TestLlmSectionValidation:
 
     def test_unknown_llm_key_is_rejected(self, tmp_path: Path) -> None:
         toml = _MINIMAL_TOML.format(name="my-agent") + (
-            "\n[tool.agentcore.llm]\nmodel_id = \"claude-3\"\ntemperature = 0.7\n"
+            '\n[tool.agentcore.llm]\nmodel_id = "claude-3"\ntemperature = 0.7\n'
         )
         _write_manifest(tmp_path, "my-agent", toml)
         from scripts.agent_manifest import ManifestValidationError


### PR DESCRIPTION
## Summary
- emit structured EventBridge lifecycle events for agent promotions and rollbacks
- document the release lifecycle event schema, semantics, and operational consumers
- fix repo validation blockers encountered during #308 completion so local and pre-push gates pass

Closes #308

## Validation
- pytest -q tests/unit/test_tenant_api_handler.py::test_platform_promote_agent_updates_metadata_and_emits_event tests/unit/test_tenant_api_handler.py::test_platform_register_and_promote_with_evidence tests/unit/test_tenant_api_handler.py::test_platform_rollback_with_metadata tests/unit/test_tenant_api_handler.py::test_platform_rollback_agent_emits_event tests/unit/test_tenant_api_handler.py::test_platform_rejects_invalid_agent_status_transition tests/unit/test_tenant_api_handler.py::test_platform_register_agent_defaults_to_built tests/unit/test_tenant_api_handler.py::test_platform_register_agent_rejects_non_built_initial_status
- make validate-local
- make preflight-session
- make pre-validate-session