### PR TITLE
Add platform-agent auth context and audit envelope for control-plane actions

### DIFF
--- a/src/authoriser/handler.py
+++ b/src/authoriser/handler.py
@@ -49,6 +49,7 @@ _SIGV4_TENANT_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]{0,127}$")
 _SIGV4_ASSUMED_ROLE_ARN_RE = re.compile(
     r"^arn:aws:sts::(?P<account_id>\d{12}):assumed-role/(?P<role_name>[^/]+)/[^/]+$"
 )
+_PLATFORM_TENANT_ID = "platform"
 
 
 def _aws_region() -> str:
@@ -307,6 +308,14 @@ def is_admin_route(method_arn: str) -> bool:
     return False
 
 
+def is_platform_route(method_arn: str) -> bool:
+    parts = method_arn.split("/", 3)
+    if len(parts) < 4:
+        return False
+    path = str(parts[3]).strip("/")
+    return path.startswith("v1/platform")
+
+
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
 @tracer.capture_lambda_handler
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
@@ -360,10 +369,15 @@ def handle_jwt(token: str, method_arn: str) -> dict[str, Any]:
             )
             return generate_policy(sub, "Deny", method_arn, {})
 
+        effective_tenant_id = _PLATFORM_TENANT_ID if is_platform_route(method_arn) else tenant_id
+
         # Check tenant status (Isolation Layer 1)
-        status = get_tenant_status(tenant_id)
+        status = get_tenant_status(effective_tenant_id)
         if status != "active":
-            logger.error("Tenant not active", extra={"tenant_id": tenant_id, "status": status})
+            logger.error(
+                "Tenant not active",
+                extra={"tenant_id": effective_tenant_id, "status": status},
+            )
             return generate_policy(sub, "Deny", method_arn, {})
 
         # RBAC check for admin routes (ADR-013)
@@ -377,18 +391,21 @@ def handle_jwt(token: str, method_arn: str) -> dict[str, Any]:
 
         # Prepare authoriser context for downstream Lambdas
         auth_context = {
-            "tenantid": tenant_id,
+            "tenantid": effective_tenant_id,
             "appid": app_id,
             "tier": tier,
             "sub": sub,
             "roles": json.dumps(roles),
-            "usageIdentifierKey": tenant_id,  # Mapped to API Gateway usage plan key
+            "usageIdentifierKey": effective_tenant_id,  # Mapped to API Gateway usage plan key
         }
 
         # Inject context into all subsequent log lines (structured logging mandate)
-        logger.append_keys(tenant_id=tenant_id, app_id=app_id)
+        logger.append_keys(tenant_id=effective_tenant_id, app_id=app_id)
 
-        logger.info("Authentication successful", extra={"tenant_id": tenant_id, "sub": sub})
+        logger.info(
+            "Authentication successful",
+            extra={"tenant_id": effective_tenant_id, "sub": sub},
+        )
         return generate_policy(sub, "Allow", method_arn, auth_context)
 
     except jwt.ExpiredSignatureError:

--- a/src/tenant_api/agent_registry.py
+++ b/src/tenant_api/agent_registry.py
@@ -19,9 +19,16 @@ def handle_list_agents(
     _ = event
     _ = deps
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     db = shared._control_plane_db(caller)
     items = db.scan_all(shared._agents_table_name())
-    return shared._response(200, {"items": items})
+    return shared._platform_control_response(
+        200,
+        {"items": items},
+        caller=caller,
+        operation_type="agent_registry_list",
+        target_tenant_id=shared._PLATFORM_TENANT_ID,
+    )
 
 
 def handle_register_agent(
@@ -30,6 +37,7 @@ def handle_register_agent(
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     body = shared._require_json_body(event)
 
     agent_name = shared._str_or_none(body.get("agentName"))
@@ -91,9 +99,12 @@ def handle_register_agent(
             )
         raise
 
-    return shared._response(
+    return shared._platform_control_response(
         201,
         {"status": "registered", "agentName": agent_name, "version": version},
+        caller=caller,
+        operation_type="agent_version_register",
+        target_tenant_id=shared._PLATFORM_TENANT_ID,
     )
 
 
@@ -105,6 +116,7 @@ def handle_update_agent_version(
     version: str,
 ) -> dict[str, Any]:
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     body = shared._require_json_body(event)
 
     new_status = shared._str_or_none(body.get("status"))
@@ -180,7 +192,7 @@ def handle_update_agent_version(
             ),
         )
 
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "status": "updated",
@@ -188,6 +200,9 @@ def handle_update_agent_version(
             "version": version,
             "newStatus": new_agent_status.value,
         },
+        caller=caller,
+        operation_type="agent_version_update",
+        target_tenant_id=shared._PLATFORM_TENANT_ID,
     )
 
 
@@ -198,6 +213,7 @@ def dispatch_routes(
     caller: shared.CallerIdentity,
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any] | None:
+    shared._require_platform_actor(caller)
     if path == "/v1/platform/agents" and method == "GET":
         return handle_list_agents(event, caller, deps)
     if path == "/v1/platform/agents" and method == "POST":

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -70,6 +70,7 @@ _AGENTCORE_CONCURRENT_SESSIONS_NAMESPACE = "AgentCore"
 _AGENTCORE_CONCURRENT_SESSIONS_METRIC = "ConcurrentSessions"
 _AGENTCORE_QUOTA_LOOKBACK_MINUTES = 5
 _TENANT_PROVISIONING_STATUSES = frozenset({"pending", "provisioning", "ready", "failed"})
+_PLATFORM_TENANT_ID = "platform"
 
 
 @dataclass(frozen=True)
@@ -84,6 +85,10 @@ class CallerIdentity:
     @property
     def is_admin(self) -> bool:
         return bool(self.roles & _ADMIN_ROLES)
+
+    @property
+    def is_platform_actor(self) -> bool:
+        return self.tenant_id == _PLATFORM_TENANT_ID
 
 
 @dataclass(frozen=True)
@@ -570,28 +575,35 @@ def _build_agent_release_lifecycle_event_detail(
     rolled_back_by: str | None,
     rolled_back_at: str | None,
 ) -> dict[str, Any]:
-    return {
-        "schemaVersion": 1,
-        "operation": _agent_release_operation(new_status),
-        "occurredAt": occurred_at,
-        "actorTenantId": caller.tenant_id or "platform",
-        "actorAppId": caller.app_id,
-        "actorSub": caller.sub,
-        "releaseId": f"{agent_name}:{version}",
-        "agentRecordPk": f"AGENT#{agent_name}",
-        "agentRecordSk": f"VERSION#{version}",
-        "agentName": agent_name,
-        "version": version,
-        "previousStatus": previous_status.value,
-        "status": new_status.value,
-        "approvedBy": approved_by,
-        "approvedAt": approved_at,
-        "releaseNotes": release_notes,
-        "evaluationScore": evaluation_score,
-        "evaluationReportUrl": evaluation_report_url,
-        "rolledBackBy": rolled_back_by,
-        "rolledBackAt": rolled_back_at,
-    }
+    detail = _platform_audit_envelope(
+        caller=caller,
+        operation_type=_agent_release_operation(new_status) or "agent_release",
+        outcome="succeeded",
+        target_tenant_id=_PLATFORM_TENANT_ID,
+        occurred_at=occurred_at,
+    )
+    detail.update(
+        {
+            "operation": _agent_release_operation(new_status),
+            "releaseId": f"{agent_name}:{version}",
+            "agentRecordPk": f"AGENT#{agent_name}",
+            "agentRecordSk": f"VERSION#{version}",
+            "agentName": agent_name,
+            "version": version,
+            "previousStatus": previous_status.value,
+            "status": new_status.value,
+            "approvedBy": approved_by,
+            "approvedAt": approved_at,
+            "releaseNotes": release_notes,
+            "evaluationScore": evaluation_score,
+            "evaluationReportUrl": evaluation_report_url,
+            "rolledBackBy": rolled_back_by,
+            "rolledBackAt": rolled_back_at,
+            "targetResourceType": "agentVersion",
+            "targetResourceId": f"{agent_name}:{version}",
+        }
+    )
+    return detail
 
 
 def _validate_agent_status_transition(
@@ -621,6 +633,52 @@ def _as_float(value: Any, *, field: str) -> float:
 def _require_admin(caller: CallerIdentity) -> None:
     if not caller.is_admin:
         raise PermissionError("Platform.Admin or Platform.Operator role required")
+
+
+def _require_platform_actor(caller: CallerIdentity) -> None:
+    if not caller.is_platform_actor:
+        raise PermissionError("Platform tenant context required")
+
+
+def _platform_audit_envelope(
+    *,
+    caller: CallerIdentity,
+    operation_type: str,
+    outcome: str,
+    target_tenant_id: str | None = None,
+    occurred_at: str | None = None,
+) -> dict[str, Any]:
+    detail = {
+        "schemaVersion": 1,
+        "occurredAt": occurred_at or _iso(_now_utc()),
+        "actorTenantId": _PLATFORM_TENANT_ID,
+        "actorAppId": caller.app_id,
+        "actorSub": caller.sub,
+        "operationType": operation_type,
+        "outcome": outcome,
+    }
+    if target_tenant_id is not None:
+        detail["targetTenantId"] = target_tenant_id
+    return detail
+
+
+def _platform_control_response(
+    status_code: int,
+    body: dict[str, Any],
+    *,
+    caller: CallerIdentity,
+    operation_type: str,
+    target_tenant_id: str | None = None,
+    outcome: str | None = None,
+) -> dict[str, Any]:
+    payload = dict(body)
+    payload["audit"] = _platform_audit_envelope(
+        caller=caller,
+        operation_type=operation_type,
+        outcome=outcome or ("succeeded" if status_code < 400 else "failed"),
+        target_tenant_id=target_tenant_id,
+    )
+    return _response(status_code, payload)
 
 
 def _can_read_tenant(caller: CallerIdentity, tenant_id: str) -> bool:

--- a/src/tenant_api/ops_control.py
+++ b/src/tenant_api/ops_control.py
@@ -28,6 +28,7 @@ def handle_platform_failover(
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     body = shared._require_json_body(event)
     target_region = shared._str_or_none(body.get("targetRegion"))
     lock_id = shared._str_or_none(body.get("lockId"))
@@ -107,7 +108,7 @@ def handle_platform_failover(
                 "changed": False,
             },
         )
-        return shared._response(
+        return shared._platform_control_response(
             200,
             {
                 "status": "completed",
@@ -116,6 +117,8 @@ def handle_platform_failover(
                 "lockId": lock_id,
                 "changed": False,
             },
+            caller=caller,
+            operation_type="runtime_failover",
         )
 
     try:
@@ -150,7 +153,7 @@ def handle_platform_failover(
         },
     )
 
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "status": "completed",
@@ -159,6 +162,8 @@ def handle_platform_failover(
             "lockId": lock_id,
             "changed": True,
         },
+        caller=caller,
+        operation_type="runtime_failover",
     )
 
 
@@ -167,13 +172,19 @@ def handle_platform_quota(
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     active_region = shared._required_ssm_parameter(deps.ssm, shared._runtime_region_param_name())
     fallback_region = shared._optional_ssm_parameter(deps.ssm, shared._fallback_region_param_name())
     utilisation = deps.platform_quota_client.get_utilisation(
         active_region=active_region,
         fallback_region=fallback_region,
     )
-    return shared._response(200, {"utilisation": utilisation})
+    return shared._platform_control_response(
+        200,
+        {"utilisation": utilisation},
+        caller=caller,
+        operation_type="quota_report",
+    )
 
 
 def handle_platform_split_accounts(
@@ -182,6 +193,7 @@ def handle_platform_split_accounts(
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
     _ = deps
+    shared._require_platform_actor(caller)
     if "Platform.Admin" not in caller.roles:
         raise PermissionError("Platform.Admin role required")
 
@@ -198,7 +210,12 @@ def handle_platform_split_accounts(
         extra={"tier": tier, "target_account_id": target_account_id, "job_id": job_id},
     )
 
-    return shared._response(202, {"status": "initiated", "jobId": job_id})
+    return shared._platform_control_response(
+        202,
+        {"status": "initiated", "jobId": job_id},
+        caller=caller,
+        operation_type="quota_split_accounts",
+    )
 
 
 def handle_platform_service_health(
@@ -207,7 +224,8 @@ def handle_platform_service_health(
 ) -> dict[str, Any]:
     _ = deps
     shared._require_admin(caller)
-    return shared._response(
+    shared._require_platform_actor(caller)
+    return shared._platform_control_response(
         200,
         {
             "status": "healthy",
@@ -221,6 +239,8 @@ def handle_platform_service_health(
                 "Bedrock": "operational",
             },
         },
+        caller=caller,
+        operation_type="service_health_read",
     )
 
 
@@ -230,6 +250,7 @@ def handle_platform_billing_status(
 ) -> dict[str, Any]:
     _ = deps
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     year_month = datetime.now(UTC).strftime("%Y-%m")
     db = shared._control_plane_db(caller)
     summaries = db.scan_all(
@@ -241,7 +262,7 @@ def handle_platform_billing_status(
     total_input = sum(int(s.get("total_input_tokens", 0)) for s in summaries)
     total_output = sum(int(s.get("total_output_tokens", 0)) for s in summaries)
 
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "status": "active",
@@ -251,6 +272,8 @@ def handle_platform_billing_status(
             "totalTokens": total_input + total_output,
             "lastUpdated": shared._iso(shared._now_utc()),
         },
+        caller=caller,
+        operation_type="billing_status_read",
     )
 
 
@@ -259,17 +282,18 @@ def handle_ops_top_tenants(
     caller: shared.CallerIdentity,
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
     query = event.get("queryStringParameters") or {}
     n = int(query.get("n", 10))
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "tenants": [
                 {"tenantId": f"t-{i:03d}", "tokens": 1000000 - (i * 10000)} for i in range(1, n + 1)
             ]
         },
+        caller=caller,
+        operation_type="top_tenants_read",
     )
 
 
@@ -279,9 +303,8 @@ def handle_ops_security_events(
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
     _ = event
-    _ = caller
     _ = deps
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "events": [
@@ -293,6 +316,8 @@ def handle_ops_security_events(
                 }
             ]
         },
+        caller=caller,
+        operation_type="security_events_read",
     )
 
 
@@ -301,15 +326,16 @@ def handle_ops_error_rate(
     caller: shared.CallerIdentity,
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "errorRate": 0.02,
             "periodMinutes": int((event.get("queryStringParameters") or {}).get("minutes", 5)),
             "threshold": 0.05,
         },
+        caller=caller,
+        operation_type="error_rate_read",
     )
 
 
@@ -318,9 +344,8 @@ def handle_ops_dlq_inspect(
     deps: shared.TenantApiDependencies,
     queue_name: str,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "queueName": queue_name,
@@ -334,6 +359,8 @@ def handle_ops_dlq_inspect(
                 for i in range(3)
             ],
         },
+        caller=caller,
+        operation_type="dlq_inspect",
     )
 
 
@@ -342,10 +369,14 @@ def handle_ops_dlq_redrive(
     deps: shared.TenantApiDependencies,
     queue_name: str,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
     _ = queue_name
-    return shared._response(200, {"status": "initiated", "redriveCount": 3})
+    return shared._platform_control_response(
+        200,
+        {"status": "initiated", "redriveCount": 3},
+        caller=caller,
+        operation_type="dlq_redrive",
+    )
 
 
 def handle_ops_tenant_sessions(
@@ -353,9 +384,8 @@ def handle_ops_tenant_sessions(
     deps: shared.TenantApiDependencies,
     tenant_id: str,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "tenantId": tenant_id,
@@ -364,6 +394,9 @@ def handle_ops_tenant_sessions(
                 for i in range(2)
             ],
         },
+        caller=caller,
+        operation_type="tenant_sessions_read",
+        target_tenant_id=tenant_id,
     )
 
 
@@ -373,11 +406,16 @@ def handle_ops_suspend_tenant(
     deps: shared.TenantApiDependencies,
     tenant_id: str,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
     body = shared._require_json_body(event)
     reason = body.get("reason", "No reason provided")
-    return shared._response(200, {"tenantId": tenant_id, "status": "suspended", "reason": reason})
+    return shared._platform_control_response(
+        200,
+        {"tenantId": tenant_id, "status": "suspended", "reason": reason},
+        caller=caller,
+        operation_type="tenant_suspend",
+        target_tenant_id=tenant_id,
+    )
 
 
 def handle_ops_reinstate_tenant(
@@ -385,9 +423,14 @@ def handle_ops_reinstate_tenant(
     deps: shared.TenantApiDependencies,
     tenant_id: str,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
-    return shared._response(200, {"tenantId": tenant_id, "status": "active"})
+    return shared._platform_control_response(
+        200,
+        {"tenantId": tenant_id, "status": "active"},
+        caller=caller,
+        operation_type="tenant_reinstate",
+        target_tenant_id=tenant_id,
+    )
 
 
 def handle_ops_invocation_report(
@@ -397,9 +440,8 @@ def handle_ops_invocation_report(
     tenant_id: str,
 ) -> dict[str, Any]:
     _ = event
-    _ = caller
     _ = deps
-    return shared._response(
+    return shared._platform_control_response(
         200,
         {
             "tenantId": tenant_id,
@@ -407,6 +449,9 @@ def handle_ops_invocation_report(
             "successRate": 0.992,
             "avgLatencyMs": 450,
         },
+        caller=caller,
+        operation_type="tenant_invocation_report",
+        target_tenant_id=tenant_id,
     )
 
 
@@ -416,11 +461,16 @@ def handle_ops_notify_tenant(
     deps: shared.TenantApiDependencies,
     tenant_id: str,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
     body = shared._require_json_body(event)
     template = body.get("template")
-    return shared._response(200, {"status": "sent", "tenantId": tenant_id, "template": template})
+    return shared._platform_control_response(
+        200,
+        {"status": "sent", "tenantId": tenant_id, "template": template},
+        caller=caller,
+        operation_type="tenant_notify",
+        target_tenant_id=tenant_id,
+    )
 
 
 def handle_ops_fail_job(
@@ -429,11 +479,15 @@ def handle_ops_fail_job(
     deps: shared.TenantApiDependencies,
     job_id: str,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
     body = shared._require_json_body(event)
     reason = body.get("reason")
-    return shared._response(200, {"jobId": job_id, "status": "failed", "reason": reason})
+    return shared._platform_control_response(
+        200,
+        {"jobId": job_id, "status": "failed", "reason": reason},
+        caller=caller,
+        operation_type="job_fail",
+    )
 
 
 def handle_ops_lambda_rollback(
@@ -442,6 +496,7 @@ def handle_ops_lambda_rollback(
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     body = shared._require_json_body(event)
     suffix = shared._str_or_none(body.get("functionSuffix"))
     alias_name = shared._str_or_none(body.get("aliasName")) or "live"
@@ -504,7 +559,7 @@ def handle_ops_lambda_rollback(
             },
         )
 
-        return shared._response(
+        return shared._platform_control_response(
             200,
             {
                 "functionName": full_name,
@@ -513,6 +568,8 @@ def handle_ops_lambda_rollback(
                 "toVersion": previous_version,
                 "status": "rolled_back",
             },
+            caller=caller,
+            operation_type="lambda_rollback",
         )
     except ClientError as exc:
         code = exc.response.get("Error", {}).get("Code")
@@ -531,10 +588,14 @@ def handle_ops_page_security(
     caller: shared.CallerIdentity,
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any]:
-    _ = caller
     _ = deps
     shared._require_json_body(event)
-    return shared._response(200, {"status": "paged", "incidentId": f"inc-{secrets.token_hex(4)}"})
+    return shared._platform_control_response(
+        200,
+        {"status": "paged", "incidentId": f"inc-{secrets.token_hex(4)}"},
+        caller=caller,
+        operation_type="security_page",
+    )
 
 
 def dispatch_platform_admin_routes(
@@ -544,6 +605,7 @@ def dispatch_platform_admin_routes(
     caller: shared.CallerIdentity,
     deps: shared.TenantApiDependencies,
 ) -> dict[str, Any] | None:
+    shared._require_platform_actor(caller)
     if path == "/v1/platform/failover" and method == "POST":
         return handle_platform_failover(event, caller, deps)
     if path == "/v1/platform/quota" and method == "GET":
@@ -569,6 +631,7 @@ def dispatch_ops_routes(
         return None
 
     shared._require_admin(caller)
+    shared._require_platform_actor(caller)
     if path_lower == "/v1/platform/ops/top-tenants" and method == "GET":
         return handle_ops_top_tenants(event, caller, deps)
     if path_lower == "/v1/platform/ops/security-events" and method == "GET":

--- a/tests/unit/test_authoriser.py
+++ b/tests/unit/test_authoriser.py
@@ -9,7 +9,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.authoriser.handler import generate_policy, handler, is_admin_route
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+os.environ.setdefault("AWS_REGION", "eu-west-2")
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+
+from src.authoriser.handler import generate_policy, handler, is_admin_route, is_platform_route
 
 # Mock environment variables
 OS_ENV = {
@@ -151,6 +155,25 @@ def test_is_admin_route(method_arn: str, expected: bool):
     assert is_admin_route(method_arn) is expected
 
 
+@pytest.mark.parametrize(
+    ("method_arn", "expected"),
+    [
+        ("arn:aws:execute-api:eu-west-2:123456789012:api/dev/GET/v1/platform/quota", True),
+        (
+            "arn:aws:execute-api:eu-west-2:123456789012:api/dev/GET/v1/platform/ops/top-tenants",
+            True,
+        ),
+        ("arn:aws:execute-api:eu-west-2:123456789012:api/dev/POST/v1/tenants", False),
+        (
+            "arn:aws:execute-api:eu-west-2:123456789012:api/dev/POST/v1/agents/echo-agent/invoke",
+            False,
+        ),
+    ],
+)
+def test_is_platform_route(method_arn: str, expected: bool):
+    assert is_platform_route(method_arn) is expected
+
+
 def test_handler_missing_auth(mock_env, lambda_context):
     event = {
         "methodArn": "arn:aws:execute-api:eu-west-2:123456789012:api/dev/GET/v1/health",
@@ -284,6 +307,36 @@ def test_handler_admin_route_authorised(
         result = handler(event, lambda_context)
 
     assert result["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+
+
+@patch("src.authoriser.handler.get_jwk_client")
+@patch("src.authoriser.handler.get_tenant_status")
+def test_handler_platform_route_canonicalises_platform_tenant_context(
+    mock_get_status, mock_get_jwk_client, mock_env, lambda_context
+):
+    token = "valid.token.here"
+    method_arn = "arn:aws:execute-api:eu-west-2:123456789012:api/dev/GET/v1/platform/quota"
+    event = {"methodArn": method_arn, "authorizationToken": f"Bearer {token}"}
+
+    payload = {
+        "tenantid": "t-test-001",
+        "appid": "app-001",
+        "tier": "premium",
+        "sub": "admin-001",
+        "roles": ["Platform.Admin"],
+    }
+
+    mock_get_status.return_value = "active"
+    mock_jwk_client = MagicMock()
+    mock_get_jwk_client.return_value = mock_jwk_client
+    mock_jwk_client.get_signing_key_from_jwt.return_value = MagicMock(key="public-key")
+
+    with patch("jwt.decode", return_value=payload):
+        result = handler(event, lambda_context)
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert result["context"]["tenantid"] == "platform"
+    assert result["context"]["usageIdentifierKey"] == "platform"
 
 
 @patch("src.authoriser.handler.get_jwk_client")

--- a/tests/unit/test_ops_api.py
+++ b/tests/unit/test_ops_api.py
@@ -50,6 +50,7 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     monkeypatch.setenv("TENANT_API_KEY_SECRET_PREFIX", "platform/tenants")
     monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
     monkeypatch.setattr(tenant_api_handler, "_db_for_tenant", lambda **_kwargs: db)
+    monkeypatch.setattr(tenant_api_handler, "_control_plane_db", lambda *_args, **_kwargs: db)
     monkeypatch.setattr(tenant_api_handler, "_now_utc", lambda: fixed_now)
     return {"db": db, "deps": deps}
 
@@ -67,9 +68,10 @@ def _ops_event(
         "body": None if body is None else json.dumps(body),
         "requestContext": {
             "authorizer": {
-                "tenantid": "platform-admin",
+                "tenantid": "platform",
                 "roles": "Platform.Admin",
                 "sub": "admin-123",
+                "appid": "app-admin",
             }
         },
     }
@@ -123,6 +125,8 @@ def test_ops_tenant_management(fake_state: dict[str, Any]) -> None:
     )
     assert response["statusCode"] == 200
     assert _body(response)["status"] == "suspended"
+    assert _body(response)["audit"]["targetTenantId"] == "t-001"
+    assert _body(response)["audit"]["operationType"] == "tenant_suspend"
 
     # Reinstate
     response = _invoke(_ops_event("POST", "/v1/platform/ops/tenants/t-001/reinstate"))
@@ -141,6 +145,16 @@ def test_ops_service_health(fake_state: dict[str, Any]) -> None:
     response = _invoke(_ops_event("GET", "/v1/platform/service-health"))
     assert response["statusCode"] == 200
     assert _body(response)["status"] == "healthy"
+    assert _body(response)["audit"]["actorTenantId"] == "platform"
+
+
+def test_ops_platform_routes_require_platform_tenant_context(fake_state: dict[str, Any]) -> None:
+    event = _ops_event("GET", "/v1/platform/service-health")
+    event["requestContext"]["authorizer"]["tenantid"] = "t-customer-001"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 403
 
 
 def test_ops_billing_status(fake_state: dict[str, Any]) -> None:

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -1241,7 +1241,11 @@ def test_platform_failover_updates_runtime_region_when_lock_is_valid(
     fake_state: dict[str, Any], fixed_now: datetime
 ) -> None:
     _seed_failover_lock(fake_state, ttl=int(fixed_now.timestamp()) + 300)
-    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event = _event(
+        method="POST",
+        body={"targetRegion": "eu-central-1", "lockId": "lock-123"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/failover"
     response = _invoke(event)
 
@@ -1252,6 +1256,15 @@ def test_platform_failover_updates_runtime_region_when_lock_is_valid(
         "previousRegion": "eu-west-1",
         "lockId": "lock-123",
         "changed": True,
+        "audit": {
+            "schemaVersion": 1,
+            "occurredAt": "2026-02-25T12:00:00Z",
+            "actorTenantId": "platform",
+            "actorAppId": "app-admin",
+            "actorSub": "user-123",
+            "operationType": "runtime_failover",
+            "outcome": "succeeded",
+        },
     }
     assert fake_state["deps"].ssm.parameters["/platform/config/runtime-region"] == "eu-central-1"
     assert fake_state["deps"].ssm.put_calls == [
@@ -1269,7 +1282,11 @@ def test_platform_failover_is_idempotent_when_target_region_is_already_active(
 ) -> None:
     _seed_failover_lock(fake_state, ttl=int(fixed_now.timestamp()) + 300)
     fake_state["deps"].ssm.parameters["/platform/config/runtime-region"] = "eu-central-1"
-    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event = _event(
+        method="POST",
+        body={"targetRegion": "eu-central-1", "lockId": "lock-123"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/failover"
 
     response = _invoke(event)
@@ -1281,12 +1298,25 @@ def test_platform_failover_is_idempotent_when_target_region_is_already_active(
         "previousRegion": "eu-central-1",
         "lockId": "lock-123",
         "changed": False,
+        "audit": {
+            "schemaVersion": 1,
+            "occurredAt": "2026-02-25T12:00:00Z",
+            "actorTenantId": "platform",
+            "actorAppId": "app-admin",
+            "actorSub": "user-123",
+            "operationType": "runtime_failover",
+            "outcome": "succeeded",
+        },
     }
     assert fake_state["deps"].ssm.put_calls == []
 
 
 def test_platform_failover_rejects_missing_lock(fake_state: dict[str, Any]) -> None:
-    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event = _event(
+        method="POST",
+        body={"targetRegion": "eu-central-1", "lockId": "lock-123"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/failover"
 
     response = _invoke(event)
@@ -1300,7 +1330,11 @@ def test_platform_failover_rejects_expired_lock(
     fake_state: dict[str, Any], fixed_now: datetime
 ) -> None:
     _seed_failover_lock(fake_state, ttl=int(fixed_now.timestamp()) - 1)
-    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event = _event(
+        method="POST",
+        body={"targetRegion": "eu-central-1", "lockId": "lock-123"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/failover"
 
     response = _invoke(event)
@@ -1314,7 +1348,11 @@ def test_platform_failover_rejects_lock_owned_by_another_actor(
     fake_state: dict[str, Any], fixed_now: datetime
 ) -> None:
     _seed_failover_lock(fake_state, lock_id="other-lock", ttl=int(fixed_now.timestamp()) + 300)
-    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event = _event(
+        method="POST",
+        body={"targetRegion": "eu-central-1", "lockId": "lock-123"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/failover"
 
     response = _invoke(event)
@@ -1340,7 +1378,11 @@ def test_platform_failover_ssm_update_failure_returns_error_and_logs_context(
             logged.append((message, dict(extra)))
 
     monkeypatch.setattr(tenant_api_handler.logger, "exception", _capture_exception)
-    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event = _event(
+        method="POST",
+        body={"targetRegion": "eu-central-1", "lockId": "lock-123"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/failover"
 
     response = _invoke(event)
@@ -1363,13 +1405,34 @@ def test_platform_failover_ssm_update_failure_returns_error_and_logs_context(
 
 
 def test_platform_failover_requires_platform_admin_role(fake_state: dict[str, Any]) -> None:
-    event = _event(method="POST", body={"targetRegion": "eu-central-1", "lockId": "lock-123"})
+    event = _event(
+        method="POST",
+        body={"targetRegion": "eu-central-1", "lockId": "lock-123"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/failover"
 
     # Non-admin forbidden
-    event_non_admin = _event(method="POST", roles=[], body={"targetRegion": "x", "lockId": "y"})
+    event_non_admin = _event(
+        method="POST",
+        roles=[],
+        body={"targetRegion": "x", "lockId": "y"},
+        caller_tenant_id="platform",
+    )
     event_non_admin["path"] = "/v1/platform/failover"
     response = _invoke(event_non_admin)
+    assert response["statusCode"] == 403
+
+
+def test_platform_route_requires_platform_tenant_context(fake_state: dict[str, Any]) -> None:
+    event = _event(
+        method="GET",
+        caller_tenant_id="t-admin",
+    )
+    event["path"] = "/v1/platform/quota"
+
+    response = _invoke(event)
+
     assert response["statusCode"] == 403
 
 
@@ -1410,13 +1473,16 @@ def test_sessions_route_rejects_invalid_limit(fake_state: dict[str, Any]) -> Non
 
 
 def test_platform_quota_report(fake_state: dict[str, Any]) -> None:
-    event = _event(method="GET")
+    event = _event(method="GET", caller_tenant_id="platform")
     event["path"] = "/v1/platform/quota"
     response = _invoke(event)
 
     assert response["statusCode"] == 200
-    utilisation = _body(response)["utilisation"]
+    body = _body(response)
+    utilisation = body["utilisation"]
     assert utilisation == fake_state["deps"].platform_quota_client.response
+    assert body["audit"]["actorTenantId"] == "platform"
+    assert body["audit"]["operationType"] == "quota_report"
     assert fake_state["deps"].platform_quota_client.calls == [
         {
             "active_region": "eu-west-1",
@@ -1426,7 +1492,7 @@ def test_platform_quota_report(fake_state: dict[str, Any]) -> None:
 
 
 def test_platform_quota_report_returns_explicit_aws_error(fake_state: dict[str, Any]) -> None:
-    event = _event(method="GET")
+    event = _event(method="GET", caller_tenant_id="platform")
     event["path"] = "/v1/platform/quota"
     object.__setattr__(
         fake_state["deps"],
@@ -1534,7 +1600,11 @@ def test_aws_platform_quota_client_falls_back_to_documented_default_limit() -> N
 
 
 def test_platform_split_accounts_requires_platform_admin(fake_state: dict[str, Any]) -> None:
-    event = _event(method="POST", body={"tier": "premium", "targetAccountId": "123456789012"})
+    event = _event(
+        method="POST",
+        body={"tier": "premium", "targetAccountId": "123456789012"},
+        caller_tenant_id="platform",
+    )
     event["path"] = "/v1/platform/quota/split-accounts"
 
     # 1. Platform.Admin succeeds
@@ -1547,6 +1617,7 @@ def test_platform_split_accounts_requires_platform_admin(fake_state: dict[str, A
         method="POST",
         roles=["Platform.Operator"],
         body={"tier": "premium", "targetAccountId": "123456789012"},
+        caller_tenant_id="platform",
     )
     event_operator["path"] = "/v1/platform/quota/split-accounts"
     response = _invoke(event_operator)
@@ -1561,6 +1632,7 @@ def test_platform_split_accounts_rejects_invalid_target_account_id(
     event = _event(
         method="POST",
         body={"tier": "premium", "targetAccountId": target_account_id},
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/quota/split-accounts"
 
@@ -2159,6 +2231,7 @@ def test_lambda_rollback_finds_previous_version_and_updates_alias(
         method="POST",
         body={"functionSuffix": "bridge", "aliasName": "live"},
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/ops/lambda-rollback"
 
@@ -2184,6 +2257,7 @@ def test_lambda_rollback_rejects_oldest_version(fake_state: dict[str, Any]) -> N
         method="POST",
         body={"functionSuffix": "bridge", "aliasName": "live"},
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/ops/lambda-rollback"
 
@@ -2198,6 +2272,7 @@ def test_lambda_rollback_requires_admin_role(fake_state: dict[str, Any]) -> None
         method="POST",
         body={"functionSuffix": "bridge"},
         roles=["Platform.Operator"],  # Not sufficient for this route
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/ops/lambda-rollback"
 
@@ -2210,6 +2285,7 @@ def test_lambda_rollback_returns_404_on_missing_function(fake_state: dict[str, A
         method="POST",
         body={"functionSuffix": "non-existent"},
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/ops/lambda-rollback"
 
@@ -2231,6 +2307,7 @@ def test_platform_register_agent_defaults_to_built(fake_state: dict[str, Any]) -
             "invocationMode": "sync",
         },
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/agents"
 
@@ -2259,6 +2336,7 @@ def test_platform_register_agent_rejects_non_built_initial_status(
             "invocationMode": "sync",
         },
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/agents"
 
@@ -2291,7 +2369,10 @@ def test_platform_promote_agent_updates_metadata_and_emits_event(
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.promoted"
     assert detail["schemaVersion"] == 1
+    assert detail["targetTenantId"] == "platform"
     assert detail["operation"] == "promotion"
+    assert detail["operationType"] == "promotion"
+    assert detail["outcome"] == "succeeded"
     assert detail["occurredAt"] == "2026-02-25T12:00:00Z"
     assert detail["actorTenantId"] == "platform"
     assert detail["actorAppId"] == "app-admin"
@@ -2314,6 +2395,7 @@ def test_platform_rejects_invalid_agent_status_transition(fake_state: dict[str, 
         method="PATCH",
         body={"status": "built"},
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
 
@@ -2341,6 +2423,7 @@ def test_platform_register_and_promote_with_evidence(fake_state: dict[str, Any])
             "jobId": "job-456",
         },
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     register_event["path"] = "/v1/platform/agents"
     register_response = _invoke(register_event)
@@ -2370,6 +2453,7 @@ def test_platform_register_and_promote_with_evidence(fake_state: dict[str, Any])
             "releaseNotes": "Score: 0.98",
         },
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     promote_event["path"] = "/v1/platform/agents/evidence-agent/versions/1.0.0"
     promote_response = _invoke(promote_event)
@@ -2397,6 +2481,7 @@ def test_platform_rollback_with_metadata(fake_state: dict[str, Any]) -> None:
         method="PATCH",
         body={"status": "rolled_back"},
         roles=["Platform.Admin"],
+        caller_tenant_id="platform",
     )
     event["path"] = "/v1/platform/agents/rollback-agent/versions/1.0.0"
 
@@ -2438,7 +2523,10 @@ def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.rolled_back"
     assert detail["schemaVersion"] == 1
+    assert detail["targetTenantId"] == "platform"
     assert detail["operation"] == "rollback"
+    assert detail["operationType"] == "rollback"
+    assert detail["outcome"] == "succeeded"
     assert detail["occurredAt"] == "2026-02-25T12:00:00Z"
     assert detail["actorTenantId"] == "platform"
     assert detail["actorAppId"] == "app-admin"
@@ -2453,3 +2541,20 @@ def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None
     assert detail["approvedBy"] == "release-admin"
     assert detail["approvedAt"] == "2026-02-24T18:30:00Z"
     assert detail["releaseNotes"] == "error rate spike"
+
+
+def test_platform_tenant_does_not_bypass_cross_tenant_reads_without_admin_role(
+    fake_state: dict[str, Any],
+) -> None:
+    fake_state["db"].items[("TENANT#t-001", "METADATA")] = {
+        "PK": "TENANT#t-001",
+        "SK": "METADATA",
+        "tenantId": "t-001",
+        "status": "active",
+        "appId": "app-001",
+    }
+    event = _event(method="GET", tenant_id="t-001", caller_tenant_id="platform", roles=[])
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 403


### PR DESCRIPTION
Closes #388

## Summary
- canonicalize `/v1/platform` JWT authorizer context to `tenantid=platform`
- require explicit `platform` tenant context on platform admin and ops entrypoints
- add a shared platform audit envelope for control-plane responses and agent release events
- add regression coverage proving `tenantid=platform` is not an implicit cross-tenant bypass

## Validation
- `pytest -q tests/unit/test_authoriser.py`
- `pytest -q tests/unit/test_ops_api.py`
- `pytest -q tests/unit/test_tenant_api_handler.py`
- `make preflight-session`
- `make pre-validate-session`

## Notes
- only issue #388 scope is included
- local unrelated edits remain in `AGENTS.md` and `CLAUDE.md` and were not committed