### PR TITLE
fix: align tenant invite listing route exposure

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -497,6 +497,40 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /v1/tenants/{tenantId}/users/invites:
+    get:
+      tags: [Tenants]
+      operationId: listTenantUserInvites
+      summary: List tenant user invites
+      description: >
+        Lists pending and historical tenant user invitations for the specified tenant.
+        Allowed for own-tenant callers with self-service admin rights and platform admin/operator roles.
+      parameters:
+        - $ref: "#/components/parameters/TenantId"
+      responses:
+        "200":
+          description: Tenant invites
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TenantUserInviteDto"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /v1/jobs/{jobId}:
     get:
       tags: [Jobs]

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -661,6 +661,7 @@ export class PlatformStack extends cdk.Stack {
     const tenantApiKeyRotate = tenantApiKey.addResource('rotate');
     const tenantUsers = tenantById.addResource('users');
     const tenantUsersInvite = tenantUsers.addResource('invite');
+    const tenantUsersInvites = tenantUsers.addResource('invites');
     const platform = v1.addResource('platform');
     const failover = platform.addResource('failover');
     const quota = platform.addResource('quota');
@@ -718,6 +719,7 @@ export class PlatformStack extends cdk.Stack {
     auditExport.addMethod('GET', tenantMgmtIntegration, securedMethodOptions);
     tenantApiKeyRotate.addMethod('POST', tenantMgmtIntegration, securedMethodOptions);
     tenantUsersInvite.addMethod('POST', tenantMgmtIntegration, securedMethodOptions);
+    tenantUsersInvites.addMethod('GET', tenantMgmtIntegration, securedMethodOptions);
 
     failover.addMethod('POST', adminOpsIntegration, securedMethodOptions);
     quota.addMethod('GET', adminOpsIntegration, securedMethodOptions);

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -142,6 +142,51 @@ describe('PlatformStack (TASK-023)', () => {
     );
   });
 
+  test('exposes documented webhook and tenant invite listing routes', () => {
+    const resources = template.findResources('AWS::ApiGateway::Resource');
+    const pathParts = Object.values(resources).map((resource) => {
+      const properties = (resource as { Properties?: { PathPart?: string } }).Properties;
+      return properties?.PathPart;
+    });
+
+    expect(pathParts).toContain('webhooks');
+    expect(pathParts).toContain('invites');
+
+    const methods = template.findResources('AWS::ApiGateway::Method') as Record<
+      string,
+      { Properties?: { HttpMethod?: string; ResourceId?: unknown } }
+    >;
+    const resourceEntries = Object.entries(resources);
+    const webhookLogicalId = resourceEntries.find(
+      ([, resource]) =>
+        (resource as { Properties?: { PathPart?: string } }).Properties?.PathPart === 'webhooks',
+    )?.[0];
+    const invitesLogicalId = resourceEntries.find(
+      ([, resource]) =>
+        (resource as { Properties?: { PathPart?: string } }).Properties?.PathPart === 'invites',
+    )?.[0];
+
+    expect(webhookLogicalId).toBeDefined();
+    expect(invitesLogicalId).toBeDefined();
+
+    expect(Object.values(methods)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          Properties: expect.objectContaining({
+            HttpMethod: 'GET',
+            ResourceId: { Ref: webhookLogicalId },
+          }),
+        }),
+        expect.objectContaining({
+          Properties: expect.objectContaining({
+            HttpMethod: 'GET',
+            ResourceId: { Ref: invitesLogicalId },
+          }),
+        }),
+      ]),
+    );
+  });
+
   test('attaches VPC Lambdas to the endpoint-trusted Lambda security group', () => {
     const template = synthTemplate('dev');
 

--- a/src/tenant_api/tenant_lifecycle.py
+++ b/src/tenant_api/tenant_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
+from boto3.dynamodb.conditions import Key
 from data_access.models import TenantStatus
 
 try:
@@ -272,6 +273,40 @@ def handle_sessions(
     return http_utils.response(200, {"items": []})
 
 
+def handle_list_invites(
+    caller: models.CallerIdentity,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    if not auth.can_read_tenant(caller, tenant_id) or not auth.can_manage_tenant_self_service(
+        caller, tenant_id
+    ):
+        raise PermissionError("Access denied")
+
+    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    item = db.get_item(db_factory.tenants_table_name(), db_utils.tenant_key(tenant_id))
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    results = db.query(
+        db_factory.tenants_table_name(),
+        sk_condition=Key("SK").begins_with("INVITE#"),
+    )
+
+    invites = [
+        {
+            "inviteId": str(invite.get("inviteId", "")),
+            "tenantId": tenant_id,
+            "email": str(invite.get("email", "")),
+            "role": str(invite.get("role", "Agent.Invoke")),
+            "status": str(invite.get("status", "")),
+            "expiresAt": invite.get("expiresAt"),
+        }
+        for invite in results.items
+    ]
+    return http_utils.response(200, {"items": invites})
+
+
 def dispatch_routes(
     path: str,
     method: str,
@@ -289,6 +324,8 @@ def dispatch_routes(
             return handle_update(event, caller, deps, tenant_id=tenant_id)
         if path == f"/v1/tenants/{tenant_id}" and method == "DELETE":
             return handle_delete(caller, deps, tenant_id=tenant_id)
+        if path == f"/v1/tenants/{tenant_id}/users/invites" and method == "GET":
+            return handle_list_invites(caller, tenant_id=tenant_id)
 
         # Dispatch sub-resources (webhooks, etc.)
         if path.startswith(f"/v1/tenants/{tenant_id}/webhooks"):

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -459,8 +459,10 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     monkeypatch.setenv("RUNTIME_REGION_PARAM", "/platform/config/runtime-region")
     monkeypatch.setenv("FALLBACK_REGION_PARAM", "/platform/config/fallback-region")
     monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
-    monkeypatch.setattr(tenant_api_handler, "_db_for_tenant", lambda **_kwargs: db)
-    monkeypatch.setattr(tenant_api_handler, "_control_plane_db", lambda *_args, **_kwargs: db)
+    monkeypatch.setattr(tenant_api_handler.db_factory, "db_for_tenant", lambda **_kwargs: db)
+    monkeypatch.setattr(
+        tenant_api_handler.db_factory, "control_plane_db", lambda *_args, **_kwargs: db
+    )
 
     # Consistently mock time across all modular boundaries
     monkeypatch.setattr(tenant_api_handler.utils, "_OVERRIDE_NOW", fixed_now)


### PR DESCRIPTION
## Summary
- add tenant invite listing route handling in the tenant lifecycle API
- expose and document the GET /v1/tenants/{tenantId}/users/invites route
- add regression coverage for the API route contract and handler fixture path

## Validation
- uv run pytest tests/unit/test_tenant_api_handler.py -k list_invites_succeeds -q
- uv run pytest tests/unit/test_openapi_contract_routes.py -q
- make preflight-session
- make pre-validate-session

Closes #217