### PR TITLE
Route platform-agent release governance through agent registry lifecycle

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -865,7 +865,7 @@ paths:
       tags: [Platform]
       operationId: updateAgentVersion
       summary: Update agent version status
-      description: Advances a version through the canonical release lifecycle or marks the currently promoted version as `rolled_back`. Successful promotion and rollback transitions emit the `AgentReleaseLifecycleEvent` detail payload on the platform EventBridge bus using detail types `platform.agent_version.promoted` and `platform.agent_version.rolled_back`.
+      description: Advances a version through the canonical release lifecycle or marks the currently promoted version as `rolled_back`. Lifecycle updates may mutate only `status` plus release-governance evidence fields (`releaseNotes`, `evaluationScore`, `evaluationReportUrl`). `approved` requires `releaseNotes`; `promoted` requires pre-existing immutable approval evidence on the release record; `rolled_back` requires `releaseNotes`. Successful promotion and rollback transitions emit the `AgentReleaseLifecycleEvent` detail payload on the platform EventBridge bus using detail types `platform.agent_version.promoted` and `platform.agent_version.rolled_back`.
       x-required-roles:
         - Platform.Admin
         - Platform.Operator
@@ -887,6 +887,12 @@ paths:
                   $ref: "#/components/schemas/AgentStatus"
                 releaseNotes:
                   type: string
+                evaluationScore:
+                  type: number
+                  format: float
+                evaluationReportUrl:
+                  type: string
+                  format: uri
       responses:
         "200":
           description: Status updated
@@ -1438,7 +1444,7 @@ components:
           $ref: "#/components/schemas/UtcTimestamp"
         releaseNotes:
           type: string
-          description: Operator-supplied release or rollback evidence.
+          description: Immutable approval evidence recorded when the release reaches `approved`.
         runtimeArn:
           type: string
         estimatedDurationSeconds:

--- a/scripts/promote_agent.py
+++ b/scripts/promote_agent.py
@@ -1,5 +1,5 @@
 """
-promote_agent.py — Promote an agent version to RELEASED status using Platform API.
+promote_agent.py — Promote an approved agent version using the Platform API.
 
 Usage:
     uv run python scripts/promote_agent.py <agent_name> <version> --env <env>
@@ -18,18 +18,8 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-import boto3
-from botocore.exceptions import ClientError
-
 logger = logging.getLogger("promote_agent")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-
-
-def require_aws_region() -> str:
-    region = os.environ.get("AWS_REGION", "").strip()
-    if not region:
-        raise RuntimeError("AWS_REGION must be set")
-    return region
 
 
 def parse_args() -> argparse.Namespace:
@@ -84,8 +74,6 @@ def promote_agent(
     api_base_url: str | None,
     token: str | None,
 ) -> bool:
-    aws_region = require_aws_region()
-
     # Resolve API Base URL and Token
     api_url = api_base_url or os.environ.get("API_BASE_URL") or os.environ.get("VITE_API_BASE_URL")
     if not api_url:
@@ -114,7 +102,7 @@ def promote_agent(
 
     promote_url = f"{api_url.rstrip('/')}/v1/platform/agents/{agent_name}/versions/{version}"
 
-    body: dict[str, Any] = {"status": "released"}
+    body: dict[str, Any] = {"status": "promoted"}
     if notes:
         body["releaseNotes"] = notes
     if score is not None:
@@ -125,15 +113,6 @@ def promote_agent(
     logger.info(f"Promoting agent '{agent_name}' v{version} via API in {env}")
     try:
         _request_api(promote_url, "PATCH", api_token, body)
-
-        # Update latest-version in SSM (as a fallback/convenience for infra)
-        ssm = boto3.client("ssm", region_name=aws_region)
-        ssm.put_parameter(
-            Name=f"/platform/agents/{env}/{agent_name}/latest-version",
-            Value=version,
-            Type="String",
-            Overwrite=True,
-        )
     except Exception as e:
         logger.error(f"Promotion failed: {e}")
         return False

--- a/scripts/register_agent.py
+++ b/scripts/register_agent.py
@@ -127,8 +127,6 @@ def register_agent(agent_name: str, env: str, api_base_url: str | None, token: s
             return False
 
     deployed_at = datetime.datetime.now(datetime.UTC).isoformat()
-    # Default status: PENDING for prod (requires approval), RELEASED for others
-    default_status = "pending" if env == "prod" else "released"
 
     body = {
         "agentName": agent_name,
@@ -141,7 +139,7 @@ def register_agent(agent_name: str, env: str, api_base_url: str | None, token: s
         "deployedAt": deployed_at,
         "invocationMode": manifest.invocation_mode.value,
         "streamingEnabled": manifest.streaming_enabled,
-        "status": default_status,
+        "status": "built",
         "runtimeArn": runtime_arn,
         "estimatedDurationSeconds": manifest.estimated_duration_seconds,
         "commitSha": os.environ.get("CI_COMMIT_SHA"),
@@ -180,20 +178,11 @@ def register_agent(agent_name: str, env: str, api_base_url: str | None, token: s
         logger.error("PLATFORM_ACCESS_TOKEN environment variable is not set")
         return False
 
-    register_url = f"{api_url.rstrip('/')}/v1/platform/agents/register"
+    register_url = f"{api_url.rstrip('/')}/v1/platform/agents"
 
     logger.info(f"Registering agent '{agent_name}' v{manifest.version} via API in {env}")
     try:
         _request_api(register_url, "POST", api_token, body)
-
-        # Update latest-version in SSM if released (as a fallback/convenience for infra)
-        if default_status == "released":
-            ssm.put_parameter(
-                Name=f"/platform/agents/{env}/{agent_name}/latest-version",
-                Value=manifest.version,
-                Type="String",
-                Overwrite=True,
-            )
     except Exception as e:
         logger.error(f"Registration failed: {e}")
         return False

--- a/scripts/rollback_agent.py
+++ b/scripts/rollback_agent.py
@@ -1,8 +1,8 @@
 """
 rollback_agent.py — Roll back an agent version using the Platform API.
 
-Uses the Platform API (tenant-api) to mark the current version as ROLLBACK.
-The Bridge Lambda automatically falls back to the previous RELEASED version.
+Uses the Platform API (tenant-api) to mark the current promoted version as
+rolled_back. The Bridge Lambda automatically falls back to the previous promoted version.
 
 Usage:
     uv run python scripts/rollback_agent.py <agent_name> --env <env>
@@ -19,23 +19,15 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-import boto3
-
 logger = logging.getLogger("rollback_agent")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-
-
-def require_aws_region() -> str:
-    region = os.environ.get("AWS_REGION", "").strip()
-    if not region:
-        raise RuntimeError("AWS_REGION must be set")
-    return region
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Roll back agent")
     parser.add_argument("agent_name", help="Name of the agent")
     parser.add_argument("--env", required=True, choices=["dev", "staging", "prod"])
+    parser.add_argument("--notes", help="Rollback evidence or operator notes")
     parser.add_argument("--api-base-url", help="Override Platform API base URL")
     parser.add_argument("--token", help="Override Platform API access token")
     return parser.parse_args()
@@ -70,9 +62,13 @@ def _request_api(
         raise RuntimeError(f"Connection Error: {e.reason}") from e
 
 
-def rollback_agent(agent_name: str, env: str, api_base_url: str | None, token: str | None) -> bool:
-    aws_region = require_aws_region()
-
+def rollback_agent(
+    agent_name: str,
+    env: str,
+    api_base_url: str | None,
+    token: str | None,
+    notes: str | None = None,
+) -> bool:
     # Resolve API Base URL and Token
     api_url = api_base_url or os.environ.get("API_BASE_URL") or os.environ.get("VITE_API_BASE_URL")
     if not api_url:
@@ -106,10 +102,10 @@ def rollback_agent(agent_name: str, env: str, api_base_url: str | None, token: s
         resp = _request_api(agents_url, "GET", api_token)
         items = resp.get("items", [])
         agent_versions = [
-            i for i in items if i.get("agent_name") == agent_name and i.get("status") == "released"
+            i for i in items if i.get("agent_name") == agent_name and i.get("status") == "promoted"
         ]
         if not agent_versions:
-            logger.error(f"No RELEASED versions found for agent '{agent_name}'")
+            logger.error(f"No PROMOTED versions found for agent '{agent_name}'")
             return False
 
         # Sort by semver (naive)
@@ -118,7 +114,7 @@ def rollback_agent(agent_name: str, env: str, api_base_url: str | None, token: s
 
         if len(agent_versions) < 2:
             logger.error(
-                f"Rollback failed: No previous RELEASED version found for agent '{agent_name}'. "
+                f"Rollback failed: No previous PROMOTED version found for agent '{agent_name}'. "
                 f"Current version is {current_version}."
             )
             return False
@@ -129,24 +125,13 @@ def rollback_agent(agent_name: str, env: str, api_base_url: str | None, token: s
     rollback_url = (
         f"{api_url.rstrip('/')}/v1/platform/agents/{agent_name}/versions/{current_version}"
     )
-    body = {"status": "rollback"}
+    body = {"status": "rolled_back"}
+    if notes:
+        body["releaseNotes"] = notes
 
     logger.info(f"Rolling back agent '{agent_name}' v{current_version} via API in {env}")
     try:
         _request_api(rollback_url, "PATCH", api_token, body)
-
-        # 2. Update latest-version in SSM (as a fallback/convenience for infra)
-        # We need to find the NEW latest released version
-        if len(agent_versions) > 1:
-            new_version = agent_versions[1]["version"]
-            ssm = boto3.client("ssm", region_name=aws_region)
-            ssm.put_parameter(
-                Name=f"/platform/agents/{env}/{agent_name}/latest-version",
-                Value=new_version,
-                Type="String",
-                Overwrite=True,
-            )
-            logger.info(f"Updated SSM latest-version to v{new_version}")
     except Exception as e:
         logger.error(f"Rollback failed: {e}")
         return False
@@ -157,5 +142,5 @@ def rollback_agent(agent_name: str, env: str, api_base_url: str | None, token: s
 
 if __name__ == "__main__":
     args = parse_args()
-    if not rollback_agent(args.agent_name, args.env, args.api_base_url, args.token):
+    if not rollback_agent(args.agent_name, args.env, args.api_base_url, args.token, args.notes):
         sys.exit(1)

--- a/src/tenant_api/agent_registry.py
+++ b/src/tenant_api/agent_registry.py
@@ -11,6 +11,69 @@ except ImportError:  # pragma: no cover - local package import path
     from src.tenant_api import handler as shared
 
 
+_REGISTER_MUTABLE_FIELDS = frozenset(
+    {
+        "agentName",
+        "version",
+        "ownerTeam",
+        "tierMinimum",
+        "layerHash",
+        "layerS3Key",
+        "scriptS3Key",
+        "deployedAt",
+        "invocationMode",
+        "streamingEnabled",
+        "status",
+        "runtimeArn",
+        "estimatedDurationSeconds",
+        "commitSha",
+        "pipelineUrl",
+        "jobId",
+        "agUi",
+        "releaseNotes",
+    }
+)
+_LIFECYCLE_UPDATE_FIELDS = frozenset(
+    {
+        "status",
+        "releaseNotes",
+        "evaluationScore",
+        "evaluationReportUrl",
+    }
+)
+
+
+def _reject_unexpected_fields(body: dict[str, Any], *, allowed: frozenset[str]) -> None:
+    unexpected = sorted(set(body) - allowed)
+    if unexpected:
+        fields = ", ".join(unexpected)
+        raise ValueError(f"Unsupported agent lifecycle fields: {fields}")
+
+
+def _require_release_evidence(body: dict[str, Any], *, status: AgentStatus) -> str:
+    release_notes = shared._str_or_none(body.get("releaseNotes"))
+    if release_notes is None:
+        raise ValueError(f"releaseNotes is required when status is {status.value}")
+    return release_notes
+
+
+def _require_existing_approval_evidence(
+    existing: dict[str, Any],
+    *,
+    agent_name: str,
+    version: str,
+) -> None:
+    approved_by = shared._str_or_none(existing.get("approved_by"))
+    approved_at = shared._str_or_none(existing.get("approved_at"))
+    approval_notes = shared._str_or_none(existing.get("release_notes"))
+    if approved_by and approved_at and approval_notes:
+        return
+    raise ValueError(
+        f"Agent version {agent_name}:{version} is missing immutable approval evidence; "
+        "transition to promoted or rolled_back is not allowed"
+    )
+
+
 def _normalize_ag_ui_metadata(raw_value: Any) -> dict[str, Any]:
     if raw_value is None:
         return {
@@ -65,6 +128,7 @@ def handle_register_agent(
     shared._require_admin(caller)
     shared._require_platform_actor(caller)
     body = shared._require_json_body(event)
+    _reject_unexpected_fields(body, allowed=_REGISTER_MUTABLE_FIELDS)
 
     agent_name = shared._str_or_none(body.get("agentName"))
     version = shared._str_or_none(body.get("version"))
@@ -145,6 +209,7 @@ def handle_update_agent_version(
     shared._require_admin(caller)
     shared._require_platform_actor(caller)
     body = shared._require_json_body(event)
+    _reject_unexpected_fields(body, allowed=_LIFECYCLE_UPDATE_FIELDS)
 
     new_status = shared._str_or_none(body.get("status"))
     if not new_status:
@@ -160,26 +225,33 @@ def handle_update_agent_version(
 
     current_status = normalize_agent_status(existing.get("status"), default=AgentStatus.PROMOTED)
     shared._validate_agent_status_transition(current_status, new_agent_status)
+    if new_agent_status is AgentStatus.APPROVED:
+        _require_release_evidence(body, status=new_agent_status)
+    if new_agent_status in {AgentStatus.PROMOTED, AgentStatus.ROLLED_BACK}:
+        _require_existing_approval_evidence(existing, agent_name=agent_name, version=version)
+    if new_agent_status is AgentStatus.ROLLED_BACK:
+        _require_release_evidence(body, status=new_agent_status)
+    if (
+        body.get("evaluationScore") is not None or body.get("evaluationReportUrl") is not None
+    ) and new_agent_status is not AgentStatus.PROMOTED:
+        raise ValueError("evaluationScore and evaluationReportUrl are only allowed for promoted")
 
     updated_at = shared._iso(shared._now_utc())
     attrs: dict[str, Any] = {
         "status": new_agent_status.value,
         "updated_at": updated_at,
     }
-    if new_agent_status in {AgentStatus.APPROVED, AgentStatus.PROMOTED}:
+    if new_agent_status is AgentStatus.APPROVED:
         attrs["approved_by"] = caller.sub
         attrs["approved_at"] = updated_at
+        attrs["release_notes"] = _require_release_evidence(body, status=new_agent_status)
     if new_agent_status is AgentStatus.ROLLED_BACK:
         attrs["rolled_back_by"] = caller.sub
         attrs["rolled_back_at"] = updated_at
-    if body.get("releaseNotes") is not None:
-        attrs["release_notes"] = str(body["releaseNotes"])
     if body.get("evaluationScore") is not None:
         attrs["evaluation_score"] = float(body["evaluationScore"])
     if body.get("evaluationReportUrl") is not None:
         attrs["evaluation_report_url"] = str(body["evaluationReportUrl"])
-    if body.get("agUi") is not None:
-        attrs.update(_normalize_ag_ui_metadata(body.get("agUi")))
 
     update_expression, expr_names, expr_values = shared._build_update_expression(attrs)
     db.update_item(
@@ -195,7 +267,7 @@ def handle_update_agent_version(
     if detail_type is not None and new_agent_status != current_status:
         approved_by = shared._str_or_none(attrs.get("approved_by") or existing.get("approved_by"))
         approved_at = shared._str_or_none(attrs.get("approved_at") or existing.get("approved_at"))
-        release_notes = shared._str_or_none(attrs.get("release_notes"))
+        release_notes = shared._str_or_none(body.get("releaseNotes"))
         evaluation_score_raw = attrs.get("evaluation_score")
         evaluation_score = float(evaluation_score_raw) if evaluation_score_raw is not None else None
         evaluation_report_url = shared._str_or_none(attrs.get("evaluation_report_url"))

--- a/tests/unit/test_agent_scripts.py
+++ b/tests/unit/test_agent_scripts.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import boto3
 import pytest
-from botocore.exceptions import ClientError
 from moto import mock_aws
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -385,17 +384,13 @@ transport = "sse"
 endpoint = "https://ag-ui.example.com/connect"
 """)
     stored_items: list[dict[str, object]] = []
-    latest_version_writes: list[dict[str, object]] = []
-
-    def put_item(**kwargs):
-        stored_items.append(kwargs["Item"])
-
-    def put_parameter(**kwargs):
-        latest_version_writes.append(kwargs)
-
-    fake_ssm = types.SimpleNamespace(put_parameter=put_parameter)
+    seen_request: dict[str, object] = {}
+    fake_ssm = types.SimpleNamespace()
 
     def fake_request_api(url, method, token, body=None):
+        seen_request["url"] = url
+        seen_request["method"] = method
+        seen_request["token"] = token
         stored_items.append(body)
         return {"status": "registered"}
 
@@ -429,21 +424,18 @@ endpoint = "https://ag-ui.example.com/connect"
     assert item["layerHash"] == ""
     assert item["layerS3Key"] == ""
     assert item["scriptS3Key"] == ""
+    assert item["status"] == "built"
     assert item["agUi"] == {
         "enabled": True,
         "transport": "sse",
         "endpoint": "https://ag-ui.example.com/connect",
     }
     assert item["runtimeArn"] == "arn:runtime:echo-agent"
-
-    assert latest_version_writes == [
-        {
-            "Name": f"/platform/agents/{env}/{agent_name}/latest-version",
-            "Value": "1.2.3",
-            "Type": "String",
-            "Overwrite": True,
-        }
-    ]
+    assert seen_request == {
+        "url": "http://localhost/v1/platform/agents",
+        "method": "POST",
+        "token": "fake-token",
+    }
 
 
 def test_register_agent_returns_false_when_dynamodb_write_fails(tmp_path, monkeypatch):
@@ -518,26 +510,13 @@ tier_minimum = "basic"
 handler = "handler:invoke"
 invocation_mode = "sync"
 """)
-    put_item_calls: list[dict[str, object]] = []
-
-    def failing_put_parameter(*args, **kwargs):
-        if kwargs.get("Name") == f"/platform/agents/{env}/{agent_name}/latest-version":
-            raise ClientError(
-                {"Error": {"Code": "InternalServerError", "Message": "ssm write failed"}},
-                "PutParameter",
-            )
-        return None
-
-    fake_table = types.SimpleNamespace(put_item=lambda **kwargs: put_item_calls.append(kwargs))
-    fake_resource = types.SimpleNamespace(Table=lambda table_name: fake_table)
-    fake_ssm = types.SimpleNamespace(put_parameter=failing_put_parameter)
+    fake_ssm = types.SimpleNamespace()
 
     monkeypatch.setattr(
         register_agent,
         "boto3",
         types.SimpleNamespace(
             client=lambda service_name, **kwargs: fake_ssm,
-            resource=lambda service_name, **kwargs: fake_resource,
         ),
     )
     monkeypatch.setattr(
@@ -557,7 +536,7 @@ invocation_mode = "sync"
     monkeypatch.setenv("API_BASE_URL", "http://localhost")
     monkeypatch.setenv("PLATFORM_ACCESS_TOKEN", "fake-token")
 
-    assert register_agent.register_agent(agent_name, env, None, None) is False
+    assert register_agent.register_agent(agent_name, env, None, None) is True
 
 
 def test_register_agent_container_allows_missing_zip_metadata(tmp_path, monkeypatch):

--- a/tests/unit/test_rollback_agent.py
+++ b/tests/unit/test_rollback_agent.py
@@ -1,12 +1,7 @@
-"""Unit tests for rollback_agent.py."""
-
 import importlib.util
 import sys
 from pathlib import Path
 from typing import Any
-
-import boto3
-from moto import mock_aws
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
@@ -26,32 +21,24 @@ def _load_module(name: str) -> Any:
 
 rollback_agent = _load_module("rollback_agent")
 
-_REGION = "eu-west-2"
 
-
-@mock_aws
-def test_rollback_agent_success(tmp_path, monkeypatch):
-    monkeypatch.setenv("AWS_REGION", _REGION)
-    monkeypatch.setenv("CI", "true")
-
+def test_rollback_agent_success(monkeypatch):
     agent_name = "test-agent"
     env = "dev"
-
-    # Setup SSM with current state (pointing to v1.1.0)
-    ssm = boto3.client("ssm", region_name=_REGION)
-    ssm.put_parameter(
-        Name=f"/platform/agents/{env}/{agent_name}/latest-version", Value="1.1.0", Type="String"
-    )
+    seen: dict[str, Any] = {}
 
     def fake_request_api(url, method, token, body=None):
         if method == "GET" and url.endswith("/v1/platform/agents"):
+            seen["list_url"] = url
             return {
                 "items": [
-                    {"agent_name": agent_name, "version": "1.0.0", "status": "released"},
-                    {"agent_name": agent_name, "version": "1.1.0", "status": "released"},
+                    {"agent_name": agent_name, "version": "1.0.0", "status": "promoted"},
+                    {"agent_name": agent_name, "version": "1.1.0", "status": "promoted"},
                 ]
             }
         if method == "PATCH" and f"/v1/platform/agents/{agent_name}/versions/1.1.0" in url:
+            seen["patch_url"] = url
+            seen["patch_body"] = body
             return {"status": "updated"}
         return {}
 
@@ -60,19 +47,19 @@ def test_rollback_agent_success(tmp_path, monkeypatch):
     monkeypatch.setenv("PLATFORM_ACCESS_TOKEN", "fake-token")
 
     # Run Rollback
-    success = rollback_agent.rollback_agent(agent_name, env, None, None)
-    assert success is True
-
-    # Verify SSM points back to v1.0.0
-    latest_version_param = ssm.get_parameter(
-        Name=f"/platform/agents/{env}/{agent_name}/latest-version"
+    success = rollback_agent.rollback_agent(
+        agent_name, env, None, None, notes="operator rollback evidence"
     )
-    assert latest_version_param["Parameter"]["Value"] == "1.0.0"
+    assert success is True
+    assert seen["list_url"] == "http://localhost/v1/platform/agents"
+    assert seen["patch_url"] == f"http://localhost/v1/platform/agents/{agent_name}/versions/1.1.0"
+    assert seen["patch_body"] == {
+        "status": "rolled_back",
+        "releaseNotes": "operator rollback evidence",
+    }
 
 
-@mock_aws
 def test_rollback_agent_fails_no_previous(monkeypatch):
-    monkeypatch.setenv("AWS_REGION", _REGION)
     agent_name = "test-agent"
     env = "dev"
 
@@ -80,7 +67,7 @@ def test_rollback_agent_fails_no_previous(monkeypatch):
         if method == "GET" and url.endswith("/v1/platform/agents"):
             return {
                 "items": [
-                    {"agent_name": agent_name, "version": "1.0.0", "status": "released"},
+                    {"agent_name": agent_name, "version": "1.0.0", "status": "promoted"},
                 ]
             }
         return {}

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -2380,10 +2380,20 @@ def test_platform_register_agent_rejects_non_built_initial_status(
 def test_platform_promote_agent_updates_metadata_and_emits_event(
     fake_state: dict[str, Any],
 ) -> None:
-    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="approved")
+    _seed_agent_version(
+        fake_state,
+        agent_name="echo-agent",
+        version="1.2.0",
+        status="approved",
+        extra={
+            "approved_by": "approver-007",
+            "approved_at": "2026-02-24T18:30:00Z",
+            "release_notes": "operator approval evidence",
+        },
+    )
     event = _event(
         method="PATCH",
-        body={"status": "promoted", "releaseNotes": "approved release evidence recorded"},
+        body={"status": "promoted", "releaseNotes": "promotion executed by operator"},
         caller_tenant_id="platform",
         roles=["Platform.Admin"],
     )
@@ -2394,9 +2404,9 @@ def test_platform_promote_agent_updates_metadata_and_emits_event(
     assert response["statusCode"] == 200
     item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]
     assert item["status"] == "promoted"
-    assert item["approved_by"] == "user-123"
-    assert item["approved_at"] == "2026-02-25T12:00:00Z"
-    assert item["release_notes"] == "approved release evidence recorded"
+    assert item["approved_by"] == "approver-007"
+    assert item["approved_at"] == "2026-02-24T18:30:00Z"
+    assert item["release_notes"] == "operator approval evidence"
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.promoted"
     assert detail["schemaVersion"] == 1
@@ -2415,9 +2425,33 @@ def test_platform_promote_agent_updates_metadata_and_emits_event(
     assert detail["version"] == "1.2.0"
     assert detail["previousStatus"] == "approved"
     assert detail["status"] == "promoted"
-    assert detail["approvedBy"] == "user-123"
-    assert detail["approvedAt"] == "2026-02-25T12:00:00Z"
-    assert detail["releaseNotes"] == "approved release evidence recorded"
+    assert detail["approvedBy"] == "approver-007"
+    assert detail["approvedAt"] == "2026-02-24T18:30:00Z"
+    assert detail["releaseNotes"] == "promotion executed by operator"
+
+
+def test_platform_approve_agent_records_immutable_approval_evidence(
+    fake_state: dict[str, Any],
+) -> None:
+    _seed_agent_version(
+        fake_state, agent_name="approve-agent", version="1.0.0", status="evaluation_passed"
+    )
+    event = _event(
+        method="PATCH",
+        body={"status": "approved", "releaseNotes": "two-person approval recorded"},
+        roles=["Platform.Admin"],
+        caller_tenant_id="platform",
+    )
+    event["path"] = "/v1/platform/agents/approve-agent/versions/1.0.0"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 200
+    item = fake_state["db"].items[("AGENT#approve-agent", "VERSION#1.0.0")]
+    assert item["status"] == "approved"
+    assert item["approved_by"] == "user-123"
+    assert item["approved_at"] == "2026-02-25T12:00:00Z"
+    assert item["release_notes"] == "two-person approval recorded"
 
 
 def test_platform_rejects_invalid_agent_status_transition(fake_state: dict[str, Any]) -> None:
@@ -2468,6 +2502,9 @@ def test_platform_register_and_promote_with_evidence(fake_state: dict[str, Any])
         version="1.0.0",
         status="approved",
         extra={
+            "approved_by": "release-admin",
+            "approved_at": "2026-02-24T18:30:00Z",
+            "release_notes": "approval evidence",
             "commit_sha": "abc12345",
             "pipeline_url": "https://gitlab.com/pipeline/123",
             "job_id": "job-456",
@@ -2496,21 +2533,78 @@ def test_platform_register_and_promote_with_evidence(fake_state: dict[str, Any])
     assert item["status"] == "promoted"
     assert item["evaluation_score"] == Decimal("0.98")
     assert item["evaluation_report_url"] == "https://frankfurt.aws/eval/789"
-    assert item["approved_by"] == "user-123"
+    assert item["approved_by"] == "release-admin"
+    assert item["approved_at"] == "2026-02-24T18:30:00Z"
+    assert item["release_notes"] == "approval evidence"
 
     # Verify event detail
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.promoted"
+    assert detail["approvedBy"] == "release-admin"
+    assert detail["approvedAt"] == "2026-02-24T18:30:00Z"
+    assert detail["releaseNotes"] == "Score: 0.98"
     assert detail["evaluationScore"] == 0.98
     assert detail["evaluationReportUrl"] == "https://frankfurt.aws/eval/789"
 
 
-def test_platform_rollback_with_metadata(fake_state: dict[str, Any]) -> None:
-    _seed_agent_version(fake_state, agent_name="rollback-agent", version="1.0.0", status="promoted")
+def test_platform_promote_requires_existing_approval_evidence(fake_state: dict[str, Any]) -> None:
+    _seed_agent_version(fake_state, agent_name="echo-agent", version="1.2.0", status="approved")
 
     event = _event(
         method="PATCH",
-        body={"status": "rolled_back"},
+        body={"status": "promoted"},
+        roles=["Platform.Admin"],
+        caller_tenant_id="platform",
+    )
+    event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+
+
+def test_platform_rejects_immutable_agent_metadata_updates(fake_state: dict[str, Any]) -> None:
+    _seed_agent_version(
+        fake_state,
+        agent_name="echo-agent",
+        version="1.2.0",
+        status="approved",
+        extra={
+            "approved_by": "release-admin",
+            "approved_at": "2026-02-24T18:30:00Z",
+            "release_notes": "approval evidence",
+        },
+    )
+
+    event = _event(
+        method="PATCH",
+        body={"status": "promoted", "agUi": {"enabled": True, "endpoint": "https://example.com"}},
+        roles=["Platform.Admin"],
+        caller_tenant_id="platform",
+    )
+    event["path"] = "/v1/platform/agents/echo-agent/versions/1.2.0"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+
+
+def test_platform_rollback_with_metadata(fake_state: dict[str, Any]) -> None:
+    _seed_agent_version(
+        fake_state,
+        agent_name="rollback-agent",
+        version="1.0.0",
+        status="promoted",
+        extra={
+            "approved_by": "release-admin",
+            "approved_at": "2026-02-24T18:30:00Z",
+            "release_notes": "approval evidence",
+        },
+    )
+
+    event = _event(
+        method="PATCH",
+        body={"status": "rolled_back", "releaseNotes": "runtime regression confirmed"},
         roles=["Platform.Admin"],
         caller_tenant_id="platform",
     )
@@ -2523,11 +2617,15 @@ def test_platform_rollback_with_metadata(fake_state: dict[str, Any]) -> None:
     assert item["status"] == "rolled_back"
     assert item["rolled_back_by"] == "user-123"
     assert item["rolled_back_at"] == "2026-02-25T12:00:00Z"
+    assert item["release_notes"] == "approval evidence"
 
     # Verify event detail
     detail_type, detail = _last_event_detail(fake_state)
     assert detail_type == "platform.agent_version.rolled_back"
     assert detail["status"] == "rolled_back"
+    assert detail["approvedBy"] == "release-admin"
+    assert detail["approvedAt"] == "2026-02-24T18:30:00Z"
+    assert detail["releaseNotes"] == "runtime regression confirmed"
     assert detail["rolledBackBy"] == "user-123"
     assert detail["rolledBackAt"] == "2026-02-25T12:00:00Z"
 
@@ -2537,6 +2635,9 @@ def test_platform_rollback_agent_emits_event(fake_state: dict[str, Any]) -> None
     fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]["approved_by"] = "release-admin"
     fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]["approved_at"] = (
         "2026-02-24T18:30:00Z"
+    )
+    fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.0")]["release_notes"] = (
+        "approval evidence"
     )
     event = _event(
         method="PATCH",


### PR DESCRIPTION
## Summary
- tighten agent-registry lifecycle updates so only status and governance evidence fields are mutable
- preserve immutable approval evidence on approved releases and require it before promote/rollback
- align register/promote/rollback scripts with the canonical ADR-015 routes and statuses, removing hidden latest-version side effects

## Testing
- `pytest -q tests/unit/test_tenant_api_handler.py -k 'platform_promote_agent_updates_metadata_and_emits_event or platform_approve_agent_records_immutable_approval_evidence or platform_register_and_promote_with_evidence or platform_promote_requires_existing_approval_evidence or platform_rejects_immutable_agent_metadata_updates or platform_rollback_with_metadata or platform_rollback_agent_emits_event'`
- `PYTHONPATH=/mnt/c/Users/julia/worktrees/wt390:/mnt/c/Users/julia/worktrees/wt390/src/data-access-lib/src pytest -q tests/unit/test_agent_scripts.py -k 'register_agent'`
- `pytest -q tests/unit/test_rollback_agent.py`
- `make preflight-session`
- `make pre-validate-session`

Closes #390