### PR TITLE
fix: align observability with agentcore metric namespace

### DIFF
--- a/infra/cdk/lib/observability-stack.ts
+++ b/infra/cdk/lib/observability-stack.ts
@@ -33,6 +33,7 @@ export class ObservabilityStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ObservabilityStackProps) {
     super(scope, id, props);
     const alarmNamePrefix = this.stackName;
+    const agentCoreMetricNamespace = 'AWS/BedrockAgentCore';
     const runtimeRegions = ['eu-west-1', 'eu-central-1'];
 
     // --- 1. Platform Operations Dashboard ---
@@ -162,7 +163,7 @@ export class ObservabilityStack extends cdk.Stack {
         left: runtimeRegions.map(
           (region) =>
             new cloudwatch.Metric({
-              namespace: 'AgentCore',
+              namespace: agentCoreMetricNamespace,
               metricName: 'ConcurrentSessions',
               region,
               statistic: 'Maximum',
@@ -172,7 +173,7 @@ export class ObservabilityStack extends cdk.Stack {
         right: runtimeRegions.map(
           (region) =>
             new cloudwatch.Metric({
-              namespace: 'AgentCore',
+              namespace: agentCoreMetricNamespace,
               metricName: 'ExecutionErrors',
               region,
               statistic: 'Sum',
@@ -338,12 +339,12 @@ export class ObservabilityStack extends cdk.Stack {
     });
 
     // FM-7: AgentCore Memory unavailable (Degraded mode metric)
-    // Note: AgentCore metrics are custom metrics from the SDK
+    // Keep alarm reads aligned with the namespace exported by AgentCoreStack metric streams.
     new cloudwatch.Alarm(this, 'Fm7AgentCoreMemoryDegradedAlarm', {
       alarmName: `${alarmNamePrefix}-FM-7-AgentCoreMemoryDegraded`,
       alarmDescription: 'AgentCore Memory is in degraded mode',
       metric: new cloudwatch.Metric({
-        namespace: 'AgentCore',
+        namespace: agentCoreMetricNamespace,
         metricName: 'DegradedMode',
         dimensionsMap: { Service: 'Memory' },
         period: cdk.Duration.minutes(5),

--- a/infra/cdk/test/observability-stack.test.ts
+++ b/infra/cdk/test/observability-stack.test.ts
@@ -81,6 +81,7 @@ describe('ObservabilityStack (TASK-026)', () => {
     const dashboardBody = JSON.stringify(dashboard.Properties?.DashboardBody);
 
     expect(dashboardBody).toContain('AgentCore Runtime (Primary + Failover)');
+    expect(dashboardBody).toContain('AWS/BedrockAgentCore');
     expect(dashboardBody).toContain('eu-west-1 ConcurrentSessions');
     expect(dashboardBody).toContain('eu-central-1 ConcurrentSessions');
     expect(dashboardBody).toContain('eu-west-1 ExecutionErrors');
@@ -138,6 +139,7 @@ describe('ObservabilityStack (TASK-026)', () => {
     const template = synthStack();
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmName: 'ObservabilityStack-FM-7-AgentCoreMemoryDegraded',
+      Namespace: 'AWS/BedrockAgentCore',
       MetricName: 'DegradedMode',
     });
   });


### PR DESCRIPTION
## Summary
- align the ObservabilityStack AgentCore dashboard widgets and FM-7 alarm with the `AWS/BedrockAgentCore` namespace exported by AgentCoreStack
- keep the failover-aware runtime dashboard view intact while removing cross-stack namespace drift
- add regression assertions so future dashboard/alarm namespace drift fails tests

## Validation
- npx jest --runInBand observability-stack.test.ts
- make preflight-session
- make pre-validate-session
