### PR TITLE
Define platform-agent control-plane backlog

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -476,6 +476,67 @@ Approved cross-tenant actions must:
 This preserves the rule that normal tenant data access remains structurally
 tenant-scoped even when initiated by platform-owned automation.
 
+## Platform-Agent Action Classes
+
+The reserved `platform` tenant exists to let platform-owned agents assist operators
+inside the control plane. It does not create a new privileged data path.
+
+Allowed action classes:
+- **Read-only platform diagnostics and runbook guidance** on platform-owned control-plane
+  state and authoritative operational signals
+- **Release-governance assistance** through the existing agent registry lifecycle,
+  including register, approve, promote, and rollback actions that already belong to
+  the control plane
+- **Tenant-operations workflow initiation** through explicit admin routes or
+  orchestrations such as suspend/reinstate, tenant notifications, and other
+  bounded operational remediations
+- **Platform-state summarisation** that helps an operator understand health, drift,
+  or release state without exposing raw customer content as a shortcut
+
+Disallowed action classes:
+- direct reads or writes against arbitrary customer-tenant stores outside approved
+  control-plane workflows
+- treating `tenantid=platform` as implicit authorization to bypass RBAC, audit, or
+  target-tenant validation
+- direct mutation of immutable release artifacts or destructive edits to
+  `platform-agents` outside the ADR-015 lifecycle contract
+- AG-UI bootstrap or browser/runtime session design; that follow-on work is tracked
+  separately under the AG-UI issue set and is not part of the platform-agent backlog
+  defined here
+- policy-sensitive mutations called out in [CLAUDE.md](../CLAUDE.md) as stop-and-ask
+  changes, including IAM trust changes, KMS key policy changes, and authoriser
+  validation logic changes
+
+Required boundary rules:
+- every platform-agent route must require explicit platform RBAC
+- every cross-tenant action must capture acting principal, acting tenant, target tenant,
+  operation type, and outcome
+- mutation flows must reuse documented admin/control-plane APIs or workflows instead of
+  inventing a parallel data-plane path
+- customer invocation content is never exposed merely because the caller is internal;
+  access must stay within the documented control-plane contract
+
+### Follow-On Backlog For Platform-Agent Operations
+
+Issue [#318](https://github.com/j3brns/tf-acore-aas/issues/318) closes only after the
+follow-on implementation backlog is explicit. The scoped follow-on work is:
+
+| Issue | Focus | Why it exists |
+|-------|-------|---------------|
+| [#388](https://github.com/j3brns/tf-acore-aas/issues/388) | Platform-agent auth context and audit envelope | Makes `tenantid=platform` explicit, auditable, and non-bypassable |
+| [#389](https://github.com/j3brns/tf-acore-aas/issues/389) | Read-only diagnostics and runbook assistance | Keeps operator-assistance flows bounded to authoritative read-only signals |
+| [#390](https://github.com/j3brns/tf-acore-aas/issues/390) | Tenant operational workflows | Forces target-tenant actions through explicit admin workflows with validation and audit |
+| [#391](https://github.com/j3brns/tf-acore-aas/issues/391) | Release-governance workflows | Reuses the ADR-015 lifecycle instead of hidden scripts or direct table mutation |
+
+Out of scope for this backlog:
+- AG-UI bootstrap, runtime session contracts, and SPA integration, which are already
+  tracked separately in issues [#381](https://github.com/j3brns/tf-acore-aas/issues/381),
+  [#382](https://github.com/j3brns/tf-acore-aas/issues/382), [#383](https://github.com/j3brns/tf-acore-aas/issues/383),
+  [#384](https://github.com/j3brns/tf-acore-aas/issues/384), and
+  [#385](https://github.com/j3brns/tf-acore-aas/issues/385)
+- any design that weakens the reserved-tenant guardrails from ADR-016 or the stop-and-ask
+  security boundaries in [CLAUDE.md](../CLAUDE.md)
+
 ### Cross-Account Tenant Provisioning (Option B/C)
 
 ```mermaid

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -163,6 +163,10 @@ be weakened or bypassed.
 - `platform` is a reserved internal tenant, not a super-tenant
 - `tenantid=platform` must never act as an implicit authorization bypass
 - cross-tenant actions must go through explicit control-plane APIs or workflows
+- allowed platform-agent action classes are limited to:
+  - read-only diagnostics and runbook assistance on authoritative platform signals
+  - bounded tenant operational workflows through explicit admin APIs
+  - release-governance actions through the ADR-015 agent-registry lifecycle
 - all such actions must record:
   - acting principal
   - acting tenant (`platform`)
@@ -173,6 +177,16 @@ be weakened or bypassed.
 - no wildcard IAM permissions introduced for platform-agent flows
 - platform-agent routes require explicit platform RBAC
 - tests must prove platform-agent flows cannot bypass tenant isolation
+
+### Explicitly Disallowed Platform-Agent Behaviors
+- direct reads or writes against arbitrary customer-tenant stores outside approved
+  control-plane workflows
+- exposing raw customer invocation content as a convenience path for internal users
+- mutating immutable release artifacts or bypassing the canonical `platform-agents`
+  status/evidence lifecycle
+- treating AG-UI or direct browser/runtime connectivity as part of the reserved-tenant
+  control-plane model; those flows require their own bootstrap and policy boundary
+- using `tenantid=platform` to justify broader IAM, audit, or target-validation bypass
 
 ### Detection
 - audit events containing `tenantid=platform`


### PR DESCRIPTION
Closes #318

## Summary
- define allowed and disallowed platform-agent action classes in the architecture docs
- add the explicit follow-on control-plane backlog for platform-agent operations
- tighten the threat-model language for reserved-platform-tenant misuse boundaries

## Follow-on backlog
- #388 platform-agent auth context and audit envelope
- #389 read-only diagnostics and runbook assistance surface
- #390 tenant operations through explicit admin workflows
- #391 release governance through the agent-registry lifecycle

## Validation
- `make preflight-session`
- `make pre-validate-session`
