### PR TITLE
fix: split deployed agent invoke from local dev invoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ dev-invoke:
 	@TENANT=$$(grep BASIC_TENANT_ID .env.test 2>/dev/null | cut -d= -f2); \
 	uv run python scripts/dev-invoke.py \
 		--agent echo-agent \
-		--tenant "$${TENANT:-t-basic-001}" \
+		--tenant "$${TENANT:-t-test-001}" \
 		--prompt "$(or $(PROMPT),Hello from local environment)" \
 		--mode "$(or $(MODE),sync)"
 
@@ -560,12 +560,12 @@ agentcore-destroy:
 	@test -n "$(AGENT)" || (echo "ERROR: AGENT required. Usage: make agentcore-destroy AGENT=my-agent" && exit 1)
 	cd agents/$(AGENT) && uv run agentcore destroy
 
-## agent-invoke: Invoke a deployed agent
-## Usage: make agent-invoke AGENT=my-agent TENANT=t-abc123 [PROMPT="hello"] [MODE=sync]
+## agent-invoke: Invoke a deployed agent directly via the Bridge Lambda
+## Usage: make agent-invoke AGENT=my-agent TENANT=t-abc123 [PROMPT="hello"] [ENV=dev]
 agent-invoke:
 	@test -n "$(AGENT)" || (echo "ERROR: AGENT required" && exit 1)
 	@test -n "$(TENANT)" || (echo "ERROR: TENANT required" && exit 1)
-	uv run python scripts/dev-invoke.py \
+	uv run python scripts/agent-invoke.py \
 		--agent $(AGENT) \
 		--tenant $(TENANT) \
 		--env $(ENV) \

--- a/docs/development/AGENT-DEVELOPER-GUIDE.md
+++ b/docs/development/AGENT-DEVELOPER-GUIDE.md
@@ -27,11 +27,11 @@ make agentcore-invoke-runtime AGENT=my-agent # Invoke the toolkit-managed runtim
 
 # 5. (Optional) Test platform integration locally (requires Docker)
 make dev                                    # Start local environment (LocalStack + mocks)
-make agent-invoke AGENT=my-agent TENANT=t-basic-001 ENV=local  # Invoke via local bridge
+make dev-invoke                              # Invoke via local bridge with seeded local fixtures
 
 # 6. Validate locally, then push through A5C to AWS dev (real compute)
 make agent-push AGENT=my-agent ENV=dev      # Package, run agent tests, deploy to Runtime, and register
-make agent-invoke AGENT=my-agent ENV=dev    # Invoke your agent on real AWS
+make agent-invoke AGENT=my-agent TENANT=t-test-001 ENV=dev  # Invoke your agent on real AWS
 ```
 
 ## Local vs. AWS Development
@@ -297,7 +297,7 @@ This dataset is used by the evaluation gate during pipeline promotion.
   "sync": [
     {
       "id": "basic-greeting",
-      "input": {"prompt": "Hello", "tenantId": "t-basic-001"},
+      "input": {"prompt": "Hello", "tenantId": "t-test-001"},
       "expected": {"result": "Hello back"}
     }
   ]

--- a/docs/development/LOCAL-SETUP.md
+++ b/docs/development/LOCAL-SETUP.md
@@ -58,11 +58,11 @@ After `make dev`, two test tenants are available. Their tenant IDs and JWTs are 
 
 | Variable              | Value      | Purpose  |
 |-----------------------|------------|----------|
-| BASIC_TENANT_JWT      | t-basic-001 | basic    |
-| PREMIUM_TENANT_JWT    | t-premium-001 | premium  |
-| ADMIN_JWT             | t-basic-001 | Platform.Admin |
+| BASIC_TENANT_JWT      | t-test-001 | basic    |
+| PREMIUM_TENANT_JWT    | t-test-002 | premium  |
+| ADMIN_JWT             | t-test-001 | Platform.Admin |
 
-Use these with `make agent-invoke AGENT=echo-agent TENANT=t-basic-001 ENV=local` or in your tests via `conftest.py`.
+Use these with `make dev-invoke` for the local bridge path, or in your tests via `conftest.py`.
 
 ## Running Tests
 

--- a/docs/operations/RUNBOOK-008-developer-onboarding.md
+++ b/docs/operations/RUNBOOK-008-developer-onboarding.md
@@ -40,7 +40,8 @@ cp -r agents/echo-agent agents/my-first-agent
 # Edit pyproject.toml: change name, version, owner_team
 # Edit handler.py: change the response
 make agent-push AGENT=my-first-agent ENV=dev
-make agent-invoke AGENT=my-first-agent TENANT=t-basic-001 ENV=local PROMPT="hello world"
+make dev-invoke
+make agent-invoke AGENT=my-first-agent TENANT=t-test-001 ENV=dev PROMPT="hello world"
 ```
 
 ## Success Criteria

--- a/scripts/agent-invoke.py
+++ b/scripts/agent-invoke.py
@@ -1,0 +1,125 @@
+"""Developer CLI for direct deployed-agent invocation via the Bridge Lambda."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+DEFAULT_ENV = "dev"
+DEFAULT_APP_ID = "platform-cli"
+DEFAULT_TIER = "premium"
+DEFAULT_SUB = "developer"
+
+
+class AgentInvokeError(RuntimeError):
+    """Domain error for CLI usage and invocation failures."""
+
+
+def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {"input": args.prompt}
+    if args.session_id:
+        payload["sessionId"] = args.session_id
+    if args.webhook_id:
+        payload["webhookId"] = args.webhook_id
+    return payload
+
+
+def build_event(args: argparse.Namespace) -> dict[str, Any]:
+    """Construct a bridge-compatible API Gateway event payload."""
+    return {
+        "httpMethod": "POST",
+        "path": f"/v1/agents/{args.agent}/invoke",
+        "pathParameters": {"agentName": args.agent},
+        "body": json.dumps(_build_payload(args)),
+        "requestContext": {
+            "authorizer": {
+                "lambda": {
+                    "tenantid": args.tenant,
+                    "appid": DEFAULT_APP_ID,
+                    "tier": DEFAULT_TIER,
+                    "sub": DEFAULT_SUB,
+                }
+            }
+        },
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Invoke a deployed agent directly via the Bridge Lambda."
+    )
+    parser.add_argument("--agent", required=True, help="Agent name")
+    parser.add_argument("--tenant", required=True, help="Tenant ID")
+    parser.add_argument("--prompt", default="Hello", help="Input prompt")
+    parser.add_argument(
+        "--mode",
+        choices=("sync", "streaming", "async"),
+        default="sync",
+        help="Requested invocation mode for the payload contract",
+    )
+    parser.add_argument(
+        "--env",
+        default=DEFAULT_ENV,
+        help="Deployment environment (dev, staging, prod). Use dev-invoke for local.",
+    )
+    parser.add_argument("--session-id", help="Optional session identifier")
+    parser.add_argument("--webhook-id", help="Optional webhook identifier")
+    return parser.parse_args(argv)
+
+
+def _print_payload(payload: Any) -> None:
+    if isinstance(payload, (dict, list)):
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(payload)
+
+
+def invoke_remote(args: argparse.Namespace) -> int:
+    """Invoke the deployed Bridge Lambda on AWS."""
+    if args.env == "local":
+        raise AgentInvokeError("ENV=local is not supported here. Use `make dev-invoke` instead.")
+
+    function_name = f"platform-{args.env}-bridge"
+    client = boto3.client("lambda")
+
+    try:
+        response = client.invoke(
+            FunctionName=function_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(build_event(args)).encode("utf-8"),
+        )
+    except ClientError as exc:
+        raise AgentInvokeError(f"AWS Lambda invocation failed: {exc}") from exc
+
+    payload_stream = response.get("Payload")
+    if payload_stream is None:
+        raise AgentInvokeError("AWS Lambda invocation returned no payload.")
+
+    raw_payload = payload_stream.read()
+    try:
+        payload = json.loads(raw_payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise AgentInvokeError("AWS Lambda invocation returned invalid JSON.") from exc
+
+    _print_payload(payload)
+    return 0 if payload.get("statusCode", 500) < 400 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        return invoke_remote(args)
+    except AgentInvokeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_agent_invoke.py
+++ b/tests/unit/test_agent_invoke.py
@@ -1,0 +1,137 @@
+"""Unit tests for scripts/agent-invoke.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_agent_invoke_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "agent_invoke_script",
+        repo_root / "scripts" / "agent-invoke.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+agent_invoke = _load_agent_invoke_module()
+
+
+class _FakePayloadStream:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._raw
+
+
+def test_parse_args_matches_deployed_contract() -> None:
+    args = agent_invoke.parse_args(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-test-001",
+            "--prompt",
+            "hello",
+            "--env",
+            "staging",
+        ]
+    )
+
+    assert args.agent == "echo-agent"
+    assert args.tenant == "t-test-001"
+    assert args.prompt == "hello"
+    assert args.env == "staging"
+    assert args.mode == "sync"
+
+
+def test_build_event_matches_bridge_contract() -> None:
+    args = agent_invoke.parse_args(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-test-001",
+            "--prompt",
+            "hello",
+            "--session-id",
+            "session-123",
+            "--webhook-id",
+            "wh-123",
+        ]
+    )
+
+    event = agent_invoke.build_event(args)
+
+    assert event["httpMethod"] == "POST"
+    assert event["path"] == "/v1/agents/echo-agent/invoke"
+    assert event["pathParameters"] == {"agentName": "echo-agent"}
+    assert json.loads(event["body"]) == {
+        "input": "hello",
+        "sessionId": "session-123",
+        "webhookId": "wh-123",
+    }
+    assert event["requestContext"]["authorizer"]["lambda"]["tenantid"] == "t-test-001"
+
+
+def test_main_rejects_local_env_with_dev_invoke_guidance(capsys) -> None:
+    rc = agent_invoke.main(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-test-001",
+            "--env",
+            "local",
+        ]
+    )
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "make dev-invoke" in captured.err
+
+
+def test_invoke_remote_targets_bridge_lambda(monkeypatch, capsys) -> None:
+    seen: dict[str, Any] = {}
+
+    class _FakeLambdaClient:
+        def invoke(self, **kwargs: Any) -> dict[str, Any]:
+            seen.update(kwargs)
+            return {
+                "Payload": _FakePayloadStream(
+                    {"statusCode": 200, "body": json.dumps({"result": "ok"})}
+                )
+            }
+
+    monkeypatch.setattr(agent_invoke.boto3, "client", lambda service: _FakeLambdaClient())
+
+    rc = agent_invoke.main(
+        [
+            "--agent",
+            "echo-agent",
+            "--tenant",
+            "t-test-001",
+            "--prompt",
+            "hello world",
+            "--env",
+            "dev",
+        ]
+    )
+
+    assert rc == 0
+    assert seen["FunctionName"] == "platform-dev-bridge"
+    assert seen["InvocationType"] == "RequestResponse"
+    payload = json.loads(seen["Payload"].decode("utf-8"))
+    assert payload["path"] == "/v1/agents/echo-agent/invoke"
+    assert json.loads(payload["body"]) == {"input": "hello world"}
+    captured = capsys.readouterr()
+    assert '"statusCode": 200' in captured.out


### PR DESCRIPTION
## Summary
- split `make agent-invoke` away from the local `dev-invoke` path by introducing a dedicated deployed Bridge Lambda CLI
- update local developer docs so `dev-invoke` is the sanctioned local path and `agent-invoke` is the deployed path
- align the local fixture docs and `make dev-invoke` fallback with the seeded `t-test-*` tenant IDs

## Validation
- uv run pytest tests/unit/test_agent_invoke.py tests/unit/test_dev_invoke.py tests/unit/test_docs_sync_audit.py -q
- make preflight-session
- make pre-validate-session
