### PR TITLE
fix: wait for local mock services before bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,8 +334,7 @@ validate-secrets-full:
 dev:
 	@echo "==> Starting local development environment"
 	docker compose up -d
-	@echo "==> Waiting for LocalStack to be ready..."
-	@until curl -sf http://localhost:4566/_localstack/health >/dev/null 2>&1; do sleep 2; done
+	uv run python scripts/wait_for_local_services.py
 	uv run python scripts/dev-bootstrap.py
 	@echo ""
 	@echo "==> Local environment ready"

--- a/docs/development/LOCAL-SETUP.md
+++ b/docs/development/LOCAL-SETUP.md
@@ -94,8 +94,8 @@ These are stable fixture-based renders derived from the current SPA page structu
 
 **LocalStack not starting**: ensure Docker is running (`docker ps` should work).
 
-**make dev-invoke fails with 401**: LocalStack may not have finished seeding.
-Wait 10 seconds and retry, or check `docker compose logs localstack`.
+**make dev-invoke fails with 401**: local startup did not complete cleanly.
+Check `docker compose logs localstack mock-runtime mock-jwks` and rerun `make dev`.
 
 **uv: command not found**: run `source ~/.bashrc` or open a new terminal after install.
 

--- a/scripts/wait_for_local_services.py
+++ b/scripts/wait_for_local_services.py
@@ -1,0 +1,104 @@
+"""Wait for local development dependencies to become healthy."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.request import urlopen
+
+
+@dataclass(frozen=True)
+class ServiceCheck:
+    name: str
+    url: str
+
+
+LOCAL_DEV_SERVICES = (
+    ServiceCheck("LocalStack", "http://localhost:4566/_localstack/health"),
+    ServiceCheck("mock runtime", "http://localhost:8765/ping"),
+    ServiceCheck("mock JWKS", "http://localhost:8766/health"),
+)
+
+
+def wait_for_service(
+    check: ServiceCheck,
+    *,
+    timeout_seconds: int,
+    interval_seconds: float,
+    fetcher: Callable[[str, float], object] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Poll a health endpoint until it responds or the timeout expires."""
+    fetch = fetcher or (lambda url, timeout: urlopen(url, timeout=timeout))
+    deadline = time.monotonic() + timeout_seconds
+    last_error: str | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            response = fetch(check.url, interval_seconds)
+            if hasattr(response, "__enter__"):
+                with response:
+                    return
+            return
+        except OSError as exc:
+            last_error = str(exc)
+        sleep(interval_seconds)
+
+    detail = f" Last error: {last_error}" if last_error else ""
+    raise TimeoutError(
+        f"Timed out waiting for {check.name} at {check.url} after {timeout_seconds}s.{detail}"
+    )
+
+
+def wait_for_all_services(
+    *,
+    timeout_seconds: int,
+    interval_seconds: float,
+    checks: tuple[ServiceCheck, ...] = LOCAL_DEV_SERVICES,
+) -> None:
+    for check in checks:
+        print(f"==> Waiting for {check.name} ({check.url})...")
+        wait_for_service(
+            check,
+            timeout_seconds=timeout_seconds,
+            interval_seconds=interval_seconds,
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Wait until local development dependencies are healthy."
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=60,
+        help="Maximum time to wait for each service",
+    )
+    parser.add_argument(
+        "--interval-seconds",
+        type=float,
+        default=2.0,
+        help="Polling interval between readiness checks",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        wait_for_all_services(
+            timeout_seconds=args.timeout_seconds,
+            interval_seconds=args.interval_seconds,
+        )
+    except TimeoutError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wait_for_local_services.py
+++ b/scripts/wait_for_local_services.py
@@ -39,9 +39,9 @@ def wait_for_service(
     while time.monotonic() < deadline:
         try:
             response = fetch(check.url, interval_seconds)
-            if hasattr(response, "__enter__"):
-                with response:
-                    return
+            closer = getattr(response, "close", None)
+            if callable(closer):
+                closer()
             return
         except OSError as exc:
             last_error = str(exc)

--- a/tests/unit/test_wait_for_local_services.py
+++ b/tests/unit/test_wait_for_local_services.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "wait_for_local_services",
+        repo_root / "scripts" / "wait_for_local_services.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+wait_for_local_services = _load_module()
+
+
+class _FakeResponse:
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: Any) -> bool:
+        return False
+
+
+def test_wait_for_service_retries_until_success() -> None:
+    seen: list[str] = []
+
+    def _fetcher(url: str, _timeout: float) -> object:
+        seen.append(url)
+        if len(seen) < 3:
+            raise OSError("not ready")
+        return _FakeResponse()
+
+    sleeps: list[float] = []
+    wait_for_local_services.wait_for_service(
+        wait_for_local_services.ServiceCheck("mock runtime", "http://localhost:8765/ping"),
+        timeout_seconds=5,
+        interval_seconds=0.01,
+        fetcher=_fetcher,
+        sleep=sleeps.append,
+    )
+
+    assert len(seen) == 3
+    assert sleeps == [0.01, 0.01]
+
+
+def test_wait_for_service_times_out_with_service_name() -> None:
+    def _fetcher(_url: str, _timeout: float) -> object:
+        raise OSError("connection refused")
+
+    with pytest.raises(TimeoutError, match="mock JWKS"):
+        wait_for_local_services.wait_for_service(
+            wait_for_local_services.ServiceCheck("mock JWKS", "http://localhost:8766/health"),
+            timeout_seconds=0,
+            interval_seconds=0.01,
+            fetcher=_fetcher,
+            sleep=lambda _seconds: None,
+        )
+
+
+def test_main_returns_non_zero_when_a_service_never_becomes_ready(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        wait_for_local_services,
+        "wait_for_all_services",
+        lambda **_kwargs: (_ for _ in ()).throw(TimeoutError("boom")),
+    )
+
+    rc = wait_for_local_services.main(["--timeout-seconds", "1"])
+
+    assert rc == 1
+    assert "boom" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- wait for LocalStack, the mock runtime, and the mock JWKS service before running local bootstrap
- add a small readiness helper with unit coverage instead of embedding more polling in the Makefile
- remove the stale docs advice that told developers to retry after a false-ready local startup

## Validation
- uv run pytest tests/unit/test_wait_for_local_services.py -q
- make preflight-session
- make pre-validate-session
