### PR TITLE
fix(manifest): preserve packaging-owned project metadata

### DIFF
--- a/docs/development/AGENT-DEVELOPER-GUIDE.md
+++ b/docs/development/AGENT-DEVELOPER-GUIDE.md
@@ -72,7 +72,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-https://github.com/j3brns/tf-acore-aas/pull/330/conflict?name=docs%252Fdevelopment%252FAGENT-DEVELOPER-GUIDE.md&ancestor_oid=dc566f919ca5fc5b5e3dea61ba6a13e53045a4a6&base_oid=61bf5a8f2a40927646c23893ec3cd6619a0f96ba&head_oid=c605d2c7cbc3a6696f08db638e21143baa050ecadev = [
+dev = [
     "bedrock-agentcore-starter-toolkit>=0.2.5",
     "pytest>=8.0.0",
 ]
@@ -97,7 +97,7 @@ type = "zip"                   # zip (default) | container
 
 | Table | Fields | Required |
 |-------|--------|----------|
-| `[project]` | `name`, `version` | yes |
+| `[project]` | Platform validates `name`, `version`; standard packaging keys such as `description`, `requires-python`, `dependencies`, and dependency groups remain allowed and agent-owned | yes |
 | `[tool.agentcore]` | `name`, `owner_team`, `tier_minimum`, `handler`, `invocation_mode` | yes |
 | `[tool.agentcore]` | `streaming_enabled`, `estimated_duration_seconds` | no |
 | `[tool.agentcore.llm]` | `model_id`, `max_tokens` | no |
@@ -106,6 +106,7 @@ type = "zip"                   # zip (default) | container
 
 Validation rules:
 - `project.name`, `tool.agentcore.name`, and the agent directory name must match.
+- The platform does not reject additional agent-owned packaging keys outside the platform-owned `tool.agentcore` tables.
 - `handler` must use `module:function` form.
 - `tier_minimum` must be `basic`, `standard`, or `premium`.
 - `invocation_mode` must be `sync`, `streaming`, or `async`.

--- a/scripts/agent_manifest.py
+++ b/scripts/agent_manifest.py
@@ -19,7 +19,6 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_EVALUATION_REGION = "eu-central-1"
 VALID_DEPLOYMENT_TYPES = frozenset({"zip", "container"})
 
-_PROJECT_KEYS = frozenset({"name", "version"})
 _MANIFEST_KEYS = frozenset(
     {
         "name",
@@ -103,7 +102,6 @@ def load_agent_manifest(agent_name: str, repo_root: Path | None = None) -> Agent
 
     project_name = _required_string(project_raw, "name", errors, table="[project]")
     version = _required_string(project_raw, "version", errors, table="[project]")
-    _check_unknown_keys(project_raw, _PROJECT_KEYS, errors, table="[project]")
     _check_unknown_keys(manifest_raw, _MANIFEST_KEYS, errors, table="[tool.agentcore]")
 
     name = _required_string(manifest_raw, "name", errors, table="[tool.agentcore]")

--- a/tests/unit/test_validate_agent_manifest.py
+++ b/tests/unit/test_validate_agent_manifest.py
@@ -219,6 +219,33 @@ class TestRequiredFields:
         with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
             assert validate_manifest("test-agent") is False
 
+    def test_project_packaging_metadata_is_allowed(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            "test-agent",
+            """\
+            [project]
+            name = "test-agent"
+            version = "1.0.0"
+            description = "Example agent"
+            requires-python = ">=3.12"
+            dependencies = ["boto3>=1.37.0"]
+
+            [dependency-groups]
+            dev = ["pytest>=8.0.0"]
+
+            [tool.agentcore]
+            name = "test-agent"
+            owner_team = "team-test"
+            tier_minimum = "basic"
+            handler = "handler:invoke"
+            invocation_mode = "sync"
+        """,
+        )
+
+        with patch("scripts.validate_agent_manifest.REPO_ROOT", tmp_path):
+            assert validate_manifest("test-agent") is True
+
     def test_loader_reads_optional_sections(self, tmp_path: Path) -> None:
         _write_manifest(
             tmp_path,
@@ -279,12 +306,14 @@ invocation_mode = "sync"
 
 class TestHandlerFormat:
     def test_handler_without_colon_is_rejected(self, tmp_path: Path) -> None:
+        invalid_handler_toml = _MINIMAL_TOML.replace(
+            'handler = "handler:invoke"',
+            'handler = "handler_invoke"',
+        )
         _write_manifest(
             tmp_path,
             "my-agent",
-            _MINIMAL_TOML.replace(
-                'handler = "handler:invoke"', 'handler = "handler_invoke"'
-            ).format(name="my-agent"),
+            invalid_handler_toml.format(name="my-agent"),
         )
         from scripts.agent_manifest import ManifestValidationError
 


### PR DESCRIPTION
Closes #312

## Summary
- keep `[tool.agentcore]` strict while allowing agent-owned packaging metadata in `[project]`
- add manifest coverage for packaging metadata and refresh the developer guide boundary docs
- validate the real `echo-agent` manifest without breaking the current `pyproject.toml` flow

## Validation
- `python scripts/validate_agent_manifest.py echo-agent`
- `pytest -q tests/unit/test_validate_agent_manifest.py`
- `pytest -q tests/unit/test_agent_scripts.py -k "manifest_invalid_before_aws or deploy_agent_zip_stores_runtime_arn_on_success or register_agent or evaluate_agent_returns_false_when_manifest_invalid_before_aws"`
- `make preflight-session`
- `make pre-validate-session`