### PR TITLE
fix: attach platform lambdas to trusted endpoint sg

### DIFF
--- a/infra/cdk/bin/app.ts
+++ b/infra/cdk/bin/app.ts
@@ -71,6 +71,7 @@ const platformStack = new PlatformStack(app, `platform-core-${env}`, {
   env: awsEnv,
   description: `Platform core services — ${env}`,
   vpc: networkStack.vpc,
+  lambdaSecurityGroup: networkStack.lambdaSecurityGroup,
 });
 
 // 4. TenantStack (real deployments triggered by EventBridge per-tenant)

--- a/infra/cdk/lib/network-stack.ts
+++ b/infra/cdk/lib/network-stack.ts
@@ -17,6 +17,7 @@ export interface NetworkStackProps extends cdk.StackProps {
 
 export class NetworkStack extends cdk.Stack {
   public readonly vpc: ec2.Vpc;
+  public readonly lambdaSecurityGroup: ec2.SecurityGroup;
 
   constructor(scope: Construct, id: string, props?: NetworkStackProps) {
     super(scope, id, props);
@@ -50,6 +51,7 @@ export class NetworkStack extends cdk.Stack {
       allowAllOutbound: false,
       description: 'Security group for platform Lambdas running in private subnets',
     });
+    this.lambdaSecurityGroup = lambdaSecurityGroup;
 
     const endpointSecurityGroup = new ec2.SecurityGroup(this, 'InterfaceEndpointSecurityGroup', {
       vpc: this.vpc,

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -64,6 +64,7 @@ type GatewayPolicyConfiguration = {
 
 export interface PlatformStackProps extends cdk.StackProps {
   readonly vpc: ec2.IVpc;
+  readonly lambdaSecurityGroup: ec2.ISecurityGroup;
 }
 
 function ensureTenantStubTemplate(
@@ -106,6 +107,7 @@ function ensureTenantStubTemplate(
 
 export class PlatformStack extends cdk.Stack {
   public readonly vpc: ec2.IVpc;
+  public readonly lambdaSecurityGroup: ec2.ISecurityGroup;
   public readonly api: apigateway.RestApi;
   public readonly tenantsTable: dynamodb.Table;
   public readonly agentsTable: dynamodb.Table;
@@ -136,6 +138,7 @@ export class PlatformStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: PlatformStackProps) {
     super(scope, id, props);
     this.vpc = props.vpc;
+    this.lambdaSecurityGroup = props.lambdaSecurityGroup;
 
     const env = ((this.node.tryGetContext('env') as string | undefined) ?? 'dev').toLowerCase();
     const bridgeCanaryPolicy = this.resolveBridgeCanaryPolicy(env);
@@ -1085,6 +1088,7 @@ export class PlatformStack extends cdk.Stack {
       memorySize: props.memorySize,
       vpc: this.vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      securityGroups: [this.lambdaSecurityGroup],
       environment: {
         LOG_LEVEL: 'INFO',
         ...props.environment,

--- a/infra/cdk/test/observability-stack.test.ts
+++ b/infra/cdk/test/observability-stack.test.ts
@@ -33,10 +33,15 @@ describe('ObservabilityStack (TASK-026)', () => {
         },
       ],
     });
+    const lambdaSecurityGroup = new ec2.SecurityGroup(networkStack, 'MockLambdaSecurityGroup', {
+      vpc: mockVpc,
+      description: 'Trusted SG for platform Lambdas',
+    });
 
     const platformStack = new PlatformStack(app, 'PlatformStack', {
       env,
       vpc: mockVpc,
+      lambdaSecurityGroup,
     });
 
     const observabilityStack = new ObservabilityStack(app, 'ObservabilityStack', {

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -30,10 +30,15 @@ describe('PlatformStack (TASK-023)', () => {
         },
       ],
     });
+    const lambdaSecurityGroup = new ec2.SecurityGroup(networkStack, 'MockLambdaSecurityGroup', {
+      vpc: mockVpc,
+      description: 'Trusted SG for platform Lambdas',
+    });
 
     const stack = new PlatformStack(app, `platform-core-${environment}`, {
       env,
       vpc: mockVpc,
+      lambdaSecurityGroup,
     });
     return Template.fromStack(stack);
   };
@@ -135,6 +140,30 @@ describe('PlatformStack (TASK-023)', () => {
         }),
       ]),
     );
+  });
+
+  test('attaches VPC Lambdas to the endpoint-trusted Lambda security group', () => {
+    const template = synthTemplate('dev');
+
+    const lambdaFunctions = template.findResources('AWS::Lambda::Function') as Record<
+      string,
+      {
+        Properties?: {
+          FunctionName?: string;
+          VpcConfig?: { SecurityGroupIds?: unknown[] };
+        };
+      }
+    >;
+
+    const securityGroupIdTokens = new Set<string>();
+
+    for (const resource of Object.values(lambdaFunctions)) {
+      const securityGroupIds = resource.Properties?.VpcConfig?.SecurityGroupIds;
+      expect(securityGroupIds).toHaveLength(1);
+      securityGroupIdTokens.add(JSON.stringify(securityGroupIds?.[0]));
+    }
+
+    expect(securityGroupIdTokens.size).toBe(1);
   });
 
   test('creates environment-aware bridge rollout policy with auto-rollback alarm', () => {


### PR DESCRIPTION
## Summary
- expose the network stack's trusted Lambda security group and pass it into PlatformStack
- attach every VPC Lambda created by PlatformStack to that explicit security group
- add regression coverage proving VPC Lambdas share the same imported endpoint-trusted SG token

## Testing
- cd infra/cdk && npx jest --runInBand platform-stack.test.ts -t "attaches VPC Lambdas"
- cd infra/cdk && npx jest --runInBand observability-stack.test.ts
- make preflight-session
- make pre-validate-session
- git push -u origin HEAD

Closes #225