### PR TITLE
fix: align billing pipeline with tenant schema

### DIFF
--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -128,6 +128,35 @@ def _iso_now() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _read_str_field(record: dict[str, Any], *names: str, default: str | None = None) -> str | None:
+    for name in names:
+        value = record.get(name)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return default
+
+
+def _read_float_field(record: dict[str, Any], *names: str, default: float = 0.0) -> float:
+    for name in names:
+        value = record.get(name)
+        if value is None:
+            continue
+        return float(value)
+    return default
+
+
+def _read_int_field(record: dict[str, Any], *names: str, default: int = 0) -> int:
+    for name in names:
+        value = record.get(name)
+        if value is None:
+            continue
+        return int(value)
+    return default
+
+
 def _get_active_tenants() -> list[dict[str, Any]]:
     """Scan platform-tenants for active/suspended tenants."""
     # System context for admin scan
@@ -148,10 +177,14 @@ def _get_active_tenants() -> list[dict[str, Any]]:
 
 
 def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
-    tenant_id = tenant["tenant_id"]
-    tier = tenant["tier"]
-    budget = float(tenant.get("monthly_budget_usd", 0.0))
-    app_id = tenant.get("app_id", "unknown")
+    tenant_id = _read_str_field(tenant, "tenantId", "tenant_id")
+    if tenant_id is None:
+        raise ValueError("tenant record is missing tenantId")
+    tier = _read_str_field(tenant, "tier")
+    if tier is None:
+        raise ValueError(f"tenant {tenant_id} is missing tier")
+    budget = _read_float_field(tenant, "monthlyBudgetUsd", "monthly_budget_usd", default=0.0)
+    app_id = _read_str_field(tenant, "appId", "app_id", default="unknown") or "unknown"
     pricing_path = f"/platform/billing/pricing/{tier}"
 
     # Day window
@@ -205,8 +238,10 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
     update_response = db.update_item(
         TENANTS_TABLE,
         summary_key,
-        "SET tenant_id = :tid, year_month = :ym, last_updated = :lu "
-        "ADD total_input_tokens :di, total_output_tokens :do, total_cost_usd :dc",
+        "SET tenantId = :tid, tenant_id = :tid, yearMonth = :ym, year_month = :ym, "
+        "updatedAt = :lu, last_updated = :lu "
+        "ADD totalInputTokens :di, total_input_tokens :di, totalOutputTokens :do, "
+        "total_output_tokens :do, totalCostUsd :dc, total_cost_usd :dc",
         {
             ":tid": tenant_id,
             ":ym": year_month,
@@ -217,9 +252,13 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
         },
     )
     updated = update_response.get("Attributes", {})
-    total_input = int(updated.get("total_input_tokens", day_input))
-    total_output = int(updated.get("total_output_tokens", day_output))
-    total_cost = float(updated.get("total_cost_usd", day_cost))
+    total_input = _read_int_field(
+        updated, "totalInputTokens", "total_input_tokens", default=day_input
+    )
+    total_output = _read_int_field(
+        updated, "totalOutputTokens", "total_output_tokens", default=day_output
+    )
+    total_cost = _read_float_field(updated, "totalCostUsd", "total_cost_usd", default=day_cost)
 
     # 4. Emit metrics for observability
     # Monthly cost metric used for per-tenant budget alarms
@@ -275,7 +314,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
             db.update_item(
                 TENANTS_TABLE,
                 {"PK": f"TENANT#{tenant_id}", "SK": "METADATA"},
-                "SET #s = :s, updated_at = :u",
+                "SET #s = :s, updatedAt = :u, updated_at = :u",
                 {":s": TenantStatus.SUSPENDED, ":u": _iso_now()},
                 expression_attribute_names={"#s": "status"},
                 condition_expression="attribute_exists(PK)",

--- a/src/tenant_api/ops_control.py
+++ b/src/tenant_api/ops_control.py
@@ -142,11 +142,15 @@ def handle_platform_billing_status(
             "yearMonth": year_month,
             "summaries": [
                 {
-                    "tenantId": s.get("tenantId"),
-                    "totalInputTokens": int(s.get("total_input_tokens", 0)),
-                    "totalOutputTokens": int(s.get("total_output_tokens", 0)),
-                    "totalCostUsd": float(s.get("total_cost_usd", 0.0)),
-                    "lastUpdated": s.get("last_updated"),
+                    "tenantId": s.get("tenantId") or s.get("tenant_id"),
+                    "totalInputTokens": int(
+                        s.get("totalInputTokens", s.get("total_input_tokens", 0))
+                    ),
+                    "totalOutputTokens": int(
+                        s.get("totalOutputTokens", s.get("total_output_tokens", 0))
+                    ),
+                    "totalCostUsd": float(s.get("totalCostUsd", s.get("total_cost_usd", 0.0))),
+                    "lastUpdated": s.get("updatedAt") or s.get("last_updated"),
                 }
                 for s in summaries
             ],

--- a/tests/unit/test_billing_handler.py
+++ b/tests/unit/test_billing_handler.py
@@ -122,11 +122,12 @@ def _seed_tenant(ddb: Any, *, status: str = "active", budget: float = BUDGET) ->
         Item={
             "PK": f"TENANT#{TENANT_ID}",
             "SK": "METADATA",
-            "tenant_id": TENANT_ID,
-            "app_id": APP_ID,
+            "tenantId": TENANT_ID,
+            "appId": APP_ID,
             "tier": TIER,
             "status": status,
-            "monthly_budget_usd": Decimal(str(budget)),
+            "monthlyBudgetUsd": Decimal(str(budget)),
+            "updatedAt": "2026-02-25T12:00:00Z",
         }
     )
 
@@ -169,10 +170,13 @@ def test_billing_aggregation_and_cost(mock_aws_clients: Any) -> None:
     resp = table.get_item(Key={"PK": f"TENANT#{TENANT_ID}", "SK": f"BILLING#{year_month}"})
     summary = resp["Item"]
 
-    assert summary["total_input_tokens"] == 3000
-    assert summary["total_output_tokens"] == 2000
+    assert summary["tenantId"] == TENANT_ID
+    assert summary["yearMonth"] == year_month
+    assert summary["totalInputTokens"] == 3000
+    assert summary["totalOutputTokens"] == 2000
     # Cost: (3.0 * 0.1) + (2.0 * 0.2) = 0.3 + 0.4 = 0.7
-    assert float(summary["total_cost_usd"]) == 0.7
+    assert float(summary["totalCostUsd"]) == 0.7
+    assert summary["updatedAt"]
 
 
 def test_budget_exceeded_suspension(mock_aws_clients: Any) -> None:
@@ -209,9 +213,12 @@ def test_incremental_update(mock_aws_clients: Any) -> None:
         Item={
             "PK": f"TENANT#{TENANT_ID}",
             "SK": f"BILLING#{year_month}",
-            "total_input_tokens": 5000,
-            "total_output_tokens": 2000,
-            "total_cost_usd": Decimal("1.5"),
+            "tenantId": TENANT_ID,
+            "yearMonth": year_month,
+            "updatedAt": "2026-02-01T00:00:00Z",
+            "totalInputTokens": 5000,
+            "totalOutputTokens": 2000,
+            "totalCostUsd": Decimal("1.5"),
         }
     )
 
@@ -227,10 +234,10 @@ def test_incremental_update(mock_aws_clients: Any) -> None:
     resp = table.get_item(Key={"PK": f"TENANT#{TENANT_ID}", "SK": f"BILLING#{year_month}"})
     summary = resp["Item"]
 
-    assert summary["total_input_tokens"] == 6000
-    assert summary["total_output_tokens"] == 3000
+    assert summary["totalInputTokens"] == 6000
+    assert summary["totalOutputTokens"] == 3000
     # New cost: 1.5 + (1*0.1 + 1*0.2) = 1.5 + 0.3 = 1.8
-    assert float(summary["total_cost_usd"]) == 1.8
+    assert float(summary["totalCostUsd"]) == 1.8
 
 
 def test_missing_pricing_parameter_fails_tenant_and_records_error(mock_aws_clients: Any) -> None:

--- a/tests/unit/test_billing_pagination.py
+++ b/tests/unit/test_billing_pagination.py
@@ -30,11 +30,8 @@ os.environ["TENANTS_TABLE_NAME"] = "platform-tenants"
 os.environ["INVOCATIONS_TABLE_NAME"] = "platform-invocations"
 
 from src.billing.handler import _get_active_tenants, _process_tenant
-from src.tenant_api.handler import (
-    CallerIdentity,
-    TenantApiDependencies,
-    _handle_platform_billing_status,
-)
+from src.tenant_api.models import CallerIdentity, TenantApiDependencies
+from src.tenant_api.ops_control import handle_platform_billing_status
 
 
 @pytest.fixture
@@ -86,7 +83,7 @@ def test_get_active_tenants_paginated(mock_aws_clients: Any) -> None:
                         {
                             "PK": "TENANT#t0",
                             "SK": "METADATA",
-                            "tenant_id": "t0",
+                            "tenantId": "t0",
                             "status": "active",
                             "tier": "basic",
                         }
@@ -99,14 +96,14 @@ def test_get_active_tenants_paginated(mock_aws_clients: Any) -> None:
                         {
                             "PK": "TENANT#t1",
                             "SK": "METADATA",
-                            "tenant_id": "t1",
+                            "tenantId": "t1",
                             "status": "active",
                             "tier": "basic",
                         },
                         {
                             "PK": "TENANT#t2",
                             "SK": "METADATA",
-                            "tenant_id": "t2",
+                            "tenantId": "t2",
                             "status": "active",
                             "tier": "basic",
                         },
@@ -147,9 +144,9 @@ def test_process_tenant_query_pagination(mock_aws_clients: Any) -> None:
         # handler can extract totals for metric emission and budget enforcement.
         mock_table.update_item.return_value = {
             "Attributes": {
-                "total_input_tokens": 2000,
-                "total_output_tokens": 0,
-                "total_cost_usd": 0.2,
+                "totalInputTokens": 2000,
+                "totalOutputTokens": 0,
+                "totalCostUsd": 0.2,
             }
         }
 
@@ -178,7 +175,7 @@ def test_process_tenant_query_pagination(mock_aws_clients: Any) -> None:
             },
         ]
 
-        tenant = {"tenant_id": tenant_id, "tier": "basic", "app_id": app_id, "status": "active"}
+        tenant = {"tenantId": tenant_id, "tier": "basic", "appId": app_id, "status": "active"}
         _process_tenant(tenant, yesterday)
 
         # CR003: billing now uses atomic ADD update_item instead of put_item.
@@ -191,11 +188,11 @@ def test_process_tenant_query_pagination(mock_aws_clients: Any) -> None:
 
 
 def test_platform_billing_status_pagination(mock_aws_clients: Any) -> None:
-    """Verify that _handle_platform_billing_status paginates through billing summaries."""
+    """Verify that handle_platform_billing_status returns canonical summary fields."""
     year_month = datetime.now(UTC).strftime("%Y-%m")
 
     caller = CallerIdentity(
-        tenant_id="platform-admin",
+        tenant_id="platform",
         app_id="platform-admin",
         tier="premium",
         sub="admin-sub",
@@ -214,33 +211,49 @@ def test_platform_billing_status_pagination(mock_aws_clients: Any) -> None:
         platform_quota_client=MagicMock(),
     )
 
-    with patch("src.tenant_api.handler.TenantScopedDynamoDB") as mock_db_class:
+    with patch("src.tenant_api.ops_control.db_factory.control_plane_db") as mock_control_plane_db:
         mock_db = MagicMock()
-        mock_db_class.return_value = mock_db
-
-        # mock scan_all for BILLING records
+        mock_control_plane_db.return_value = mock_db
         mock_db.scan_all.return_value = [
             {
                 "PK": "TENANT#t1",
                 "SK": f"BILLING#{year_month}",
-                "total_cost_usd": 10.0,
-                "total_input_tokens": 1000,
-                "total_output_tokens": 500,
+                "tenantId": "t1",
+                "totalCostUsd": 10.0,
+                "totalInputTokens": 1000,
+                "totalOutputTokens": 500,
+                "updatedAt": "2026-02-01T00:00:00Z",
             },
             {
                 "PK": "TENANT#t2",
                 "SK": f"BILLING#{year_month}",
-                "total_cost_usd": 20.0,
-                "total_input_tokens": 2000,
-                "total_output_tokens": 1000,
+                "tenantId": "t2",
+                "totalCostUsd": 20.0,
+                "totalInputTokens": 2000,
+                "totalOutputTokens": 1000,
+                "updatedAt": "2026-02-02T00:00:00Z",
             },
         ]
 
-        result = _handle_platform_billing_status(caller, deps)
+        result = handle_platform_billing_status({}, caller, deps)
 
         assert result["statusCode"] == 200
         body = json.loads(result["body"])
-        assert body["tenantCount"] == 2
-        assert body["totalCostUsd"] == 30.0
-        assert body["totalTokens"] == 4500  # (1000+500) + (2000+1000) = 1500 + 3000 = 4500
+        assert body["yearMonth"] == year_month
+        assert body["summaries"] == [
+            {
+                "tenantId": "t1",
+                "totalInputTokens": 1000,
+                "totalOutputTokens": 500,
+                "totalCostUsd": 10.0,
+                "lastUpdated": "2026-02-01T00:00:00Z",
+            },
+            {
+                "tenantId": "t2",
+                "totalInputTokens": 2000,
+                "totalOutputTokens": 1000,
+                "totalCostUsd": 20.0,
+                "lastUpdated": "2026-02-02T00:00:00Z",
+            },
+        ]
         assert mock_db.scan_all.call_count == 1


### PR DESCRIPTION
## Summary
- make billing consume canonical tenant metadata fields written by tenant lifecycle APIs, with explicit fallback for legacy snake_case records
- write canonical billing summary and suspension fields while preserving legacy aliases for compatibility
- update billing regressions to use real tenant-shaped fixtures and the modularized billing-status handler seam

## Senior Review Notes
- kept the high-risk platform billing status route stable by adding compatibility reads instead of forcing a consumer-side schema cutover
- intentionally avoided touching unrelated billing/pricing logic

## Validation
- uv run pytest tests/unit/test_billing_handler.py tests/unit/test_billing_pagination.py -q
- make preflight-session
- make pre-validate-session