### PR TITLE
fix: architecture review — webhook table bug, X-Ray tracing, lazy init, lock warning

### DIFF
--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -314,6 +314,7 @@ export class PlatformStack extends cdk.Stack {
       environment: {
         POWERTOOLS_SERVICE_NAME: 'webhook-delivery',
         JOBS_TABLE: this.jobsTable.tableName,
+        TENANTS_TABLE: this.tenantsTable.tableName,
         WEBHOOK_RETRY_QUEUE_URL: webhookDeliveryRetryQueue.queueUrl,
         WEBHOOK_DLQ_URL: webhookDeliveryRetryDlq.queueUrl,
         WEBHOOK_MAX_RETRY_ATTEMPTS: '3',
@@ -372,6 +373,7 @@ export class PlatformStack extends cdk.Stack {
     });
 
     this.tenantsTable.grantReadData(this.authoriserFn);
+    this.tenantsTable.grantReadData(this.webhookDeliveryFn);
     this.jobsTable.grantReadWriteData(this.webhookDeliveryFn);
     this.webhookDeliveryFn.addToRolePolicy(
       new iam.PolicyStatement({

--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 from typing import Any
 
 import boto3
-from aws_lambda_powertools import Logger
+from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Attr, Key
 from data_access.client import TenantScopedDynamoDB
@@ -30,17 +30,50 @@ from data_access.models import (
 )
 
 logger = Logger(service="billing")
+tracer = Tracer()
 
 # Table names from environment
 TENANTS_TABLE = os.environ["TENANTS_TABLE_NAME"]
 INVOCATIONS_TABLE = os.environ["INVOCATIONS_TABLE_NAME"]
 EVENT_BUS_NAME = os.environ.get("EVENT_BUS_NAME", "default")
 
-# Boto3 clients
-_ssm = boto3.client("ssm", region_name=os.environ["AWS_REGION"])
-_events = boto3.client("events", region_name=os.environ["AWS_REGION"])
-_dynamodb = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"])
-_cloudwatch = boto3.client("cloudwatch", region_name=os.environ["AWS_REGION"])
+# Boto3 clients — lazy initialisation (matches handler convention; avoids import-time failures)
+_ssm = None
+_events = None
+_dynamodb = None
+_cloudwatch = None
+
+
+def _aws_region() -> str:
+    return os.environ["AWS_REGION"]
+
+
+def _get_ssm() -> Any:
+    global _ssm
+    if _ssm is None:
+        _ssm = boto3.client("ssm", region_name=_aws_region())
+    return _ssm
+
+
+def _get_events() -> Any:
+    global _events
+    if _events is None:
+        _events = boto3.client("events", region_name=_aws_region())
+    return _events
+
+
+def _get_dynamodb() -> Any:
+    global _dynamodb
+    if _dynamodb is None:
+        _dynamodb = boto3.resource("dynamodb", region_name=_aws_region())
+    return _dynamodb
+
+
+def _get_cloudwatch() -> Any:
+    global _cloudwatch
+    if _cloudwatch is None:
+        _cloudwatch = boto3.client("cloudwatch", region_name=_aws_region())
+    return _cloudwatch
 
 
 class PricingResolutionError(RuntimeError):
@@ -51,7 +84,7 @@ def _get_pricing(tier: str) -> dict[str, float]:
     """Fetch pricing for a tier from SSM."""
     path = f"/platform/billing/pricing/{tier}"
     try:
-        response = _ssm.get_parameter(Name=path)
+        response = _get_ssm().get_parameter(Name=path)
         value = response.get("Parameter", {}).get("Value")
     except Exception as exc:
         raise PricingResolutionError(f"Failed to fetch pricing parameter {path} from SSM") from exc
@@ -104,7 +137,7 @@ def _get_active_tenants() -> list[dict[str, Any]]:
         tier=TenantTier.PREMIUM,
         sub="billing-pipeline",
     )
-    db = TenantScopedDynamoDB(ctx, dynamodb_resource=_dynamodb)
+    db = TenantScopedDynamoDB(ctx, dynamodb_resource=_get_dynamodb())
     # CR001: FilterExpression requires Attr() conditions, not Key() conditions.
     # Key() is only valid in KeyConditionExpression.
     return db.scan_all(
@@ -139,7 +172,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
         tier=TenantTier(tier),
         sub="billing-pipeline",
     )
-    db = TenantScopedDynamoDB(ctx, dynamodb_resource=_dynamodb)
+    db = TenantScopedDynamoDB(ctx, dynamodb_resource=_get_dynamodb())
 
     # 1. Query invocations for the day
     # SK starts with INV#timestamp
@@ -195,7 +228,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
             {"Name": "TenantId", "Value": tenant_id},
             {"Name": "Tier", "Value": tier},
         ]
-        _cloudwatch.put_metric_data(
+        _get_cloudwatch().put_metric_data(
             Namespace="Platform/Billing",
             MetricData=[
                 {
@@ -249,7 +282,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
             )
 
             # Publish event
-            _events.put_events(
+            _get_events().put_events(
                 Entries=[
                     {
                         "Source": "platform.billing",
@@ -272,6 +305,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
             logger.info("Tenant already suspended", cost=total_cost, budget=budget)
 
 
+@tracer.capture_lambda_handler
 def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
     """Lambda entry point."""
     logger.info("Billing pipeline started")

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -239,6 +239,10 @@ def release_lock(lock_name: str, lock_id: str) -> bool:
         )
         return True
     except Exception:
+        logger.warning(
+            "Failed to release ops lock; will expire via TTL",
+            extra={"lock_name": lock_name},
+        )
         return False
 
 

--- a/src/webhook_delivery/handler.py
+++ b/src/webhook_delivery/handler.py
@@ -17,15 +17,17 @@ from typing import Any
 
 import boto3
 import requests
-from aws_lambda_powertools import Logger
+from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.types import TypeDeserializer
 from data_access import TenantContext, TenantScopedDynamoDB
 from data_access.models import TenantTier
 
 logger = Logger(service="webhook-delivery")
+tracer = Tracer()
 
 JOBS_TABLE = os.environ.get("JOBS_TABLE", "platform-jobs")
+TENANTS_TABLE = os.environ.get("TENANTS_TABLE", "platform-tenants")
 WEBHOOK_RETRY_QUEUE_URL = os.environ.get("WEBHOOK_RETRY_QUEUE_URL")
 WEBHOOK_DLQ_URL = os.environ.get("WEBHOOK_DLQ_URL")
 WEBHOOK_MAX_RETRY_ATTEMPTS = int(os.environ.get("WEBHOOK_MAX_RETRY_ATTEMPTS", "3"))
@@ -53,6 +55,7 @@ def get_sqs():
     return _sqs_client
 
 
+@tracer.capture_lambda_handler
 def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
     records = event.get("Records", [])
     if not records:
@@ -331,7 +334,10 @@ def _get_webhook_registration(
     tenant_context: TenantContext, webhook_id: str
 ) -> dict[str, Any] | None:
     db = TenantScopedDynamoDB(tenant_context)
-    record = db.get_item(JOBS_TABLE, {"PK": f"WEBHOOK#{webhook_id}", "SK": "METADATA"})
+    record = db.get_item(
+        TENANTS_TABLE,
+        {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": f"WEBHOOK#{webhook_id}"},
+    )
     if record is None:
         return None
     if str(record.get("tenant_id", "")) != tenant_context.tenant_id:

--- a/tests/unit/test_webhook_delivery_handler.py
+++ b/tests/unit/test_webhook_delivery_handler.py
@@ -43,16 +43,24 @@ def setup_delivery_env(aws_credentials):
         ddb = boto3.resource("dynamodb", region_name="eu-west-2")
         sqs = boto3.client("sqs", region_name="eu-west-2")
 
+        _key_schema = [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ]
+        _attr_defs = [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ]
         ddb.create_table(
             TableName="platform-jobs",
-            KeySchema=[
-                {"AttributeName": "PK", "KeyType": "HASH"},
-                {"AttributeName": "SK", "KeyType": "RANGE"},
-            ],
-            AttributeDefinitions=[
-                {"AttributeName": "PK", "AttributeType": "S"},
-                {"AttributeName": "SK", "AttributeType": "S"},
-            ],
+            KeySchema=_key_schema,
+            AttributeDefinitions=_attr_defs,
+            BillingMode="PAY_PER_REQUEST",
+        )
+        ddb.create_table(
+            TableName="platform-tenants",
+            KeySchema=_key_schema,
+            AttributeDefinitions=_attr_defs,
             BillingMode="PAY_PER_REQUEST",
         )
 
@@ -61,6 +69,7 @@ def setup_delivery_env(aws_credentials):
 
         webhook_handler._sqs_client = None
         webhook_handler.JOBS_TABLE = "platform-jobs"
+        webhook_handler.TENANTS_TABLE = "platform-tenants"
         webhook_handler.WEBHOOK_RETRY_QUEUE_URL = retry_queue_url
         webhook_handler.WEBHOOK_DLQ_URL = dlq_queue_url
         webhook_handler.WEBHOOK_MAX_RETRY_ATTEMPTS = 3
@@ -80,14 +89,18 @@ def _serialize_item(item: dict[str, object]) -> dict[str, dict[str, object]]:
 
 
 def _seed_registration(
-    table, *, webhook_id: str = "webhook-001", events: list[str] | None = None
+    tenants_table,
+    *,
+    tenant_id: str = "t-001",
+    webhook_id: str = "webhook-001",
+    events: list[str] | None = None,
 ) -> None:
-    table.put_item(
+    tenants_table.put_item(
         Item={
-            "PK": f"WEBHOOK#{webhook_id}",
-            "SK": "METADATA",
+            "PK": f"TENANT#{tenant_id}",
+            "SK": f"WEBHOOK#{webhook_id}",
             "webhook_id": webhook_id,
-            "tenant_id": "t-001",
+            "tenant_id": tenant_id,
             "app_id": "app-001",
             "callback_url": "https://example.com/webhooks/platform",
             "events": events or ["job.completed"],
@@ -122,7 +135,8 @@ def _seed_job(table, **overrides: object) -> dict[str, object]:
 
 def test_delivers_signed_webhook_and_marks_job_delivered(setup_delivery_env):
     jobs_table = setup_delivery_env["ddb"].Table("platform-jobs")
-    _seed_registration(jobs_table)
+    tenants_table = setup_delivery_env["ddb"].Table("platform-tenants")
+    _seed_registration(tenants_table)
     job_item = _seed_job(jobs_table)
 
     response = MagicMock()
@@ -157,7 +171,8 @@ def test_delivers_signed_webhook_and_marks_job_delivered(setup_delivery_env):
 
 def test_queues_retry_after_delivery_failure(setup_delivery_env):
     jobs_table = setup_delivery_env["ddb"].Table("platform-jobs")
-    _seed_registration(jobs_table)
+    tenants_table = setup_delivery_env["ddb"].Table("platform-tenants")
+    _seed_registration(tenants_table)
     job_item = _seed_job(jobs_table)
 
     with patch.object(
@@ -192,7 +207,8 @@ def test_queues_retry_after_delivery_failure(setup_delivery_env):
 
 def test_marks_job_failed_and_sends_dlq_after_retries_exhausted(setup_delivery_env):
     jobs_table = setup_delivery_env["ddb"].Table("platform-jobs")
-    _seed_registration(jobs_table)
+    tenants_table = setup_delivery_env["ddb"].Table("platform-tenants")
+    _seed_registration(tenants_table)
     _seed_job(jobs_table)
 
     with patch.object(


### PR DESCRIPTION
## Summary

Senior engineer architecture review identified 4 actionable fixes across 3 simulated execution instances (sync invocation, async+webhook delivery, billing aggregation).

- **CRITICAL** `webhook_delivery`: `_get_webhook_registration` queried the wrong table (`platform-jobs`) with the wrong key pattern (`WEBHOOK#{id}` / `METADATA`). `WebhookRecord` is stored as `TENANT#{tenant_id}` PK / `WEBHOOK#{webhook_id}` SK in `platform-tenants`. Every webhook delivery was silently failing and routing to DLQ on the first attempt. Fixed: correct table + key, `TENANTS_TABLE` env var added to CDK, `grantReadData(webhookDeliveryFn)` added.
- **LOW** `billing` and `webhook_delivery` both lacked `Tracer` / `@tracer.capture_lambda_handler`, violating the absolute constraint _"Every Lambda: X-Ray tracing"_.
- **LOW** `billing/handler.py` initialised 4 boto3 clients at module level (import time), breaking unit tests without `AWS_REGION` set and diverging from the lazy-init convention in every other handler.
- **LOW** `bridge/handler.py` `release_lock` swallowed failures silently. A failed release holds the failover lock for its 300 s TTL with no observable ops signal.

Two issues were identified but require operator decision before action — not addressed in this PR:

- **HIGH** SigV4 authoriser performs a full `platform-tenants` table scan on every machine-auth cache miss (CR005). Needs a GSI on `executionRoleArn`; stop-and-ask per CLAUDE.md.
- **MEDIUM** Billing SK range query may silently exclude invocations stored with `Z` timestamp suffix vs `+00:00`. Requires audit of all `InvocationRecord` write sites in `bridge/handler.py`.

## Test plan

- [x] `uv run pytest tests/unit/test_billing_handler.py tests/unit/test_webhook_delivery_handler.py tests/unit/test_bridge_handler.py` — 34 passed
- [x] `ruff check` + `ruff format --check` clean on all changed Python files
- [ ] CDK synth + cfn-guard (requires full `make validate-local` environment)

https://claude.ai/code/session_01GfUm8PZC4GiiwrBi723mPR