### PR TITLE
fix: unify runtime failover lock naming

### DIFF
--- a/infra/cdk/lib/platform-compute.ts
+++ b/infra/cdk/lib/platform-compute.ts
@@ -170,6 +170,7 @@ export function createPlatformCompute(
       POWERTOOLS_SERVICE_NAME: 'admin-ops-service',
       TENANTS_TABLE_NAME: storage.tenantsTable.tableName,
       OPS_LOCKS_TABLE: storage.opsLocksTable.tableName,
+      FAILOVER_LOCK_NAME: 'platform-runtime-failover',
       RUNTIME_REGION_PARAM: '/platform/config/runtime-region',
       FALLBACK_REGION_PARAM: '/platform/config/fallback-region',
     },
@@ -214,6 +215,9 @@ export function createPlatformCompute(
       INVOCATIONS_TABLE: storage.invocationsTable.tableName,
       JOBS_TABLE: storage.jobsTable.tableName,
       TENANTS_TABLE: storage.tenantsTable.tableName,
+      OPS_LOCKS_TABLE: storage.opsLocksTable.tableName,
+      FAILOVER_LOCK_NAME: 'platform-runtime-failover',
+      RUNTIME_REGION_PARAM: '/platform/config/runtime-region',
       APPCONFIG_APPLICATION_ID: storage.appconfigApp.ref,
       APPCONFIG_ENVIRONMENT_ID: storage.appconfigEnv.ref,
       APPCONFIG_PROFILE_ID: storage.capabilityProfile.ref,
@@ -224,6 +228,15 @@ export function createPlatformCompute(
   storage.agentsTable.grantReadData(bridgeFn);
   storage.invocationsTable.grantReadWriteData(bridgeFn);
   storage.jobsTable.grantReadWriteData(bridgeFn);
+  storage.opsLocksTable.grantReadWriteData(bridgeFn);
+  bridgeFn.addToRolePolicy(
+    new iam.PolicyStatement({
+      actions: ['ssm:GetParameter', 'ssm:PutParameter'],
+      resources: [
+        `arn:aws:ssm:${stack.region}:${stack.account}:parameter/platform/config/runtime-region`,
+      ],
+    }),
+  );
   bridgeFn.addToRolePolicy(
     new iam.PolicyStatement({
       actions: ['appconfig:GetLatestConfiguration', 'appconfig:StartConfigurationSession'],

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -587,6 +587,19 @@ describe('PlatformStack (TASK-023)', () => {
           POWERTOOLS_SERVICE_NAME: 'admin-ops-service',
           TENANTS_TABLE_NAME: Match.anyValue(),
           OPS_LOCKS_TABLE: Match.anyValue(),
+          FAILOVER_LOCK_NAME: 'platform-runtime-failover',
+        }),
+      },
+    });
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'platform-core-dev-bridge',
+      Handler: 'handler.handler',
+      Environment: {
+        Variables: Match.objectLike({
+          OPS_LOCKS_TABLE: Match.anyValue(),
+          FAILOVER_LOCK_NAME: 'platform-runtime-failover',
+          RUNTIME_REGION_PARAM: '/platform/config/runtime-region',
         }),
       },
     });

--- a/src/bridge/constants.py
+++ b/src/bridge/constants.py
@@ -10,6 +10,7 @@ INVOCATIONS_TABLE = os.environ.get("INVOCATIONS_TABLE", "platform-invocations")
 JOBS_TABLE = os.environ.get("JOBS_TABLE", "platform-jobs")
 SESSIONS_TABLE = os.environ.get("SESSIONS_TABLE", "platform-sessions")
 OPS_LOCKS_TABLE = os.environ.get("OPS_LOCKS_TABLE", "platform-ops-locks")
+FAILOVER_LOCK_NAME = os.environ.get("FAILOVER_LOCK_NAME", "platform-runtime-failover")
 
 # Environment & Infrastructure
 JOB_RESULTS_BUCKET = os.environ.get("JOB_RESULTS_BUCKET")

--- a/src/bridge/lock_manager.py
+++ b/src/bridge/lock_manager.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from aws_lambda_powertools import Logger
 
-from src.bridge.constants import OPS_LOCKS_TABLE
+from src.bridge.constants import FAILOVER_LOCK_NAME, OPS_LOCKS_TABLE
 
 logger = Logger(service="bridge-lock-manager")
 
@@ -78,7 +78,7 @@ def trigger_failover(
     import time
 
     new_region = "eu-central-1" if current_region == "eu-west-1" else "eu-west-1"
-    lock_name = "runtime-region-failover"
+    lock_name = FAILOVER_LOCK_NAME
     identity = f"bridge-lambda-{os.environ.get('AWS_LAMBDA_LOG_STREAM_NAME', 'local')}"
 
     lock_id = acquire_lock(dynamodb, lock_name=lock_name, identity=identity)

--- a/src/platform_tools/diagnostics_handler.py
+++ b/src/platform_tools/diagnostics_handler.py
@@ -41,7 +41,7 @@ RUNBOOKS = {
         "trigger": "ServiceUnavailableException from the active runtime region (e.g., eu-west-1).",
         "steps": [
             "1. Verify regional outage via Service Health Dashboard or CloudWatch metrics.",
-            "2. Acquire the runtime-region-failover lock via the Platform API.",
+            "2. Acquire the platform-runtime-failover lock via the Platform API.",
             "3. Trigger failover to the fallback region (e.g., eu-central-1) "
             "via POST /v1/platform/failover.",
             "4. Verify traffic is flowing in the new region.",

--- a/tests/unit/test_bridge_failover.py
+++ b/tests/unit/test_bridge_failover.py
@@ -180,7 +180,7 @@ def test_handler_failover_already_in_progress(setup_data):
     lock_table = ddb.Table("platform-ops-locks")
     lock_table.put_item(
         Item={
-            "PK": "LOCK#runtime-region-failover",
+            "PK": "LOCK#platform-runtime-failover",
             "SK": "METADATA",
             "lock_id": "other-id",
             "ttl": int(time.time()) + 300,


### PR DESCRIPTION
## Summary
- configure bridge and admin failover paths with the same canonical failover lock name
- remove the bridge hardcoded runtime failover lock key
- update regression coverage and operator diagnostics text to match the shared lock record

## Validation
- make preflight-session
- make pre-validate-session
- direct CDK synth assertion for bridge/admin failover env wiring
- bridge failover pytest target stalled under the worktree harness and timed out at 90s without an assertion failure

Closes #211