### PR TITLE
[codex] add local codex flow board and ADR drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Scratch / local-only tooling
 .scratch/
+.codex
+.codex-flow/
 
 # Python
 __pycache__/

--- a/docs/decisions/ADR-701-tenant-agent-inference-chargeback-and-tagging.md
+++ b/docs/decisions/ADR-701-tenant-agent-inference-chargeback-and-tagging.md
@@ -1,0 +1,291 @@
+# ADR-701: Tenant, Agent, and Inference Chargeback With Tenant-Instantiation Tags
+
+## Status: Proposed
+## Date: 2026-04-03
+
+## Context
+The platform already has partial foundations for tenant-aware billing and
+attribution:
+- tenant provisioning creates per-tenant stacks and currently applies minimal
+  stack tags during create
+- invocation records already capture `tenantId`, `appId`, `agentName`,
+  `agentVersion`, token counts, and runtime region
+- the daily billing pipeline already aggregates invocation token counts to
+  produce tenant-level billing summaries
+
+However, the current design does not yet declare a single end-to-end chargeback
+strategy spanning:
+- tenant infrastructure allocation
+- per-agent invocation attribution
+- LLM inference attribution
+- future downstream gateway or proxy-based model invocation
+
+The architecture also has an important near-term default:
+- inference is expected to run in the `a5c-cell` / `tf-acore-aas` account path
+  by default
+- downstream inference through a dedicated model gateway may be introduced later
+  as a phased evolution
+
+That means the platform needs a design that is:
+- immediately usable for the current default where `a5c-cell` is the direct
+  inference owner
+- explicitly prepared for a later phase where a downstream gateway becomes the
+  authoritative inference meter
+
+Without an explicit decision, the platform risks:
+- tenant tags that are too weak for finance or AWS-native cost allocation
+- control-plane records that cannot explain model-level spend
+- future migration friction when inference moves behind a downstream gateway
+- ambiguous source-of-truth boundaries between infrastructure chargeback and
+  runtime inference chargeback
+
+## Current State Assessment
+The platform is **partially catered for already**, but not fully:
+
+1. **Already present**
+   - Tenant invocation records include tenant, app, agent, token, and runtime
+     dimensions in the invocation ledger
+   - Tenant billing is computed from invocation records
+   - Tenant provisioning already applies a minimal tag set at stack creation
+
+2. **Missing or not yet declared**
+   - a mandatory chargeback tag set across tenant-instantiated resources
+   - a formal distinction between infrastructure tags and runtime usage ledgers
+   - a required persistence model for `modelId` / `inferenceProfileId`
+   - a phased design for later downstream inference metering
+
+## Decision
+The platform adopts a two-layer chargeback model:
+
+1. **Infrastructure chargeback uses AWS resource tags**
+   - Tags are mandatory on tenant-instantiated infrastructure
+   - Tags support CUR / Cost Explorer / account-level allocation and operator
+     reporting
+
+2. **Inference chargeback uses the invocation ledger**
+   - The control plane invocation record is the canonical billing and audit record
+   - It must carry tenant, app, agent, and model attribution dimensions
+
+3. **Current default**
+   - While inference remains in the `a5c-cell` / `tf-acore-aas` account path,
+     `a5c-cell` is both:
+     - the attribution owner
+     - the authoritative inference meter
+
+4. **Future phased evolution**
+   - If inference later moves to a downstream Bedrock proxy or model gateway,
+     the platform keeps `a5c-cell` as the canonical billing-record owner
+   - The downstream gateway may become the authoritative inference meter
+   - That future mode must use a joined-ledger contract rather than replacing
+     the control-plane billing record
+
+5. **Audit and observability invariants remain inherited from ADR-016**
+   - chargeback-related logs, metrics, traces, and metering envelopes must
+     preserve `tenantid` and `appid`
+   - downstream metering integration must not create a second unaudited billing
+     path or weaken the control-plane tenant boundary
+
+## Mandatory Chargeback Dimensions
+The following dimensions are mandatory for runtime chargeback:
+- `tenantId`
+- `appId`
+- `agentName`
+- `modelId` or `inferenceProfileId`
+
+The following are strongly recommended and should be persisted when available:
+- `agentVersion`
+- `invocationId`
+- `sessionId`
+- `runtimeRegion`
+- `gatewayAccountId` when inference is performed by a downstream gateway
+- `gatewayRegion` when inference is performed by a downstream gateway
+
+## Canonical Persisted Field Contract
+The invocation ledger and any downstream metering integration must use the
+following canonical persisted fields.
+
+Identity and attribution:
+- `tenant_id`
+- `app_id`
+- `agent_name`
+- `agent_version`
+- `invocation_id`
+- `session_id`
+- `runtime_region`
+
+Requested inference target:
+- `requested_model_id`
+- `requested_inference_profile_id`
+
+Resolved authoritative inference target:
+- `resolved_model_id`
+- `resolved_inference_profile_id`
+
+Usage fields:
+- `estimated_input_tokens`
+- `estimated_output_tokens`
+- `authoritative_input_tokens`
+- `authoritative_output_tokens`
+- `usage_quality`
+
+Downstream gateway provenance when applicable:
+- `metering_source`
+- `gateway_account_id`
+- `gateway_region`
+
+Field semantics:
+- `requested_*` reflects what the control plane or caller intended
+- `resolved_*` reflects what actually executed and is authoritative for
+  chargeback when present
+- `usage_quality` must be one of `authoritative`, `estimated`, or `unknown`
+- `metering_source` must identify the authoritative meter, such as
+  `a5c-cell` or a named downstream gateway
+
+## Usage Quality Model
+The platform distinguishes between estimated and authoritative usage:
+- `estimatedUsage` is provisional and may be used for admission control,
+  internal quotas, or early UX
+- `authoritativeUsage` is final and used for chargeback and billing
+
+Estimated and authoritative usage must not overwrite each other.
+
+If no authoritative usage is available, any fallback billing based on estimated
+usage must:
+- be explicitly marked degraded
+- set `usageQuality = estimated`
+- be treated as an exception path, not the steady state
+
+## Tenant Instantiation Tagging Strategy
+Mandatory tags must be applied as part of tenant instantiation for tenant-owned
+or tenant-dedicated resources.
+
+The mandatory base tag set is:
+- `tenantid`
+- `appid`
+- `platform:environment`
+- `platform:chargeback-scope`
+- `platform:managed-by`
+
+Required semantics:
+- `tenantid`: canonical tenant identifier
+- `appid`: canonical application identifier for the tenant-facing workload
+- `platform:environment`: `dev`, `staging`, or `prod`
+- `platform:chargeback-scope`: one of `tenant-dedicated`, `tenant-shared`,
+  `platform-shared`
+- `platform:managed-by`: control-plane provisioning system identifier
+
+Recommended extension tags where supported:
+- `platform:tier`
+- `platform:owner-team`
+- `platform:service`
+- `platform:cost-center`
+
+Mandatory-tag availability rules:
+- tenant instantiation must not silently create tenant-dedicated infrastructure
+  without the mandatory base tag set
+- if `tenantid` is unavailable, provisioning fails
+- if `appid` is unavailable for a tenant-dedicated create path, provisioning
+  fails rather than inventing a placeholder
+- shared platform resources that cannot truthfully carry a tenant/app tag must
+  not be provisioned through a tenant-dedicated path; they must use an approved
+  shared-resource path and `platform:chargeback-scope` value
+
+## Tagging Rules
+1. Tenant-instantiated stacks must apply the mandatory base tag set at create
+   time.
+2. Updates must preserve the mandatory tag set; missing mandatory chargeback
+   tags are configuration drift.
+3. Shared platform resources that cannot truthfully carry a single tenant tag
+   must use `platform:chargeback-scope = platform-shared` or
+   `tenant-shared` and rely on runtime ledgers for allocation.
+4. Agent names must not be used as AWS infrastructure tags for every resource by
+   default because many shared resources serve multiple agents; agent-level
+   chargeback belongs primarily in the invocation ledger.
+
+`platform:chargeback-scope` truth table:
+- `tenant-dedicated`: resource is instantiated for exactly one tenant and may
+  carry `tenantid` and `appid`
+- `tenant-shared`: resource serves multiple tenants within a bounded service or
+  account boundary and must not be allocated by tag alone
+- `platform-shared`: resource is global/shared control-plane infrastructure and
+  must not pretend to be tenant-owned for finance purposes
+
+## Inference Metering Policy
+### Phase 1: Current default in `a5c-cell`
+- `a5c-cell` meters inference directly when it receives the authoritative model
+  response
+- invocation records must persist:
+  - requested and resolved `modelId` or `inferenceProfileId` when applicable
+  - authoritative input/output token counts
+  - optional estimated usage kept separately if used
+
+### Phase 2: Optional downstream gateway later
+- the downstream gateway may become the authoritative inference meter
+- `a5c-cell` remains the canonical billing-record owner
+- the gateway must return or emit a metering envelope linked by `invocationId`
+- the control plane persists the authoritative downstream usage on the
+  invocation record
+
+## Joined-Ledger Preparation
+The design must be ready now for later downstream inference without requiring a
+billing-model rewrite.
+
+If a downstream gateway is introduced, the metering envelope should include:
+- `invocationId`
+- `tenantId`
+- `appId`
+- `agentName`
+- `agentVersion` when available
+- `modelId` or `inferenceProfileId`
+- `authoritativeInputTokens`
+- `authoritativeOutputTokens`
+- `gatewayAccountId`
+- `gatewayRegion`
+
+This later gateway mode is additive and phased. It does not change the default
+current position that `a5c-cell` performs direct inference and direct metering.
+
+## Billing Semantics
+The current tenant billing pipeline remains tenant-tier priced unless and until a
+successor ADR explicitly approves model-sensitive or profile-sensitive billing.
+
+That means:
+- tenant invoices and budget enforcement may continue to use the current tier
+  pricing path
+- persisted `resolved_model_id` and `resolved_inference_profile_id` are still
+  mandatory for attribution, optimization, audit, and future pricing evolution
+- model/profile dimensions must not be omitted merely because current billing is
+  still tier-priced
+
+## Consequences
+- The current platform can continue using the existing invocation-ledger billing
+  path without waiting for a downstream gateway.
+- Tenant instantiation gets a declared, finance-usable chargeback tag baseline.
+- Agent-level chargeback is represented in runtime ledgers rather than forced
+  onto inappropriate shared-resource tags.
+- The platform is prepared for future downstream inference without changing the
+  canonical billing record owner.
+- Billing, audit, and AWS-native cost allocation each have a clear source of
+  truth for the concerns they are actually good at answering.
+
+## Implementation Notes
+- Update tenant instantiation so the mandatory base tag set is provided on all
+  create paths and preserved on update paths.
+- Extend invocation records and billing transforms to persist the canonical
+  chargeback field contract defined above.
+- Keep estimated usage fields separate from authoritative usage fields.
+- Where direct inference remains in `a5c-cell`, copy the authoritative metering
+  pattern from the Bedrock-facing component that receives the model response
+  rather than relying only on static estimates.
+- Treat missing mandatory chargeback tags on tenant-dedicated resources as
+  configuration drift that must be corrected rather than normalized away.
+
+## Alternatives Rejected
+- **Tags only for all chargeback**: insufficient for shared runtime paths and
+  cannot represent per-agent or per-invocation inference allocation.
+- **Invocation ledger only with no mandatory resource tags**: weak for AWS-native
+  cost allocation, CUR analysis, and infrastructure showback.
+- **Make downstream gateways the sole billing system of record**: breaks the
+  existing control-plane audit and tenant-attribution boundary.
+- **Delay the design until downstream inference exists**: creates avoidable
+  migration friction and leaves current tenant instantiation under-specified.

--- a/docs/decisions/ADR-702-bedrock-proxy-gateway-as-additive-internal-model-gateway.md
+++ b/docs/decisions/ADR-702-bedrock-proxy-gateway-as-additive-internal-model-gateway.md
@@ -1,0 +1,185 @@
+# ADR-702: Bedrock Proxy Gateway as an Additive Internal Model Gateway
+
+## Status: Proposed
+## Date: 2026-04-03
+
+## Context
+The platform already has a defined tenant-aware northbound invocation path:
+- CloudFront and REST API Gateway form the public ingress boundary
+- Authoriser Lambda establishes tenant identity and policy context
+- Bridge Lambda assumes tenant execution roles and invokes AgentCore Runtime
+- AgentCore Runtime is the canonical execution surface for published agents
+
+This control-plane contract is intentionally different from direct foundation
+model access.
+
+Separately, a Bedrock proxy gateway can provide direct `bedrock-runtime`
+capabilities such as:
+- direct foundation-model invocation
+- model and inference-profile abstraction
+- Bedrock guardrail attachment
+- Bedrock-specific quota and rate controls
+- cross-account Bedrock routing
+
+Those concerns are useful, but they do not belong on the public northbound
+tenant API by default.
+
+If the platform integrates a Bedrock proxy gateway without an explicit boundary,
+it risks:
+- weakening the existing tenant-aware public API contract
+- introducing a second public invoke surface that bypasses platform policy and
+  audit controls
+- coupling AgentCore runtime orchestration to direct Bedrock model-routing
+  concerns
+- confusing agent execution with direct model invocation
+
+The current platform architecture also has a near-term default:
+- direct inference and metering remain in the platform control-plane / platform
+  account path by default
+- a downstream model gateway is a later additive option, not the starting point
+
+## Decision
+The platform will treat any Bedrock proxy gateway as an additive internal model
+gateway, not as a replacement for the public AgentCore invoke path.
+
+The integration model is:
+
+1. **Keep the current public invoke path**
+   - `tf-acore-aas` remains the only tenant-facing and operator-facing public API
+     for agent invocation
+   - the `Bridge Lambda -> AgentCore Runtime` path remains the canonical path
+     for published agent execution
+
+2. **Use the Bedrock proxy gateway only as an internal downstream service**
+   - the gateway is private platform infrastructure
+   - it may be called only by approved internal services, platform-owned agents,
+     or explicitly approved tool and agent execution paths that need direct
+     foundation-model access
+
+3. **Do not redefine the public contract around direct model invocation**
+   - public clients do not call the model gateway directly
+   - direct model invocation remains an internal implementation concern unless a
+     future ADR explicitly approves a new public API surface
+   - the gateway must not become a generic tenant invoke router or a hidden
+     alternate path for published-agent invocation semantics
+
+4. **Preserve the current default**
+   - while inference remains in the platform control-plane / platform account
+     path, the control plane remains both the attribution owner and the
+     authoritative inference meter
+   - introducing a downstream gateway later is a phased evolution, not an
+     immediate architectural inversion
+
+5. **Prepare for later additive integration**
+   - if a downstream Bedrock proxy gateway is introduced later, it may become an
+     authoritative inference meter for the calls it executes directly
+   - the control plane remains the canonical billing-record owner under ADR-701
+   - any downstream gateway integration must preserve the joined-ledger and
+     tenant-attribution rules from ADR-701
+
+## Boundary Rules
+### Public API Boundary
+- The public tenant-facing API remains the REST control plane.
+- Agent invocation stays anchored to the existing auth, RBAC, audit, and Bridge
+  semantics.
+- A Bedrock proxy gateway must not be exposed as a second general-purpose
+  tenant-facing invoke endpoint by default.
+
+### Internal Service Boundary
+- A Bedrock proxy gateway is an internal platform service for model-access
+  concerns.
+- It is not a second generic invocation plane for tenant API clients.
+- It may be used where direct foundation-model APIs are the correct abstraction,
+  for example:
+  - internal tools
+  - explicitly approved agent sub-steps that require direct model access
+  - future inference-profile-backed routing
+  - Bedrock guardrail-enforced calls
+
+Allowed-caller rule:
+- any non-platform use of the gateway from tenant-invoked agent execution must
+  be an explicit approved capability, not an implicit right of all agents
+- Bridge-mediated published-agent execution remains the canonical invoke path;
+  use of a gateway inside agent execution is an internal implementation detail,
+  not a new public contract
+
+### Tenant and Audit Boundary
+- Tenant identity, app identity, and agent attribution remain owned by the
+  control plane.
+- Any call into a downstream model gateway must carry trusted platform-derived
+  attribution context rather than arbitrary client-supplied identity.
+- This preserves the invariants of ADR-016: `tenantid` and `appid` remain
+  visible in logs, metrics, traces, and auditable metering flows.
+
+Minimum downstream contract:
+- any downstream gateway integration must return or emit the ADR-701 canonical
+  chargeback fields required for authoritative metering when it acts as the
+  direct inference meter
+- at minimum this includes:
+  - `invocation_id`
+  - `resolved_model_id`
+  - `resolved_inference_profile_id`
+  - `authoritative_input_tokens`
+  - `authoritative_output_tokens`
+  - `usage_quality`
+  - `metering_source`
+
+## Configuration Ownership
+- `tf-acore-aas` owns:
+  - public API contracts
+  - tenant identity and authorization
+  - agent registry and invocation policy
+  - execution-role assumption
+  - billing-record ownership and chargeback attribution
+- the internal Bedrock proxy gateway owns, when present:
+  - direct Bedrock Runtime request forwarding
+  - model and inference-profile abstraction
+  - Bedrock-specific quota controls
+  - Bedrock guardrail attachment
+  - authoritative metering for the direct model calls it executes
+
+## Consequences
+### Positive
+- The current public invoke contract remains stable.
+- The platform can add direct foundation-model access without collapsing
+  AgentCore and Bedrock Runtime into one public surface.
+- Bedrock-specific capabilities such as inference profiles and guardrail routing
+  get a clear home if they are introduced later.
+- Chargeback and attribution boundaries stay consistent with ADR-701.
+
+### Negative
+- Additional integration work is required if a downstream gateway is introduced:
+  - private networking
+  - service authentication
+  - trusted attribution propagation
+  - metering-envelope reconciliation
+- Some model-facing functionality remains intentionally unavailable directly to
+  public clients unless a later ADR approves it.
+
+## Implementation Notes
+- Default posture: no downstream gateway required for the current platform
+  baseline.
+- If introduced later, the target posture is private ingress and private DNS or
+  equivalent service-to-service connectivity.
+- Early adoption must not assume that all runtime and networking prerequisites
+  for a fully private path already exist in the current topology; any exception
+  must be explicit and documented rather than assumed away.
+- Gateway endpoint configuration and secrets must live in approved platform
+  config surfaces rather than application code constants.
+- Any later gateway integration must persist requested and resolved model/profile
+  dimensions on the invocation record in line with ADR-701.
+- The gateway must not become an undocumented second northbound boundary.
+
+## Alternatives Rejected
+- **Replace the public AgentCore invoke path with a Bedrock proxy gateway**:
+  breaks the current platform contract and conflates agent execution with direct
+  model access.
+- **Expose the Bedrock proxy gateway directly to tenants as a second public API**:
+  introduces a second policy boundary and risks bypassing control-plane audit and
+  authorization semantics.
+- **Fold all Bedrock model-routing concerns directly into Bridge Lambda**:
+  increases coupling between public invocation orchestration and direct
+  model-access concerns.
+- **Ignore direct model access as a future concern**: leaves no explicit place
+  for inference profiles, Bedrock guardrails, or direct model-routing concerns if
+  they are later needed.

--- a/docs/development/CODEX-FLOW.md
+++ b/docs/development/CODEX-FLOW.md
@@ -1,0 +1,67 @@
+# Codex Flow
+
+`codex_flow` is a separate local kanban for agent work. It does not read GitHub
+issue labels, does not use the repository issue queue, and does not try to be
+the canonical workflow. It is just a lightweight local board for planning and
+tracking work while you keep using Codex or Gemini.
+
+Local state lives entirely under `.codex-flow/`.
+
+## What it is for
+
+- keeping a small local backlog
+- moving cards between `backlog`, `next`, `doing`, `blocked`, and `done`
+- assigning a card to `codex`, `gemini`, or `manual`
+- attaching optional metadata like `issue`, `worktree_path`, and `branch`
+- keeping short per-card notes
+
+## What it is not
+
+- not the GitHub issue queue
+- not label-driven
+- not tied to `ready` or `status:*`
+- not a replacement for the canonical repo lifecycle
+
+## Commands
+
+```bash
+uv run python -m scripts.codex_flow init
+uv run python -m scripts.codex_flow add "stabilize bridge auth split" --lane next
+uv run python -m scripts.codex_flow assign 1 --owner codex --role implement
+uv run python -m scripts.codex_flow move 1 --lane doing
+uv run python -m scripts.codex_flow attach 1 --issue 388 --path ../worktrees/wt388
+uv run python -m scripts.codex_flow note 1
+uv run python -m scripts.codex_flow import-github --state open --lane backlog
+uv run python -m scripts.codex_flow board
+```
+
+## GitHub migration
+
+If you already have GitHub issues and want them in the local board:
+
+```bash
+uv run python -m scripts.codex_flow init
+uv run python -m scripts.codex_flow import-github --state open --lane backlog
+```
+
+That imports issue numbers and titles as cards. It does not make the board
+dependent on labels or the issue queue after import.
+
+## Suggested usage
+
+Use it as a separate planning surface:
+
+- add cards for what you actually want to do
+- move one or two cards into `doing`
+- assign one owner per card
+- attach issue/worktree metadata only when useful
+
+Recommended split:
+
+- `codex` + `implement`
+- `gemini` + `review`
+- `gemini` + `plan`
+- `manual` for work you do yourself
+
+The point is to give you a local kanban without forcing the GitHub issue system
+to act like one.

--- a/scripts/codex_flow/__init__.py
+++ b/scripts/codex_flow/__init__.py
@@ -1,0 +1,6 @@
+"""Standalone Codex-first workflow helpers.
+
+This namespace intentionally sits beside the main issue-tool workflow rather than
+changing it. The wrapper provides a thinner operator surface for starting,
+tracking, and finishing worktree sessions with optional owner assignment.
+"""

--- a/scripts/codex_flow/__main__.py
+++ b/scripts/codex_flow/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_flow/cli.py
+++ b/scripts/codex_flow/cli.py
@@ -1,0 +1,485 @@
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+LOCAL_STATE_DIR = Path(".codex-flow")
+BOARD_FILE = LOCAL_STATE_DIR / "board.json"
+NOTES_DIR = LOCAL_STATE_DIR / "notes"
+DEFAULT_LANES = ["backlog", "next", "doing", "blocked", "done"]
+DEFAULT_OWNERS = ("codex", "gemini", "manual")
+DEFAULT_ROLES = ("implement", "review", "plan")
+DEFAULT_IMPORT_LIMIT = 200
+
+
+@dataclass(slots=True)
+class Card:
+    id: int
+    title: str
+    lane: str
+    owner: str | None
+    role: str | None
+    issue: int | None
+    worktree_path: str | None
+    branch: str | None
+    note: str
+    updated_at: str
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(result.stdout.strip()).resolve()
+
+
+def iso_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def load_json_file(path: Path, *, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json_file(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def default_board() -> dict[str, Any]:
+    return {
+        "lanes": list(DEFAULT_LANES),
+        "cards": [],
+        "next_id": 1,
+        "updated_at": iso_now(),
+    }
+
+
+def load_board(root: Path) -> dict[str, Any]:
+    board = load_json_file(root / BOARD_FILE, default=default_board())
+    if not isinstance(board, dict):
+        return default_board()
+    lanes = board.get("lanes")
+    cards = board.get("cards")
+    next_id = board.get("next_id")
+    if not isinstance(lanes, list) or not isinstance(cards, list) or not isinstance(next_id, int):
+        return default_board()
+    return board
+
+
+def save_board(root: Path, board: dict[str, Any]) -> None:
+    board["updated_at"] = iso_now()
+    save_json_file(root / BOARD_FILE, board)
+
+
+def normalize_card(payload: dict[str, Any]) -> Card:
+    return Card(
+        id=int(payload["id"]),
+        title=str(payload.get("title") or ""),
+        lane=str(payload.get("lane") or "backlog"),
+        owner=str(payload["owner"]) if payload.get("owner") is not None else None,
+        role=str(payload["role"]) if payload.get("role") is not None else None,
+        issue=int(payload["issue"]) if payload.get("issue") is not None else None,
+        worktree_path=(
+            str(payload["worktree_path"]) if payload.get("worktree_path") is not None else None
+        ),
+        branch=str(payload["branch"]) if payload.get("branch") is not None else None,
+        note=str(payload.get("note") or ""),
+        updated_at=str(payload.get("updated_at") or ""),
+    )
+
+
+def card_to_payload(card: Card) -> dict[str, Any]:
+    return {
+        "id": card.id,
+        "title": card.title,
+        "lane": card.lane,
+        "owner": card.owner,
+        "role": card.role,
+        "issue": card.issue,
+        "worktree_path": card.worktree_path,
+        "branch": card.branch,
+        "note": card.note,
+        "updated_at": card.updated_at,
+    }
+
+
+def board_cards(board: dict[str, Any]) -> list[Card]:
+    return [normalize_card(card) for card in board.get("cards", []) if isinstance(card, dict)]
+
+
+def ensure_lane(board: dict[str, Any], lane: str) -> None:
+    lanes = board.get("lanes", [])
+    if lane not in lanes:
+        raise SystemExit(f"Unknown lane '{lane}'. Valid lanes: {', '.join(lanes)}")
+
+
+def find_card(board: dict[str, Any], card_id: int) -> tuple[int, Card]:
+    for idx, payload in enumerate(board.get("cards", [])):
+        if isinstance(payload, dict) and int(payload.get("id", -1)) == card_id:
+            return idx, normalize_card(payload)
+    raise SystemExit(f"Card {card_id} was not found.")
+
+
+def next_card_id(board: dict[str, Any]) -> int:
+    current = int(board.get("next_id", 1))
+    board["next_id"] = current + 1
+    return current
+
+
+def append_card(board: dict[str, Any], card: Card) -> None:
+    board.setdefault("cards", []).append(card_to_payload(card))
+
+
+def replace_card(board: dict[str, Any], index: int, card: Card) -> None:
+    board["cards"][index] = card_to_payload(card)
+
+
+def notes_path(root: Path, card_id: int) -> Path:
+    return root / NOTES_DIR / f"card-{card_id}.md"
+
+
+def detect_git_context(path: Path) -> tuple[str | None, str | None]:
+    try:
+        root_result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return None, None
+    worktree_path = Path(root_result.stdout.strip()).resolve()
+    branch = branch_result.stdout.strip()
+    return str(worktree_path), branch
+
+
+def github_repo_slug(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    raw = result.stdout.strip()
+    if raw.endswith(".git"):
+        raw = raw[:-4]
+    if raw.startswith("git@github.com:"):
+        return raw.split(":", 1)[1]
+    if "github.com/" in raw:
+        return raw.split("github.com/", 1)[1]
+    raise SystemExit(f"Could not derive GitHub repo slug from origin URL: {raw}")
+
+
+def fetch_github_issues(root: Path, *, state: str, limit: int) -> list[dict[str, Any]]:
+    repo = github_repo_slug(root)
+    command = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        state,
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,state,labels",
+    ]
+    result = subprocess.run(command, cwd=root, check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, list):
+        raise SystemExit("Unexpected gh issue list payload.")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def import_github_issues(
+    board: dict[str, Any],
+    issues: list[dict[str, Any]],
+    *,
+    lane: str,
+) -> int:
+    ensure_lane(board, lane)
+    existing_issue_numbers = {
+        card.issue for card in board_cards(board) if card.issue is not None
+    }
+    added = 0
+    for issue in issues:
+        issue_number = issue.get("number")
+        title = issue.get("title")
+        if not isinstance(issue_number, int) or not isinstance(title, str):
+            continue
+        if issue_number in existing_issue_numbers:
+            continue
+        card = Card(
+            id=next_card_id(board),
+            title=title,
+            lane=lane,
+            owner=None,
+            role=None,
+            issue=issue_number,
+            worktree_path=None,
+            branch=None,
+            note="imported from GitHub issue",
+            updated_at=iso_now(),
+        )
+        append_card(board, card)
+        existing_issue_numbers.add(issue_number)
+        added += 1
+    return added
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    root = repo_root()
+    board_path = root / BOARD_FILE
+    if board_path.exists() and not args.force:
+        raise SystemExit(f"{board_path} already exists. Use --force to overwrite it.")
+    save_board(root, default_board())
+    print(board_path)
+    return 0
+
+
+def cmd_board(_args: argparse.Namespace) -> int:
+    root = repo_root()
+    board = load_board(root)
+    cards = board_cards(board)
+    if not cards:
+        print("Kanban board is empty.")
+        return 0
+
+    print("Codex Flow Kanban")
+    for lane in board.get("lanes", DEFAULT_LANES):
+        lane_cards = [card for card in cards if card.lane == lane]
+        print(f"\n[{lane}]")
+        if not lane_cards:
+            print("  -")
+            continue
+        for card in lane_cards:
+            owner = card.owner or "-"
+            role = card.role or "-"
+            issue = f" issue=#{card.issue}" if card.issue is not None else ""
+            print(f"  {card.id}. {card.title} owner={owner} role={role}{issue}")
+            if card.worktree_path:
+                print(f"     wt={card.worktree_path}")
+            if card.note:
+                print(f"     note={card.note}")
+    return 0
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    root = repo_root()
+    board = load_board(root)
+    ensure_lane(board, args.lane)
+    card = Card(
+        id=next_card_id(board),
+        title=args.title,
+        lane=args.lane,
+        owner=args.owner,
+        role=args.role,
+        issue=args.issue,
+        worktree_path=args.worktree,
+        branch=args.branch,
+        note=args.note or "",
+        updated_at=iso_now(),
+    )
+    append_card(board, card)
+    save_board(root, board)
+    print(card.id)
+    return 0
+
+
+def cmd_move(args: argparse.Namespace) -> int:
+    root = repo_root()
+    board = load_board(root)
+    ensure_lane(board, args.lane)
+    index, card = find_card(board, args.card)
+    updated = Card(
+        id=card.id,
+        title=card.title,
+        lane=args.lane,
+        owner=card.owner,
+        role=card.role,
+        issue=card.issue,
+        worktree_path=card.worktree_path,
+        branch=card.branch,
+        note=args.note if args.note is not None else card.note,
+        updated_at=iso_now(),
+    )
+    replace_card(board, index, updated)
+    save_board(root, board)
+    return 0
+
+
+def cmd_assign(args: argparse.Namespace) -> int:
+    root = repo_root()
+    board = load_board(root)
+    index, card = find_card(board, args.card)
+    updated = Card(
+        id=card.id,
+        title=card.title,
+        lane=card.lane,
+        owner=args.owner,
+        role=args.role,
+        issue=card.issue,
+        worktree_path=card.worktree_path,
+        branch=card.branch,
+        note=args.note if args.note is not None else card.note,
+        updated_at=iso_now(),
+    )
+    replace_card(board, index, updated)
+    save_board(root, board)
+    return 0
+
+
+def cmd_attach(args: argparse.Namespace) -> int:
+    root = repo_root()
+    board = load_board(root)
+    index, card = find_card(board, args.card)
+
+    worktree_path = args.path
+    branch = args.branch
+    if worktree_path is None or branch is None:
+        detected_path, detected_branch = detect_git_context(Path.cwd())
+        if worktree_path is None:
+            worktree_path = detected_path
+        if branch is None:
+            branch = detected_branch
+
+    updated = Card(
+        id=card.id,
+        title=card.title,
+        lane=card.lane,
+        owner=card.owner,
+        role=card.role,
+        issue=args.issue if args.issue is not None else card.issue,
+        worktree_path=worktree_path,
+        branch=branch,
+        note=args.note if args.note is not None else card.note,
+        updated_at=iso_now(),
+    )
+    replace_card(board, index, updated)
+    save_board(root, board)
+    return 0
+
+
+def cmd_note(args: argparse.Namespace) -> int:
+    root = repo_root()
+    board = load_board(root)
+    _index, card = find_card(board, args.card)
+    path = notes_path(root, card.id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(
+            (
+                f"# Card {card.id}: {card.title}\n\n"
+                f"Lane: {card.lane}\n"
+                f"Owner: {card.owner or '-'}\n"
+                f"Role: {card.role or '-'}\n"
+                f"Issue: {card.issue or '-'}\n"
+                f"Worktree: {card.worktree_path or '-'}\n\n"
+                "## Context\n\n"
+                "## Next step\n\n"
+                "## Handoff\n"
+            ),
+            encoding="utf-8",
+        )
+    print(path)
+    return 0
+
+
+def cmd_import_github(args: argparse.Namespace) -> int:
+    root = repo_root()
+    board = load_board(root)
+    issues = fetch_github_issues(root, state=args.state, limit=args.limit)
+    added = import_github_issues(board, issues, lane=args.lane)
+    save_board(root, board)
+    print(f"Imported {added} issues into lane '{args.lane}'.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.codex_flow",
+        description="Separate local kanban for Codex/Gemini work without issue-label coupling.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init = subparsers.add_parser("init", help="Create a fresh local kanban board.")
+    init.add_argument("--force", action="store_true")
+    init.set_defaults(func=cmd_init)
+
+    board = subparsers.add_parser("board", help="Print the local kanban board.")
+    board.set_defaults(func=cmd_board)
+
+    add = subparsers.add_parser("add", help="Add a new card to the local board.")
+    add.add_argument("title")
+    add.add_argument("--lane", default="backlog")
+    add.add_argument("--owner", choices=DEFAULT_OWNERS)
+    add.add_argument("--role", choices=DEFAULT_ROLES)
+    add.add_argument("--issue", type=int)
+    add.add_argument("--worktree")
+    add.add_argument("--branch")
+    add.add_argument("--note")
+    add.set_defaults(func=cmd_add)
+
+    move = subparsers.add_parser("move", help="Move a card to another lane.")
+    move.add_argument("card", type=int)
+    move.add_argument("--lane", required=True)
+    move.add_argument("--note")
+    move.set_defaults(func=cmd_move)
+
+    assign = subparsers.add_parser("assign", help="Assign a card owner and role.")
+    assign.add_argument("card", type=int)
+    assign.add_argument("--owner", required=True, choices=DEFAULT_OWNERS)
+    assign.add_argument("--role", required=True, choices=DEFAULT_ROLES)
+    assign.add_argument("--note")
+    assign.set_defaults(func=cmd_assign)
+
+    attach = subparsers.add_parser(
+        "attach",
+        help="Attach optional issue/worktree metadata to a card.",
+    )
+    attach.add_argument("card", type=int)
+    attach.add_argument("--issue", type=int)
+    attach.add_argument("--path")
+    attach.add_argument("--branch")
+    attach.add_argument("--note")
+    attach.set_defaults(func=cmd_attach)
+
+    note = subparsers.add_parser("note", help="Create or print a per-card note file.")
+    note.add_argument("card", type=int)
+    note.set_defaults(func=cmd_note)
+
+    import_github = subparsers.add_parser(
+        "import-github",
+        help="Import GitHub issues into the local board as cards.",
+    )
+    import_github.add_argument("--state", default="open", choices=("open", "closed", "all"))
+    import_github.add_argument("--limit", type=int, default=DEFAULT_IMPORT_LIMIT)
+    import_github.add_argument("--lane", default="backlog")
+    import_github.set_defaults(func=cmd_import_github)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))

--- a/scripts/codex_flow/cli.py
+++ b/scripts/codex_flow/cli.py
@@ -217,9 +217,7 @@ def import_github_issues(
     lane: str,
 ) -> int:
     ensure_lane(board, lane)
-    existing_issue_numbers = {
-        card.issue for card in board_cards(board) if card.issue is not None
-    }
+    existing_issue_numbers = {card.issue for card in board_cards(board) if card.issue is not None}
     added = 0
     for issue in issues:
         issue_number = issue.get("number")

--- a/tests/unit/test_codex_flow.py
+++ b/tests/unit/test_codex_flow.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_codex_flow_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "codex_flow_cli", repo_root / "scripts" / "codex_flow" / "cli.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+codex_flow = _load_codex_flow_module()
+
+
+def test_default_board_has_expected_lanes():
+    board = codex_flow.default_board()
+
+    assert board["lanes"] == ["backlog", "next", "doing", "blocked", "done"]
+    assert board["cards"] == []
+    assert board["next_id"] == 1
+
+
+def test_append_card_persists_roundtrip(tmp_path):
+    root = tmp_path
+    board = codex_flow.default_board()
+    card = codex_flow.Card(
+        id=codex_flow.next_card_id(board),
+        title="split bridge auth",
+        lane="next",
+        owner="codex",
+        role="implement",
+        issue=388,
+        worktree_path=None,
+        branch=None,
+        note="",
+        updated_at=codex_flow.iso_now(),
+    )
+
+    codex_flow.append_card(board, card)
+    codex_flow.save_board(root, board)
+    loaded = codex_flow.load_board(root)
+    cards = codex_flow.board_cards(loaded)
+
+    assert len(cards) == 1
+    assert cards[0].title == "split bridge auth"
+    assert cards[0].lane == "next"
+
+
+def test_find_and_replace_card_updates_lane(tmp_path):
+    root = tmp_path
+    board = codex_flow.default_board()
+    card = codex_flow.Card(
+        id=1,
+        title="review authoriser",
+        lane="backlog",
+        owner=None,
+        role=None,
+        issue=None,
+        worktree_path=None,
+        branch=None,
+        note="",
+        updated_at=codex_flow.iso_now(),
+    )
+    codex_flow.append_card(board, card)
+
+    index, existing = codex_flow.find_card(board, 1)
+    updated = codex_flow.Card(
+        id=existing.id,
+        title=existing.title,
+        lane="doing",
+        owner="gemini",
+        role="review",
+        issue=existing.issue,
+        worktree_path=existing.worktree_path,
+        branch=existing.branch,
+        note="active",
+        updated_at=codex_flow.iso_now(),
+    )
+    codex_flow.replace_card(board, index, updated)
+    codex_flow.save_board(root, board)
+
+    loaded_card = codex_flow.board_cards(codex_flow.load_board(root))[0]
+    assert loaded_card.lane == "doing"
+    assert loaded_card.owner == "gemini"
+    assert loaded_card.role == "review"
+
+
+def test_notes_path_is_scoped_under_local_state(tmp_path):
+    root = tmp_path
+    path = codex_flow.notes_path(root, 7)
+
+    assert path == root / ".codex-flow" / "notes" / "card-7.md"
+
+
+def test_import_github_issues_adds_only_missing_issue_cards():
+    board = codex_flow.default_board()
+    codex_flow.append_card(
+        board,
+        codex_flow.Card(
+            id=1,
+            title="existing",
+            lane="backlog",
+            owner=None,
+            role=None,
+            issue=388,
+            worktree_path=None,
+            branch=None,
+            note="",
+            updated_at=codex_flow.iso_now(),
+        ),
+    )
+
+    added = codex_flow.import_github_issues(
+        board,
+        [
+            {"number": 388, "title": "existing"},
+            {"number": 389, "title": "new issue"},
+        ],
+        lane="backlog",
+    )
+
+    cards = codex_flow.board_cards(board)
+    assert added == 1
+    assert [card.issue for card in cards] == [388, 389]


### PR DESCRIPTION
## Summary
- add a separate local `codex_flow` kanban CLI and tests without touching the canonical issue workflow
- document the local board workflow in `docs/development/CODEX-FLOW.md`
- add ADR-701 and ADR-702 drafts for chargeback and Bedrock proxy gateway positioning
- ignore local `.codex` and `.codex-flow/` artifacts in the repo root

## Validation
- uv run ruff check scripts/codex_flow tests/unit/test_codex_flow.py
- uv run pytest tests/unit/test_codex_flow.py -q
- pre-push validation via `git push`

## Notes
- this is intentionally a draft because the `codex_flow` work is a local workflow layer, not yet wired into the repo's canonical issue lifecycle