### PR TITLE
fix: cover failover runtime metrics in observability

### DIFF
--- a/infra/cdk/lib/observability-stack.ts
+++ b/infra/cdk/lib/observability-stack.ts
@@ -33,6 +33,7 @@ export class ObservabilityStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ObservabilityStackProps) {
     super(scope, id, props);
     const alarmNamePrefix = this.stackName;
+    const runtimeRegions = ['eu-west-1', 'eu-central-1'];
 
     // --- 1. Platform Operations Dashboard ---
 
@@ -157,23 +158,27 @@ export class ObservabilityStack extends cdk.Stack {
         height: 1,
       }),
       new cloudwatch.GraphWidget({
-        title: 'AgentCore Runtime (eu-west-1)',
-        left: [
-          new cloudwatch.Metric({
-            namespace: 'AgentCore',
-            metricName: 'ConcurrentSessions',
-            region: 'eu-west-1',
-            statistic: 'Maximum',
-          }),
-        ],
-        right: [
-          new cloudwatch.Metric({
-            namespace: 'AgentCore',
-            metricName: 'ExecutionErrors',
-            region: 'eu-west-1',
-            statistic: 'Sum',
-          }),
-        ],
+        title: 'AgentCore Runtime (Primary + Failover)',
+        left: runtimeRegions.map(
+          (region) =>
+            new cloudwatch.Metric({
+              namespace: 'AgentCore',
+              metricName: 'ConcurrentSessions',
+              region,
+              statistic: 'Maximum',
+              label: `${region} ConcurrentSessions`,
+            }),
+        ),
+        right: runtimeRegions.map(
+          (region) =>
+            new cloudwatch.Metric({
+              namespace: 'AgentCore',
+              metricName: 'ExecutionErrors',
+              region,
+              statistic: 'Sum',
+              label: `${region} ExecutionErrors`,
+            }),
+        ),
         width: 12,
       }),
       new cloudwatch.GraphWidget({

--- a/infra/cdk/test/observability-stack.test.ts
+++ b/infra/cdk/test/observability-stack.test.ts
@@ -71,6 +71,22 @@ describe('ObservabilityStack (TASK-026)', () => {
     });
   });
 
+  test('includes both primary and failover AgentCore runtime regions in the dashboard view', () => {
+    const template = synthStack();
+    const dashboards = template.findResources('AWS::CloudWatch::Dashboard') as Record<
+      string,
+      { Properties?: { DashboardBody?: unknown } }
+    >;
+    const dashboard = Object.values(dashboards)[0];
+    const dashboardBody = JSON.stringify(dashboard.Properties?.DashboardBody);
+
+    expect(dashboardBody).toContain('AgentCore Runtime (Primary + Failover)');
+    expect(dashboardBody).toContain('eu-west-1 ConcurrentSessions');
+    expect(dashboardBody).toContain('eu-central-1 ConcurrentSessions');
+    expect(dashboardBody).toContain('eu-west-1 ExecutionErrors');
+    expect(dashboardBody).toContain('eu-central-1 ExecutionErrors');
+  });
+
   test('creates FM-1 Runtime Region Unavailable alarm', () => {
     const template = synthStack();
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {


### PR DESCRIPTION
## Summary
- update the AgentCore dashboard widget to include both primary and failover runtime regions
- add regression coverage that asserts the failover-aware dashboard view stays in place
- preserve the existing observability scope while making failover operator visibility explicit

## Validation
- make preflight-session
- make pre-validate-session
- npx jest --runInBand observability-stack.test.ts

## Notes
- `make validate-local` is currently blocked by unrelated pointer-stub drift between `AGENTS.md` and `GEMINI.md`; this change does not touch those files.
