### PR TITLE
fix: wire tenant audit exports in deployed api

### DIFF
--- a/infra/cdk/lib/platform-compute.ts
+++ b/infra/cdk/lib/platform-compute.ts
@@ -25,6 +25,8 @@ export type PythonLambdaFactoryProps = {
 export interface PlatformComputeProps {
   readonly envName: string;
   readonly storage: PlatformStorageResources;
+  readonly resultsBucketArn: string;
+  readonly resultsBucketName: string;
   readonly entra: EntraConfiguration;
   readonly scopedTokenSigningKeySecret: secretsmanager.ISecret;
   readonly tenantStackTemplateAsset: s3assets.Asset;
@@ -53,6 +55,8 @@ export function createPlatformCompute(
   const {
     envName,
     storage,
+    resultsBucketArn,
+    resultsBucketName,
     entra,
     scopedTokenSigningKeySecret,
     tenantStackTemplateAsset,
@@ -79,6 +83,7 @@ export function createPlatformCompute(
       POWERTOOLS_SERVICE_NAME: 'tenant-mgmt-service',
       TENANTS_TABLE_NAME: storage.tenantsTable.tableName,
       INVOCATIONS_TABLE_NAME: storage.invocationsTable.tableName,
+      AUDIT_EXPORT_BUCKET: resultsBucketName,
       EVENT_BUS_NAME: 'default',
       TENANT_API_KEY_SECRET_PREFIX: 'platform/tenants', // pragma: allowlist secret
     },
@@ -108,6 +113,23 @@ export function createPlatformCompute(
     new iam.PolicyStatement({
       actions: ['ssm:GetParameter'],
       resources: [`arn:aws:ssm:${stack.region}:${stack.account}:parameter/platform/config/runtime-region`],
+    }),
+  );
+  tenantMgmtFn.addToRolePolicy(
+    new iam.PolicyStatement({
+      actions: ['s3:ListBucket'],
+      resources: [resultsBucketArn],
+      conditions: {
+        StringLike: {
+          's3:prefix': ['tenants/*'],
+        },
+      },
+    }),
+  );
+  tenantMgmtFn.addToRolePolicy(
+    new iam.PolicyStatement({
+      actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+      resources: [`${resultsBucketArn}/tenants/*`],
     }),
   );
 

--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -187,9 +187,27 @@ export class PlatformStack extends cdk.Stack {
     const tenantStackTemplateAsset = new s3assets.Asset(this, 'TenantStackTemplateAsset', {
       path: tenantStackTemplatePath,
     });
+
+    const resultsBucket = new s3.Bucket(this, 'ResultsBucket', {
+      bucketName: `platform-results-${env}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      versioned: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    new ssm.StringParameter(this, 'ResultsBucketArnParam', {
+      parameterName: `/platform/core/${env}/results-bucket-arn`,
+      stringValue: resultsBucket.bucketArn,
+      description: 'ARN for the platform results S3 bucket',
+    });
+
     const compute = createPlatformCompute(this, {
       envName: env,
       storage,
+      resultsBucketArn: resultsBucket.bucketArn,
+      resultsBucketName: resultsBucket.bucketName,
       entra,
       scopedTokenSigningKeySecret,
       tenantStackTemplateAsset,
@@ -273,15 +291,6 @@ export class PlatformStack extends cdk.Stack {
       versioned: true,
     });
 
-    const resultsBucket = new s3.Bucket(this, 'ResultsBucket', {
-      bucketName: `platform-results-${env}`,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-      versioned: true,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
-    });
-
     const spaLogBucket = new s3.Bucket(this, 'SpaLogBucket', {
       bucketName: `platform-spa-logs-${env}`,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
@@ -290,12 +299,6 @@ export class PlatformStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
       accessControl: s3.BucketAccessControl.LOG_DELIVERY_WRITE,
-    });
-
-    new ssm.StringParameter(this, 'ResultsBucketArnParam', {
-      parameterName: `/platform/core/${env}/results-bucket-arn`,
-      stringValue: resultsBucket.bucketArn,
-      description: 'ARN for the platform results S3 bucket',
     });
 
     const spaResponseHeadersPolicy = new cloudfront.CfnResponseHeadersPolicy(

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -545,15 +545,63 @@ describe('PlatformStack (TASK-023)', () => {
   });
 
   test('splits tenant control-plane routes across dedicated service lambdas', () => {
-    template.hasResourceProperties('AWS::Lambda::Function', {
-      FunctionName: 'platform-core-dev-tenant-mgmt',
-      Handler: 'tenant_mgmt_handler.lambda_handler',
-      Environment: {
-        Variables: Match.objectLike({
-          POWERTOOLS_SERVICE_NAME: 'tenant-mgmt-service',
-          TENANTS_TABLE_NAME: Match.anyValue(),
-          INVOCATIONS_TABLE_NAME: Match.anyValue(),
-        }),
+    const lambdaFunctions = template.findResources('AWS::Lambda::Function') as Record<
+      string,
+      {
+        Properties?: {
+          FunctionName?: string;
+          Handler?: string;
+          Environment?: { Variables?: Record<string, unknown> };
+        };
+      }
+    >;
+
+    const tenantMgmtLambda = Object.values(lambdaFunctions).find(
+      (resource) => resource.Properties?.FunctionName === 'platform-core-dev-tenant-mgmt',
+    );
+
+    expect(tenantMgmtLambda?.Properties?.Handler).toBe('tenant_mgmt_handler.lambda_handler');
+    expect(tenantMgmtLambda?.Properties?.Environment?.Variables).toEqual(
+      expect.objectContaining({
+        POWERTOOLS_SERVICE_NAME: 'tenant-mgmt-service',
+        TENANTS_TABLE_NAME: expect.anything(),
+        INVOCATIONS_TABLE_NAME: expect.anything(),
+        AUDIT_EXPORT_BUCKET: {
+          Ref: 'ResultsBucketA95A2103',
+        },
+        TENANT_API_KEY_SECRET_PREFIX: 'platform/tenants', // pragma: allowlist secret
+      }),
+    );
+
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 's3:ListBucket',
+            Resource: {
+              'Fn::GetAtt': ['ResultsBucketA95A2103', 'Arn'],
+            },
+            Condition: {
+              StringLike: {
+                's3:prefix': ['tenants/*'],
+              },
+            },
+          }),
+          Match.objectLike({
+            Action: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  {
+                    'Fn::GetAtt': ['ResultsBucketA95A2103', 'Arn'],
+                  },
+                  '/tenants/*',
+                ],
+              ],
+            },
+          }),
+        ]),
       },
     });
 

--- a/src/tenant_api/tenant_lifecycle.py
+++ b/src/tenant_api/tenant_lifecycle.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import os
+import secrets
 from datetime import timedelta
 from typing import Any
 
@@ -273,6 +276,174 @@ def handle_sessions(
     return http_utils.response(200, {"items": []})
 
 
+def _invocation_timestamp(item: dict[str, Any]) -> str | None:
+    timestamp = utils.str_or_none(item.get("timestamp"))
+    if timestamp is not None:
+        return timestamp
+    sort_key = utils.str_or_none(item.get("SK"))
+    if sort_key is None or not sort_key.startswith("INV#"):
+        return None
+    parts = sort_key.split("#", 2)
+    if len(parts) < 3:
+        return None
+    return utils.str_or_none(parts[1])
+
+
+def _audit_export_sk_condition(
+    *,
+    start_at: Any,
+    end_at: Any,
+) -> Any:
+    start_text = f"INV#{utils.iso(start_at)}" if start_at is not None else None
+    end_text = f"INV#{utils.iso(end_at)}~" if end_at is not None else None
+    if start_text and end_text:
+        return Key("SK").between(start_text, end_text)
+    if start_text:
+        return Key("SK").gte(start_text)
+    if end_text:
+        return Key("SK").lte(end_text)
+    return None
+
+
+def _collect_audit_export_records(
+    *,
+    tenant_id: str,
+    caller: models.CallerIdentity,
+    app_id: str | None,
+    start_at: Any,
+    end_at: Any,
+) -> list[dict[str, Any]]:
+    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+    last_evaluated_key: dict[str, Any] | None = None
+    items: list[dict[str, Any]] = []
+    sk_condition = _audit_export_sk_condition(start_at=start_at, end_at=end_at)
+    start_text = utils.iso(start_at) if start_at is not None else None
+    end_text = utils.iso(end_at) if end_at is not None else None
+
+    while True:
+        page = db.query(
+            db_factory.invocations_table_name(),
+            sk_condition=sk_condition,
+            limit=constants.AUDIT_EXPORT_PAGE_SIZE,
+            exclusive_start_key=last_evaluated_key,
+        )
+        for item in page.items:
+            item_timestamp = _invocation_timestamp(item)
+            if item_timestamp is None:
+                continue
+            if start_text is not None and item_timestamp < start_text:
+                continue
+            if end_text is not None and item_timestamp > end_text:
+                continue
+            items.append(item)
+        last_evaluated_key = page.last_evaluated_key
+        if last_evaluated_key is None:
+            return items
+
+
+def _format_export_timestamp(value: Any) -> str:
+    return value.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _audit_export_url_expiry_seconds() -> int:
+    raw = os.environ.get("AUDIT_EXPORT_URL_EXPIRY_SECONDS")
+    return utils.coerce_positive_int(raw, default=constants.AUDIT_EXPORT_URL_EXPIRY_SECONDS)
+
+
+def _audit_export_key(tenant_id: str, generated_at: Any) -> str:
+    timestamp = _format_export_timestamp(generated_at)
+    nonce = secrets.token_hex(8)
+    return (
+        f"tenants/{tenant_id}/{constants.AUDIT_EXPORT_PREFIX}/audit-export-{timestamp}-{nonce}.json"
+    )
+
+
+def _build_audit_export_payload(
+    *,
+    tenant_id: str,
+    generated_at: Any,
+    start_at: Any,
+    end_at: Any,
+    records: list[dict[str, Any]],
+) -> bytes:
+    payload = {
+        "tenantId": tenant_id,
+        "generatedAt": utils.iso(generated_at),
+        "windowStart": utils.iso(start_at) if start_at is not None else None,
+        "windowEnd": utils.iso(end_at) if end_at is not None else None,
+        "recordCount": len(records),
+        "records": records,
+    }
+    return json.dumps(payload, default=utils.json_default).encode("utf-8")
+
+
+def handle_audit_export(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    auth.require_admin(caller)
+    existing = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if existing is None:
+        return http_utils.error(404, "NOT_FOUND", "Tenant not found")
+
+    query = event.get("queryStringParameters") or {}
+    start_at = validation.parse_optional_utc_timestamp(query.get("start"), field="start")
+    end_at = validation.parse_optional_utc_timestamp(query.get("end"), field="end")
+    if start_at is not None and end_at is not None and start_at > end_at:
+        raise ValueError("start must be less than or equal to end")
+
+    bucket = utils.str_or_none(os.environ.get(constants.AUDIT_EXPORT_BUCKET_ENV))
+    if bucket is None:
+        return http_utils.error(500, "INTERNAL_ERROR", "Audit export bucket is not configured")
+
+    app_id = utils.str_or_none(existing.get("appId"))
+    records = _collect_audit_export_records(
+        tenant_id=tenant_id,
+        caller=caller,
+        app_id=app_id,
+        start_at=start_at,
+        end_at=end_at,
+    )
+    generated_at = utils.now_utc()
+    object_key = _audit_export_key(tenant_id, generated_at)
+    payload = _build_audit_export_payload(
+        tenant_id=tenant_id,
+        generated_at=generated_at,
+        start_at=start_at,
+        end_at=end_at,
+        records=records,
+    )
+
+    try:
+        tenant_s3 = db_factory.s3_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+        tenant_s3.put_object(
+            bucket,
+            object_key,
+            payload,
+            ContentType="application/json",
+        )
+        expires_in = _audit_export_url_expiry_seconds()
+        download_url = tenant_s3.generate_presigned_url(
+            bucket,
+            object_key,
+            expires_in=expires_in,
+        )
+    except Exception:
+        return http_utils.error(500, "INTERNAL_ERROR", "Failed to generate audit export")
+
+    expires_at = generated_at + timedelta(seconds=_audit_export_url_expiry_seconds())
+    return http_utils.response(
+        200,
+        {
+            "tenantId": tenant_id,
+            "downloadUrl": download_url,
+            "expiresAt": utils.iso(expires_at),
+        },
+    )
+
+
 def handle_list_invites(
     caller: models.CallerIdentity,
     *,
@@ -324,6 +495,8 @@ def dispatch_routes(
             return handle_update(event, caller, deps, tenant_id=tenant_id)
         if path == f"/v1/tenants/{tenant_id}" and method == "DELETE":
             return handle_delete(caller, deps, tenant_id=tenant_id)
+        if path == f"/v1/tenants/{tenant_id}/audit-export" and method == "GET":
+            return handle_audit_export(event, caller, tenant_id=tenant_id)
         if path == f"/v1/tenants/{tenant_id}/users/invites" and method == "GET":
             return handle_list_invites(caller, tenant_id=tenant_id)
 

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from data_access.models import PaginatedItems
 
+from src.tenant_api import db_utils as tenant_api_db_utils
 from src.tenant_api import handler as tenant_api_handler
 
 
@@ -463,6 +464,8 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     monkeypatch.setattr(
         tenant_api_handler.db_factory, "control_plane_db", lambda *_args, **_kwargs: db
     )
+    monkeypatch.setattr(tenant_api_db_utils, "db_for_tenant", lambda **_kwargs: db)
+    monkeypatch.setattr(tenant_api_db_utils, "control_plane_db", lambda *_args, **_kwargs: db)
 
     # Consistently mock time across all modular boundaries
     monkeypatch.setattr(tenant_api_handler.utils, "_OVERRIDE_NOW", fixed_now)
@@ -1123,6 +1126,8 @@ def test_list_tenants_admin_only(fake_state: dict[str, Any]) -> None:
 def test_audit_export_writes_real_s3_export_and_returns_presigned_url(
     fake_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    from src.tenant_api import tenant_lifecycle
+
     fake_state["db"].items[("TENANT#t-005", "METADATA")] = {
         "PK": "TENANT#t-005",
         "SK": "METADATA",
@@ -1150,8 +1155,8 @@ def test_audit_export_writes_real_s3_export_and_returns_presigned_url(
     }
 
     fake_s3 = FakeTenantScopedS3()
-    monkeypatch.setattr(tenant_api_handler.secrets, "token_hex", lambda _n: "feedfacecafebeef")
-    monkeypatch.setattr(tenant_api_handler, "_tenant_s3_for_scope", lambda **_kwargs: fake_s3)
+    monkeypatch.setattr(tenant_lifecycle.secrets, "token_hex", lambda _n: "feedfacecafebeef")
+    monkeypatch.setattr(tenant_lifecycle.db_factory, "s3_for_tenant", lambda **_kwargs: fake_s3)
 
     event = _event(method="GET", tenant_id="t-005")
     event["path"] = "/v1/tenants/t-005/audit-export"


### PR DESCRIPTION
## Summary
- wire the canonical platform results bucket into tenant-mgmt and grant tenant-scoped audit export S3 access
- restore the modularized tenant audit export route that regressed out of tenant_lifecycle
- tighten regression coverage around deployed env/IAM wiring and the real audit export path

## Validation
- uv run pytest tests/unit/test_tenant_api_handler.py -k audit_export -q
- node -r ts-node/register/transpile-only <<'EOF' ... direct CDK synth assertion for tenant-mgmt AUDIT_EXPORT_BUCKET and S3 IAM ... EOF
- make preflight-session
- make pre-validate-session