### PR TITLE
fix: restrict tenant results bucket listing

### DIFF
--- a/infra/cdk/lib/tenant-stack.ts
+++ b/infra/cdk/lib/tenant-stack.ts
@@ -140,13 +140,27 @@ export class TenantStack extends cdk.Stack {
     // Scoped permissions for S3 (tenants/{tenant_id} prefix)
     executionRole.addToPolicy(
       new iam.PolicyStatement({
-        sid: 'TenantS3Access',
+        sid: 'TenantS3ListAccess',
         effect: iam.Effect.ALLOW,
-        actions: ['s3:GetObject', 's3:PutObject', 's3:ListBucket', 's3:DeleteObject'],
-        resources: [
-          resultsBucketArn,
-          `${resultsBucketArn}/tenants/${tenantId}/*`,
-        ],
+        actions: ['s3:ListBucket'],
+        resources: [resultsBucketArn],
+        conditions: {
+          StringLike: {
+            's3:prefix': [
+              `tenants/${tenantId}`,
+              `tenants/${tenantId}/*`,
+            ],
+          },
+        },
+      }),
+    );
+
+    executionRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'TenantS3ObjectAccess',
+        effect: iam.Effect.ALLOW,
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [`${resultsBucketArn}/tenants/${tenantId}/*`],
       }),
     );
 

--- a/infra/cdk/test/tenant-stack.test.ts
+++ b/infra/cdk/test/tenant-stack.test.ts
@@ -29,6 +29,19 @@ describe('TenantStack (TASK-025)', () => {
     return statement as { Action: string[]; Resource: string[]; Sid: string };
   };
 
+  const policyStatement = (template: Template, sid: string) => {
+    const policies = template.findResources('AWS::IAM::Policy') as Record<
+      string,
+      { Properties?: { PolicyDocument?: { Statement?: Array<Record<string, unknown>> } } }
+    >;
+    const statement = Object.values(policies)
+      .flatMap((policy) => policy.Properties?.PolicyDocument?.Statement ?? [])
+      .find((candidate) => candidate.Sid === sid);
+
+    expect(statement).toBeDefined();
+    return statement as Record<string, unknown>;
+  };
+
   const asArray = (value: string | string[]) => (Array.isArray(value) ? value : [value]);
 
   const defaultContext = {
@@ -70,12 +83,34 @@ describe('TenantStack (TASK-025)', () => {
             }),
           }),
           Match.objectLike({
-            Sid: 'TenantS3Access',
-            Action: Match.arrayWith(['s3:GetObject', 's3:PutObject']),
+            Sid: 'TenantS3ListAccess',
+            Action: 's3:ListBucket',
+            Resource: Match.anyValue(),
+            Condition: Match.objectLike({
+              StringLike: {
+                's3:prefix': ['tenants/t-test123', 'tenants/t-test123/*'],
+              },
+            }),
+          }),
+          Match.objectLike({
+            Sid: 'TenantS3ObjectAccess',
+            Action: Match.arrayWith(['s3:GetObject', 's3:PutObject', 's3:DeleteObject']),
             Resource: Match.anyValue(),
           }),
         ]),
       }),
+    });
+  });
+
+  test('limits bucket listing to the tenant results prefix', () => {
+    const template = synthTemplate(defaultContext);
+    const statement = policyStatement(template, 'TenantS3ListAccess');
+
+    expect(asArray(statement.Action as string | string[])).toEqual(['s3:ListBucket']);
+    expect(statement.Condition).toEqual({
+      StringLike: {
+        's3:prefix': ['tenants/t-test123', 'tenants/t-test123/*'],
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- split tenant execution-role S3 access into separate bucket-list and object-access statements
- restrict `s3:ListBucket` to the tenant results prefix with an `s3:prefix` condition
- add CDK regression coverage for the narrowed list permission

## Testing
- npx jest --runInBand tenant-stack.test.ts
- make preflight-session
- make pre-validate-session

Closes #220