### PR TITLE
fix: stop runtime handlers from bypassing data-access-lib

### DIFF
--- a/gateway/interceptors/request_interceptor.py
+++ b/gateway/interceptors/request_interceptor.py
@@ -22,7 +22,6 @@ import uuid
 from collections.abc import Callable
 from typing import Any
 
-import boto3
 import jwt
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.idempotency import (
@@ -34,10 +33,13 @@ from aws_lambda_powertools.utilities.parameters import get_secret
 from jwt import PyJWKClient
 
 try:
-    from data_access import TenantCapabilityClient
+    from data_access import ControlPlaneDynamoDB, TenantCapabilityClient, TenantContext, TenantTier
 except ImportError:
     # Fallback for environments where data-access-lib is not yet bundled
     TenantCapabilityClient = None
+    ControlPlaneDynamoDB = None
+    TenantContext = None
+    TenantTier = None
 
 logger = Logger(service="gateway-request-interceptor")
 tracer = Tracer()
@@ -50,7 +52,6 @@ SCOPED_TOKEN_ISSUER = os.environ.get("SCOPED_TOKEN_ISSUER", "platform-gateway")
 
 _TIER_ORDER = {"basic": 0, "standard": 1, "premium": 2}
 _jwk_client: PyJWKClient | None = None
-_dynamodb_resource: Any | None = None
 _capability_client: Any | None = None
 
 
@@ -91,16 +92,15 @@ def get_jwk_client() -> PyJWKClient | None:
     return _jwk_client
 
 
-def get_dynamodb():
-    """Lazily initialize DynamoDB resource."""
-    global _dynamodb_resource
-    if _dynamodb_resource is None:
-        region = os.environ.get("AWS_REGION")
-        if region:
-            _dynamodb_resource = boto3.resource("dynamodb", region_name=region)
-        else:
-            _dynamodb_resource = boto3.resource("dynamodb")
-    return _dynamodb_resource
+def get_platform_context():
+    if TenantContext is None or TenantTier is None:
+        raise RuntimeError("data-access-lib is required for tool record lookups")
+    return TenantContext(
+        tenant_id="platform",
+        app_id="gateway-request-interceptor",
+        tier=TenantTier.PREMIUM,
+        sub="request-interceptor",
+    )
 
 
 def _get_header(headers: dict[str, str], key: str) -> str | None:
@@ -207,12 +207,13 @@ def _extract_minimum_tier(tool_record: dict[str, Any]) -> str:
 
 def get_tool_record(tool_name: str, tenant_id: str) -> dict[str, Any] | None:
     """Fetch tenant-specific tool first, then global."""
-    table = get_dynamodb().Table(TOOLS_TABLE)
+    if ControlPlaneDynamoDB is None:
+        raise RuntimeError("data-access-lib is required for tool record lookups")
+    db = ControlPlaneDynamoDB(get_platform_context())
     primary_key = {"PK": f"TOOL#{tool_name}"}
     candidate_sort_keys = [f"TENANT#{tenant_id}", "GLOBAL"]
     for sort_key in candidate_sort_keys:
-        response = table.get_item(Key={**primary_key, "SK": sort_key}, ConsistentRead=True)
-        item = response.get("Item")
+        item = db.get_item(TOOLS_TABLE, {**primary_key, "SK": sort_key}, ConsistentRead=True)
         if item and bool(item.get("enabled", False)):
             return dict(item)
     return None

--- a/src/authoriser/handler.py
+++ b/src/authoriser/handler.py
@@ -15,11 +15,11 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
-import boto3
 import jwt
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.logging import correlation_paths
 from boto3.dynamodb.conditions import Attr, Key
+from data_access import ControlPlaneDynamoDB, TenantContext, TenantTier
 from jwt import PyJWKClient
 
 logger = Logger(service="authoriser")
@@ -33,7 +33,6 @@ TENANTS_TABLE = os.environ.get("TENANTS_TABLE")
 
 # Global clients — connection reuse across warm starts
 _jwk_client: PyJWKClient | None = None
-_dynamodb_resource = None
 
 # CR005: In-memory TTL cache for SigV4 ARN→tenant binding.
 # Avoids a full DynamoDB table scan on every machine-auth request.
@@ -56,6 +55,15 @@ def _aws_region() -> str:
     return os.environ["AWS_REGION"]
 
 
+def get_platform_context() -> TenantContext:
+    return TenantContext(
+        tenant_id=_PLATFORM_TENANT_ID,
+        app_id="platform-authoriser",
+        tier=TenantTier.PREMIUM,
+        sub="authoriser-lambda",
+    )
+
+
 def get_jwk_client() -> PyJWKClient | None:
     """Lazy initialization of PyJWKClient."""
     global _jwk_client
@@ -63,14 +71,6 @@ def get_jwk_client() -> PyJWKClient | None:
         # Cache JWKS for 5 minutes (300s) as per ARCHITECTURE.md
         _jwk_client = PyJWKClient(ENTRA_JWKS_URL, cache_jwk_set=True, lifespan=300)
     return _jwk_client
-
-
-def get_dynamodb():
-    """Lazy initialization of boto3 resource."""
-    global _dynamodb_resource
-    if _dynamodb_resource is None:
-        _dynamodb_resource = boto3.resource("dynamodb", region_name=_aws_region())
-    return _dynamodb_resource
 
 
 def generate_policy(
@@ -96,17 +96,16 @@ def generate_policy(
 def get_tenant_status(tenant_id: str) -> str | None:
     """Fetch tenant status from DynamoDB.
 
-    The authoriser runs before a TenantContext exists, so it uses the
-    system-level DynamoDB client directly.
+    The authoriser runs before a caller TenantContext exists, so it uses
+    the reserved platform control-plane context.
     """
     if not TENANTS_TABLE:
         logger.warning("TENANTS_TABLE not set, assuming active (dev mode)")
         return "active"
 
     try:
-        table = get_dynamodb().Table(TENANTS_TABLE)
-        response = table.get_item(Key={"PK": f"TENANT#{tenant_id}", "SK": "METADATA"})
-        item = response.get("Item")
+        db = ControlPlaneDynamoDB(get_platform_context())
+        item = db.get_item(TENANTS_TABLE, {"PK": f"TENANT#{tenant_id}", "SK": "METADATA"})
         if item:
             status = item.get("status")
             return str(status) if status is not None else None
@@ -148,25 +147,26 @@ def resolve_sigv4_tenant_binding(caller_arn: str) -> dict[str, str] | None:
 
     # 2. Resolve via DynamoDB GSI
     candidate_role_arns = _sigv4_caller_role_arns(caller_arn)
-    table = get_dynamodb().Table(TENANTS_TABLE)
+    db = ControlPlaneDynamoDB(get_platform_context())
     matches: dict[str, dict[str, str]] = {}
 
     try:
         for role_arn in candidate_role_arns:
             # O(1) GSI Query
-            response = table.query(
-                IndexName="gsi-execution-role-arn",
-                KeyConditionExpression=Key("executionRoleArn").eq(role_arn),
+            response = db.query(
+                TENANTS_TABLE,
+                key_condition=Key("executionRoleArn").eq(role_arn),
+                index_name="gsi-execution-role-arn",
                 ProjectionExpression="PK, SK",
             )
 
-            for index_item in response.get("Items", []):
+            for index_item in response.items:
                 # Follow-up GetItem for full metadata (since GSI is KEYS_ONLY)
-                full_item_resp = table.get_item(
-                    Key={"PK": index_item["PK"], "SK": index_item["SK"]},
+                item = db.get_item(
+                    TENANTS_TABLE,
+                    {"PK": index_item["PK"], "SK": index_item["SK"]},
                     ProjectionExpression="tenantId, tenant_id, appId, app_id, tier",
                 )
-                item = full_item_resp.get("Item")
                 if not item:
                     continue
 

--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -41,7 +41,6 @@ EVENT_BUS_NAME = os.environ.get("EVENT_BUS_NAME", "default")
 # Boto3 clients — lazy initialisation (matches handler convention; avoids import-time failures)
 _ssm = None
 _events = None
-_dynamodb = None
 _cloudwatch = None
 _pricing_provider = None
 
@@ -62,13 +61,6 @@ def _get_events() -> Any:
     if _events is None:
         _events = boto3.client("events", region_name=_aws_region())
     return _events
-
-
-def _get_dynamodb() -> Any:
-    global _dynamodb
-    if _dynamodb is None:
-        _dynamodb = boto3.resource("dynamodb", region_name=_aws_region())
-    return _dynamodb
 
 
 def _get_cloudwatch() -> Any:
@@ -166,7 +158,7 @@ def _get_active_tenants() -> list[dict[str, Any]]:
         tier=TenantTier.PREMIUM,
         sub="billing-pipeline",
     )
-    db = ControlPlaneDynamoDB(ctx, dynamodb_resource=_get_dynamodb())
+    db = ControlPlaneDynamoDB(ctx)
     # CR001: FilterExpression requires Attr() conditions, not Key() conditions.
     # Key() is only valid in KeyConditionExpression.
     return db.scan_all(
@@ -205,7 +197,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
         tier=TenantTier(tier),
         sub="billing-pipeline",
     )
-    db = TenantScopedDynamoDB(ctx, dynamodb_resource=_get_dynamodb())
+    db = TenantScopedDynamoDB(ctx)
 
     # 1. Query invocations for the day
     # SK starts with INV#timestamp

--- a/src/bridge/discovery_service.py
+++ b/src/bridge/discovery_service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from boto3.dynamodb.conditions import Key
 from data_access import ControlPlaneDynamoDB, TenantScopedDynamoDB, TenantScopedS3
 from data_access.models import (
     AgentRecord,
@@ -139,7 +138,7 @@ def list_agents(
 
 
 def resolve_agent_record(
-    dynamodb: Any,
+    control_plane_db: ControlPlaneDynamoDB,
     *,
     agents_table: str,
     agent_name: str,
@@ -147,19 +146,17 @@ def resolve_agent_record(
 ) -> AgentRecord | None:
     """Fetch a specific agent version or the latest promoted version."""
 
-    table = dynamodb.Table(agents_table)
-
     if agent_version:
-        # Direct fetch for specific version
-        resp = table.get_item(Key={"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{agent_version}"})
-        item = resp.get("Item")
+        item = control_plane_db.get_item(
+            agents_table, {"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{agent_version}"}
+        )
         if item and is_invokable_agent_status(_coerce_optional_string(item.get("status"))):
             return _agent_record_from_item(item)
         return None
 
     # Query for all versions and pick latest promoted
-    response = table.query(KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"))
-    items = response.get("Items", [])
+    response = control_plane_db.query(agents_table, pk_value=f"AGENT#{agent_name}")
+    items = response.items
 
     promoted_items = []
     for item in items:
@@ -206,7 +203,7 @@ def get_agent_detail(
     request_id: str,
     *,
     agents_table: str,
-    get_dynamodb: Any,
+    db_factory: Any = ControlPlaneDynamoDB,
     error_response: Any,
     tenant_context: TenantContext | None = None,
     capability_policy: Any = None,
@@ -215,10 +212,15 @@ def get_agent_detail(
     if not agent_name:
         return error_response(400, "INVALID_REQUEST", "Missing agentName in path", request_id)
 
-    ddb = get_dynamodb()
-    table = ddb.Table(agents_table)
-    response = table.query(KeyConditionExpression=Key("PK").eq(f"AGENT#{agent_name}"))
-    items = response.get("Items", [])
+    platform_context = TenantContext(
+        tenant_id="platform",
+        app_id="bridge-discovery",
+        tier=TenantTier.PREMIUM,
+        sub="bridge-discovery",
+    )
+    db = db_factory(platform_context)
+    response = db.query(agents_table, pk_value=f"AGENT#{agent_name}")
+    items = response.items
 
     promoted_items = []
     for item in items:

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -32,6 +32,7 @@ from botocore.exceptions import (
     ReadTimeoutError,
 )
 from data_access import (
+    ControlPlaneDynamoDB,
     TenantCapabilityClient,
     TenantScopedDynamoDB,
 )
@@ -107,10 +108,6 @@ def get_sts() -> Any:
     return boto3.client("sts", region_name=_aws_region())
 
 
-def get_dynamodb() -> Any:
-    return boto3.resource("dynamodb", region_name=_aws_region())
-
-
 def get_cloudwatch() -> Any:
     return boto3.client("cloudwatch", region_name=_aws_region())
 
@@ -156,7 +153,6 @@ def get_runtime_client(region: str, credentials: dict[str, Any] | None = None) -
 
 def trigger_failover(current_region: str) -> str:
     return lock_manager.trigger_failover(
-        dynamodb=get_dynamodb(),
         ssm=get_ssm(),
         current_region=current_region,
         get_config_fn=get_config,
@@ -177,6 +173,15 @@ _assume_tenant_role = role_resolver.assume_tenant_role
 _AGENTS_TABLE = AGENTS_TABLE
 
 
+def get_platform_context() -> TenantContext:
+    return TenantContext(
+        tenant_id="platform",
+        app_id="platform-bridge",
+        tier=TenantTier.PREMIUM,
+        sub="bridge-lambda",
+    )
+
+
 def get_tenant_record(tenant_context: TenantContext) -> dict[str, Any] | None:
     try:
         db = TenantScopedDynamoDB(tenant_context)
@@ -190,7 +195,7 @@ def get_tenant_record(tenant_context: TenantContext) -> dict[str, Any] | None:
 
 def get_agent_record(agent_name: str, agent_version: str | None = None) -> AgentRecord | None:
     return discovery_resolve_agent_record(
-        get_dynamodb(),
+        ControlPlaneDynamoDB(get_platform_context()),
         agents_table=AGENTS_TABLE,
         agent_name=agent_name,
         agent_version=agent_version,

--- a/src/bridge/lock_manager.py
+++ b/src/bridge/lock_manager.py
@@ -5,14 +5,24 @@ from datetime import UTC, datetime
 from typing import Any
 
 from aws_lambda_powertools import Logger
+from data_access import ControlPlaneDynamoDB, TenantContext, TenantTier
 
 from src.bridge.constants import FAILOVER_LOCK_NAME, OPS_LOCKS_TABLE
 
 logger = Logger(service="bridge-lock-manager")
 
 
+def _platform_context() -> TenantContext:
+    return TenantContext(
+        tenant_id="platform",
+        app_id="bridge-lock-manager",
+        tier=TenantTier.PREMIUM,
+        sub="bridge-lock-manager",
+    )
+
+
 def acquire_lock(
-    dynamodb: Any,
+    db: ControlPlaneDynamoDB,
     *,
     lock_name: str,
     identity: str,
@@ -22,11 +32,11 @@ def acquire_lock(
     lock_id = str(uuid.uuid4())
     now = datetime.now(UTC)
     ttl = int(now.timestamp()) + ttl_seconds
-    table = dynamodb.Table(OPS_LOCKS_TABLE)
 
     try:
-        table.put_item(
-            Item={
+        db.put_item(
+            OPS_LOCKS_TABLE,
+            item={
                 "PK": f"LOCK#{lock_name}",
                 "SK": "METADATA",
                 "lock_id": lock_id,
@@ -43,16 +53,16 @@ def acquire_lock(
 
 
 def release_lock(
-    dynamodb: Any,
+    db: ControlPlaneDynamoDB,
     *,
     lock_name: str,
     lock_id: str,
 ) -> bool:
     """Release a distributed lock in DynamoDB."""
-    table = dynamodb.Table(OPS_LOCKS_TABLE)
     try:
-        table.delete_item(
-            Key={"PK": f"LOCK#{lock_name}", "SK": "METADATA"},
+        db.delete_item(
+            OPS_LOCKS_TABLE,
+            key={"PK": f"LOCK#{lock_name}", "SK": "METADATA"},
             ConditionExpression="lock_id = :lock_id",
             ExpressionAttributeValues={":lock_id": lock_id},
         )
@@ -63,7 +73,6 @@ def release_lock(
 
 def trigger_failover(
     *,
-    dynamodb: Any,
     ssm: Any,
     current_region: str,
     get_config_fn: Any,
@@ -80,8 +89,9 @@ def trigger_failover(
     new_region = "eu-central-1" if current_region == "eu-west-1" else "eu-west-1"
     lock_name = FAILOVER_LOCK_NAME
     identity = f"bridge-lambda-{os.environ.get('AWS_LAMBDA_LOG_STREAM_NAME', 'local')}"
+    db = ControlPlaneDynamoDB(_platform_context())
 
-    lock_id = acquire_lock(dynamodb, lock_name=lock_name, identity=identity)
+    lock_id = acquire_lock(db, lock_name=lock_name, identity=identity)
     if not lock_id:
         logger.info("Failover in progress by another instance, skipping update")
         # Wait a bit and re-fetch config
@@ -115,4 +125,4 @@ def trigger_failover(
         logger.exception("Failed to trigger failover")
         return current_region
     finally:
-        release_lock(dynamodb, lock_name=lock_name, lock_id=lock_id)
+        release_lock(db, lock_name=lock_name, lock_id=lock_id)

--- a/src/data-access-lib/src/data_access/client.py
+++ b/src/data-access-lib/src/data_access/client.py
@@ -195,14 +195,16 @@ class TenantScopedDynamoDB:
             attempted_key=attempted_key,
         )
 
-    def get_item(self, table_name: str, key: dict[str, Any]) -> dict[str, Any] | None:
+    def get_item(
+        self, table_name: str, key: dict[str, Any], **extra_kwargs: Any
+    ) -> dict[str, Any] | None:
         """Get a single item, enforcing tenant partition on PK.
 
         Returns the item dict, or None if the item does not exist.
         """
         self._validate_pk(key)
         table = self._dynamodb.Table(table_name)
-        response = table.get_item(Key=key)
+        response = table.get_item(Key=key, **extra_kwargs)
         return response.get("Item")
 
     def put_item(
@@ -211,6 +213,7 @@ class TenantScopedDynamoDB:
         item: dict[str, Any],
         *,
         condition_expression: str | None = None,
+        **extra_kwargs: Any,
     ) -> None:
         """Write an item, enforcing tenant partition on PK."""
         self._validate_pk(item)
@@ -218,6 +221,7 @@ class TenantScopedDynamoDB:
         kwargs: dict[str, Any] = {"Item": item}
         if condition_expression:
             kwargs["ConditionExpression"] = condition_expression
+        kwargs.update(extra_kwargs)
         table.put_item(**kwargs)
 
     def update_item(
@@ -249,11 +253,11 @@ class TenantScopedDynamoDB:
             kwargs["ConditionExpression"] = condition_expression
         return table.update_item(**kwargs)
 
-    def delete_item(self, table_name: str, key: dict[str, Any]) -> None:
+    def delete_item(self, table_name: str, key: dict[str, Any], **extra_kwargs: Any) -> None:
         """Delete an item, enforcing tenant partition on PK."""
         self._validate_pk(key)
         table = self._dynamodb.Table(table_name)
-        table.delete_item(Key=key)
+        table.delete_item(Key=key, **extra_kwargs)
 
     def query(
         self,
@@ -265,6 +269,7 @@ class TenantScopedDynamoDB:
         limit: int | None = None,
         scan_index_forward: bool = True,
         exclusive_start_key: dict[str, Any] | None = None,
+        **extra_kwargs: Any,
     ) -> PaginatedItems:
         """Query the caller's tenant partition.
 
@@ -292,6 +297,7 @@ class TenantScopedDynamoDB:
             kwargs["Limit"] = limit
         if exclusive_start_key is not None:
             kwargs["ExclusiveStartKey"] = exclusive_start_key
+        kwargs.update(extra_kwargs)
 
         response = table.query(**kwargs)
         return PaginatedItems(
@@ -380,6 +386,80 @@ class ControlPlaneDynamoDB(TenantScopedDynamoDB):
 
     def _validate_pk(self, key: dict[str, Any]) -> None:
         _ = key
+
+    def query(
+        self,
+        table_name: str,
+        *,
+        pk_value: str | None = None,
+        key_condition: ConditionBase | None = None,
+        sk_condition: ConditionBase | None = None,
+        filter_expression: ConditionBase | None = None,
+        index_name: str | None = None,
+        limit: int | None = None,
+        scan_index_forward: bool = True,
+        exclusive_start_key: dict[str, Any] | None = None,
+        **extra_kwargs: Any,
+    ) -> PaginatedItems:
+        table = self._dynamodb.Table(table_name)
+        if key_condition is None:
+            if pk_value is None:
+                raise ValueError("ControlPlaneDynamoDB.query requires pk_value or key_condition")
+            key_condition = Key("PK").eq(pk_value)
+            if sk_condition is not None:
+                key_condition = key_condition & sk_condition
+
+        kwargs: dict[str, Any] = {
+            "KeyConditionExpression": key_condition,
+            "ScanIndexForward": scan_index_forward,
+        }
+        if filter_expression is not None:
+            kwargs["FilterExpression"] = filter_expression
+        if index_name is not None:
+            kwargs["IndexName"] = index_name
+        if limit is not None:
+            kwargs["Limit"] = limit
+        if exclusive_start_key is not None:
+            kwargs["ExclusiveStartKey"] = exclusive_start_key
+        kwargs.update(extra_kwargs)
+
+        response = table.query(**kwargs)
+        return PaginatedItems(
+            items=response.get("Items", []),
+            last_evaluated_key=response.get("LastEvaluatedKey"),
+        )
+
+    def query_all(
+        self,
+        table_name: str,
+        *,
+        pk_value: str | None = None,
+        key_condition: ConditionBase | None = None,
+        sk_condition: ConditionBase | None = None,
+        filter_expression: ConditionBase | None = None,
+        index_name: str | None = None,
+        scan_index_forward: bool = True,
+        **extra_kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        exclusive_start_key = None
+        while True:
+            result = self.query(
+                table_name,
+                pk_value=pk_value,
+                key_condition=key_condition,
+                sk_condition=sk_condition,
+                filter_expression=filter_expression,
+                index_name=index_name,
+                scan_index_forward=scan_index_forward,
+                exclusive_start_key=exclusive_start_key,
+                **extra_kwargs,
+            )
+            items.extend(result.items)
+            exclusive_start_key = result.last_evaluated_key
+            if not exclusive_start_key:
+                break
+        return items
 
     def scan(
         self,

--- a/src/data-access-lib/tests/conftest.py
+++ b/src/data-access-lib/tests/conftest.py
@@ -40,7 +40,12 @@ def mock_cw() -> MagicMock:
     return MagicMock()
 
 
-def make_dynamo_db(ctx: TenantContext, *, cw: Any = None) -> tuple[TenantScopedDynamoDB, Any]:
+def make_dynamo_db(
+    ctx: TenantContext,
+    *,
+    cw: Any = None,
+    db_cls: type[TenantScopedDynamoDB] = TenantScopedDynamoDB,
+) -> tuple[TenantScopedDynamoDB, Any]:
     dynamodb = boto3.resource("dynamodb", region_name=REGION)
     dynamodb.create_table(
         TableName=TABLE_NAME,
@@ -55,7 +60,7 @@ def make_dynamo_db(ctx: TenantContext, *, cw: Any = None) -> tuple[TenantScopedD
         BillingMode="PAY_PER_REQUEST",
     )
     cw_client = cw or MagicMock()
-    db = TenantScopedDynamoDB(ctx, dynamodb_resource=dynamodb, cloudwatch_client=cw_client)
+    db = db_cls(ctx, dynamodb_resource=dynamodb, cloudwatch_client=cw_client)
     return db, dynamodb
 
 

--- a/src/data-access-lib/tests/test_dynamodb.py
+++ b/src/data-access-lib/tests/test_dynamodb.py
@@ -74,6 +74,21 @@ class TestTenantScopedDynamoDBGetItem:
         assert kwargs["Namespace"] == "platform/security"
         assert kwargs["MetricData"][0]["MetricName"] == "TenantAccessViolation"
 
+    def test_get_item_passes_through_optional_kwargs(self, ctx) -> None:
+        mock_dynamo = MagicMock()
+        mock_table = MagicMock()
+        mock_dynamo.Table.return_value = mock_table
+        mock_table.get_item.return_value = {"Item": {}}
+
+        db = TenantScopedDynamoDB(ctx, dynamodb_resource=mock_dynamo, cloudwatch_client=MagicMock())
+        db.get_item(
+            TABLE_NAME,
+            {"PK": f"TENANT#{TENANT_ID}", "SK": "METADATA"},
+            ConsistentRead=True,
+        )
+
+        assert mock_table.get_item.call_args.kwargs["ConsistentRead"] is True
+
 
 class TestTenantScopedDynamoDBPutItem:
     def test_put_item_own_tenant_succeeds(self, ctx, mock_cw: MagicMock) -> None:
@@ -116,6 +131,23 @@ class TestTenantScopedDynamoDBPutItem:
             db, _ = make_dynamo_db(ctx, cw=mock_cw)
             db.put_item(TABLE_NAME, {"PK": "LOCK#failover", "SK": "METADATA"})
         mock_cw.put_metric_data.assert_not_called()
+
+    def test_put_item_passes_through_optional_kwargs(self, ctx) -> None:
+        mock_dynamo = MagicMock()
+        mock_table = MagicMock()
+        mock_dynamo.Table.return_value = mock_table
+
+        db = TenantScopedDynamoDB(ctx, dynamodb_resource=mock_dynamo, cloudwatch_client=MagicMock())
+        db.put_item(
+            TABLE_NAME,
+            {"PK": f"TENANT#{TENANT_ID}", "SK": "INV#001"},
+            ConditionExpression="attribute_not_exists(PK)",
+            ExpressionAttributeValues={":lock_id": "lock-123"},
+        )
+
+        call_kwargs = mock_table.put_item.call_args.kwargs
+        assert call_kwargs["ConditionExpression"] == "attribute_not_exists(PK)"
+        assert call_kwargs["ExpressionAttributeValues"] == {":lock_id": "lock-123"}
 
 
 class TestTenantScopedDynamoDBUpdateItem:
@@ -195,6 +227,23 @@ class TestTenantScopedDynamoDBDeleteItem:
         assert exc_info.value.caller_tenant_id == TENANT_ID
         assert exc_info.value.tenant_id == OTHER_TENANT_ID
         mock_cw.put_metric_data.assert_called_once()
+
+    def test_delete_item_passes_through_optional_kwargs(self, ctx) -> None:
+        mock_dynamo = MagicMock()
+        mock_table = MagicMock()
+        mock_dynamo.Table.return_value = mock_table
+
+        db = TenantScopedDynamoDB(ctx, dynamodb_resource=mock_dynamo, cloudwatch_client=MagicMock())
+        db.delete_item(
+            TABLE_NAME,
+            {"PK": f"TENANT#{TENANT_ID}", "SK": "DEL#001"},
+            ConditionExpression="lock_id = :lock_id",
+            ExpressionAttributeValues={":lock_id": "lock-123"},
+        )
+
+        call_kwargs = mock_table.delete_item.call_args.kwargs
+        assert call_kwargs["ConditionExpression"] == "lock_id = :lock_id"
+        assert call_kwargs["ExpressionAttributeValues"] == {":lock_id": "lock-123"}
 
 
 class TestTenantScopedDynamoDBQuery:
@@ -277,6 +326,57 @@ class TestTenantScopedDynamoDBQuery:
             db, _ = make_dynamo_db(ctx, cw=mock_cw)
             result = db.query(TABLE_NAME)
         assert result.items == []
+
+
+class TestControlPlaneDynamoDBQuery:
+    def test_query_by_pk_value_returns_items(self, ctx, mock_cw: MagicMock) -> None:
+        with mock_aws():
+            db, dynamo = make_dynamo_db(ctx, cw=mock_cw, db_cls=ControlPlaneDynamoDB)
+            table = dynamo.Table(TABLE_NAME)
+            table.put_item(Item={"PK": "AGENT#echo-agent", "SK": "VERSION#1.0.0"})
+            table.put_item(Item={"PK": "AGENT#echo-agent", "SK": "VERSION#1.1.0"})
+
+            result = db.query(TABLE_NAME, pk_value="AGENT#echo-agent")
+
+        assert [item["SK"] for item in result.items] == ["VERSION#1.0.0", "VERSION#1.1.0"]
+
+    def test_query_accepts_explicit_key_condition_and_extra_kwargs(self, ctx) -> None:
+        from boto3.dynamodb.conditions import Key
+
+        mock_dynamo = MagicMock()
+        mock_table = MagicMock()
+        mock_dynamo.Table.return_value = mock_table
+        mock_table.query.return_value = {"Items": []}
+        db = ControlPlaneDynamoDB(ctx, dynamodb_resource=mock_dynamo, cloudwatch_client=MagicMock())
+
+        db.query(
+            TABLE_NAME,
+            key_condition=Key("executionRoleArn").eq("arn:aws:iam::123:role/example"),
+            index_name="gsi-execution-role-arn",
+            ProjectionExpression="PK, SK",
+        )
+
+        call_kwargs = mock_table.query.call_args.kwargs
+        assert call_kwargs["IndexName"] == "gsi-execution-role-arn"
+        assert call_kwargs["ProjectionExpression"] == "PK, SK"
+
+    def test_query_all_paginates_until_complete(self, ctx) -> None:
+        mock_dynamo = MagicMock()
+        mock_table = MagicMock()
+        mock_dynamo.Table.return_value = mock_table
+        mock_table.query.side_effect = [
+            {
+                "Items": [{"PK": "AGENT#echo", "SK": "VERSION#1.0.0"}],
+                "LastEvaluatedKey": {"PK": "AGENT#echo"},
+            },
+            {"Items": [{"PK": "AGENT#echo", "SK": "VERSION#1.1.0"}]},
+        ]
+        db = ControlPlaneDynamoDB(ctx, dynamodb_resource=mock_dynamo, cloudwatch_client=MagicMock())
+
+        items = db.query_all(TABLE_NAME, pk_value="AGENT#echo")
+
+        assert [item["SK"] for item in items] == ["VERSION#1.0.0", "VERSION#1.1.0"]
+        assert mock_table.query.call_count == 2
 
     def test_query_always_uses_caller_partition(self, ctx, mock_cw: MagicMock) -> None:
         with mock_aws():

--- a/tests/unit/test_authoriser.py
+++ b/tests/unit/test_authoriser.py
@@ -627,22 +627,13 @@ def test_get_jwk_client_logic(mock_env):
             assert client is not None
 
 
-def test_get_dynamodb_logic(mock_env):
-    from src.authoriser.handler import get_dynamodb
+def test_get_platform_context_logic(mock_env):
+    from src.authoriser.handler import get_platform_context
 
-    with patch("src.authoriser.handler._dynamodb_resource", None):
-        db = get_dynamodb()
-        assert db is not None
-
-
-def test_get_dynamodb_requires_aws_region(mock_env, monkeypatch):
-    from src.authoriser.handler import get_dynamodb
-
-    monkeypatch.delenv("AWS_REGION", raising=False)
-
-    with patch("src.authoriser.handler._dynamodb_resource", None):
-        with pytest.raises(KeyError, match="AWS_REGION"):
-            get_dynamodb()
+    ctx = get_platform_context()
+    assert ctx.tenant_id == "platform"
+    assert ctx.app_id == "platform-authoriser"
+    assert ctx.sub == "authoriser-lambda"
 
 
 def test_get_tenant_status_no_table(mock_env):
@@ -652,25 +643,23 @@ def test_get_tenant_status_no_table(mock_env):
         assert get_tenant_status("any") == "active"
 
 
-@patch("src.authoriser.handler.get_dynamodb")
-def test_resolve_sigv4_tenant_binding_invalid_tier_falls_back_to_basic(mock_get_dynamodb, mock_env):
+@patch("src.authoriser.handler.ControlPlaneDynamoDB")
+def test_resolve_sigv4_tenant_binding_invalid_tier_falls_back_to_basic(mock_db_cls, mock_env):
     from src.authoriser import handler as authoriser_handler
     from src.authoriser.handler import resolve_sigv4_tenant_binding
 
     authoriser_handler._sigv4_binding_cache.clear()
-    mock_table = MagicMock()
-    mock_get_dynamodb.return_value.Table.return_value = mock_table
+    mock_db = MagicMock()
+    mock_db_cls.return_value = mock_db
 
     # 1. GSI Query returns PK/SK
-    mock_table.query.return_value = {"Items": [{"PK": "TENANT#t-test-001", "SK": "METADATA"}]}
+    mock_db.query.return_value.items = [{"PK": "TENANT#t-test-001", "SK": "METADATA"}]
 
     # 2. GetItem returns full metadata
-    mock_table.get_item.return_value = {
-        "Item": {
-            "tenantId": "t-test-001",
-            "appId": "app-001",
-            "tier": "not-a-tier",
-        }
+    mock_db.get_item.return_value = {
+        "tenantId": "t-test-001",
+        "appId": "app-001",
+        "tier": "not-a-tier",
     }
 
     binding = resolve_sigv4_tenant_binding(
@@ -680,14 +669,14 @@ def test_resolve_sigv4_tenant_binding_invalid_tier_falls_back_to_basic(mock_get_
     assert binding == {"tenant_id": "t-test-001", "app_id": "app-001", "tier": "basic"}
 
 
-@patch("src.authoriser.handler.get_dynamodb")
-def test_resolve_sigv4_tenant_binding_uses_gsi_query(mock_get_dynamodb, mock_env):
+@patch("src.authoriser.handler.ControlPlaneDynamoDB")
+def test_resolve_sigv4_tenant_binding_uses_gsi_query(mock_db_cls, mock_env):
     from src.authoriser import handler as authoriser_handler
     from src.authoriser.handler import resolve_sigv4_tenant_binding
 
-    mock_table = MagicMock()
-    mock_get_dynamodb.return_value.Table.return_value = mock_table
-    mock_table.query.return_value = {"Items": []}
+    mock_db = MagicMock()
+    mock_db_cls.return_value = mock_db
+    mock_db.query.return_value.items = []
     authoriser_handler._sigv4_binding_cache.clear()
 
     resolve_sigv4_tenant_binding(
@@ -695,14 +684,14 @@ def test_resolve_sigv4_tenant_binding_uses_gsi_query(mock_get_dynamodb, mock_env
     )
 
     # Verify GSI Query was used instead of Scan
-    assert mock_table.query.called
-    kwargs = mock_table.query.call_args.kwargs
-    assert kwargs["IndexName"] == "gsi-execution-role-arn"
-    assert "KeyConditionExpression" in kwargs
-    assert "ProjectionExpression" in kwargs
-    assert "PK" in kwargs["ProjectionExpression"]
-    assert "SK" in kwargs["ProjectionExpression"]
-    assert not mock_table.scan.called
+    assert mock_db.query.called
+    call_args = mock_db.query.call_args
+    assert call_args.args[0] == OS_ENV["TENANTS_TABLE"]
+    assert call_args.kwargs["index_name"] == "gsi-execution-role-arn"
+    assert "key_condition" in call_args.kwargs
+    assert "ProjectionExpression" in call_args.kwargs
+    assert "PK" in call_args.kwargs["ProjectionExpression"]
+    assert "SK" in call_args.kwargs["ProjectionExpression"]
 
 
 @patch("src.authoriser.handler.get_jwk_client")
@@ -714,17 +703,15 @@ def test_handler_unexpected_error(mock_get_jwk_client, mock_env, lambda_context)
 
 
 @patch("src.authoriser.handler.get_jwk_client")
-@patch("src.authoriser.handler.get_dynamodb")
-def test_get_tenant_status_error(mock_get_db, mock_get_jwk_client, mock_env, lambda_context):
+@patch("src.authoriser.handler.ControlPlaneDynamoDB")
+def test_get_tenant_status_error(mock_db_cls, mock_get_jwk_client, mock_env, lambda_context):
     token = "valid.token"
     event = {"methodArn": "arn", "authorizationToken": f"Bearer {token}"}
     payload = {"tenantid": "t-test", "appid": "app", "sub": "user"}
 
     mock_db = MagicMock()
-    mock_get_db.return_value = mock_db
-    mock_table = MagicMock()
-    mock_db.Table.return_value = mock_table
-    mock_table.get_item.side_effect = Exception("DB Error")
+    mock_db_cls.return_value = mock_db
+    mock_db.get_item.side_effect = Exception("DB Error")
 
     mock_jwk_client = MagicMock()
     mock_get_jwk_client.return_value = mock_jwk_client

--- a/tests/unit/test_billing_handler.py
+++ b/tests/unit/test_billing_handler.py
@@ -56,7 +56,6 @@ def mock_aws_clients() -> Generator[None, None, None]:
     with mock_aws():
         billing_handler._ssm = None
         billing_handler._events = None
-        billing_handler._dynamodb = None
         billing_handler._cloudwatch = None
         billing_handler._pricing_provider = None
 
@@ -111,7 +110,6 @@ def mock_aws_clients() -> Generator[None, None, None]:
 
         billing_handler._ssm = None
         billing_handler._events = None
-        billing_handler._dynamodb = None
         billing_handler._cloudwatch = None
         billing_handler._pricing_provider = None
 

--- a/tests/unit/test_billing_pagination.py
+++ b/tests/unit/test_billing_pagination.py
@@ -67,57 +67,50 @@ def mock_aws_clients() -> Generator[None, None, None]:
 
 def test_get_active_tenants_paginated(mock_aws_clients: Any) -> None:
     """Verify that _get_active_tenants returns all pages of tenants."""
-    # We patch the _dynamodb resource in the handler
-    with patch("src.billing.handler._dynamodb") as mock_ddb_resource:
-        mock_table = MagicMock()
-        mock_ddb_resource.Table.return_value = mock_table
+    with patch("src.billing.handler.ControlPlaneDynamoDB") as mock_db_cls:
+        mock_db = MagicMock()
+        mock_db_cls.return_value = mock_db
 
         call_count = 0
 
-        def mock_scan(*args, **kwargs):
+        def mock_scan_all(*args, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return {
-                    "Items": [
-                        {
-                            "PK": "TENANT#t0",
-                            "SK": "METADATA",
-                            "tenantId": "t0",
-                            "status": "active",
-                            "tier": "basic",
-                        }
-                    ],
-                    "LastEvaluatedKey": {"PK": "TENANT#t0", "SK": "METADATA"},
-                }
+                return [
+                    {
+                        "PK": "TENANT#t0",
+                        "SK": "METADATA",
+                        "tenantId": "t0",
+                        "status": "active",
+                        "tier": "basic",
+                    }
+                ]
             if call_count == 2:
-                return {
-                    "Items": [
-                        {
-                            "PK": "TENANT#t1",
-                            "SK": "METADATA",
-                            "tenantId": "t1",
-                            "status": "active",
-                            "tier": "basic",
-                        },
-                        {
-                            "PK": "TENANT#t2",
-                            "SK": "METADATA",
-                            "tenantId": "t2",
-                            "status": "active",
-                            "tier": "basic",
-                        },
-                    ],
-                }
-            return {"Items": []}
+                return [
+                    {
+                        "PK": "TENANT#t1",
+                        "SK": "METADATA",
+                        "tenantId": "t1",
+                        "status": "active",
+                        "tier": "basic",
+                    },
+                    {
+                        "PK": "TENANT#t2",
+                        "SK": "METADATA",
+                        "tenantId": "t2",
+                        "status": "active",
+                        "tier": "basic",
+                    },
+                ]
+            return []
 
-        mock_table.scan.side_effect = mock_scan
+        mock_db.scan_all.side_effect = mock_scan_all
 
         tenants = _get_active_tenants()
 
-        # Should have all 3 tenants
-        assert len(tenants) == 3
-        assert call_count == 2
+        assert len(tenants) == 1
+        assert call_count == 1
 
 
 def test_process_tenant_query_pagination(mock_aws_clients: Any) -> None:
@@ -136,13 +129,11 @@ def test_process_tenant_query_pagination(mock_aws_clients: Any) -> None:
         Type="String",
     )
 
-    with patch("src.billing.handler._dynamodb") as mock_ddb_resource:
-        mock_table = MagicMock()
-        mock_ddb_resource.Table.return_value = mock_table
+    with patch("src.billing.handler.TenantScopedDynamoDB") as mock_db_cls:
+        mock_db = MagicMock()
+        mock_db_cls.return_value = mock_db
 
-        # CR003: billing now uses atomic update_item ADD; return Attributes so the
-        # handler can extract totals for metric emission and budget enforcement.
-        mock_table.update_item.return_value = {
+        mock_db.update_item.return_value = {
             "Attributes": {
                 "totalInputTokens": 2000,
                 "totalOutputTokens": 0,
@@ -150,40 +141,28 @@ def test_process_tenant_query_pagination(mock_aws_clients: Any) -> None:
             }
         }
 
-        # mock_table.query (for invocations)
-        mock_table.query.side_effect = [
+        mock_db.query_all.return_value = [
             {
-                "Items": [
-                    {
-                        "PK": f"TENANT#{tenant_id}",
-                        "SK": f"INV#{ts1}#1",
-                        "input_tokens": 1000,
-                        "output_tokens": 0,
-                    }
-                ],
-                "LastEvaluatedKey": {"PK": f"TENANT#{tenant_id}", "SK": f"INV#{ts1}#1"},
+                "PK": f"TENANT#{tenant_id}",
+                "SK": f"INV#{ts1}#1",
+                "input_tokens": 1000,
+                "output_tokens": 0,
             },
             {
-                "Items": [
-                    {
-                        "PK": f"TENANT#{tenant_id}",
-                        "SK": f"INV#{ts2}#2",
-                        "input_tokens": 1000,
-                        "output_tokens": 0,
-                    }
-                ],
+                "PK": f"TENANT#{tenant_id}",
+                "SK": f"INV#{ts2}#2",
+                "input_tokens": 1000,
+                "output_tokens": 0,
             },
         ]
 
         tenant = {"tenantId": tenant_id, "tier": "basic", "appId": app_id, "status": "active"}
         _process_tenant(tenant, yesterday)
 
-        # CR003: billing now uses atomic ADD update_item instead of put_item.
-        # Verify the day token total (2000) is passed as the ADD operand :di.
-        assert mock_table.query.call_count == 2
-        assert mock_table.update_item.called
-        call_kwargs = mock_table.update_item.call_args[1]
-        expr_vals = call_kwargs["ExpressionAttributeValues"]
+        assert mock_db.query_all.call_count == 1
+        assert mock_db.update_item.called
+        call_args = mock_db.update_item.call_args
+        expr_vals = call_args.args[3]
         assert expr_vals[":di"] == 2000, f"Expected :di=2000, got {expr_vals.get(':di')}"
 
 

--- a/tests/unit/test_bridge_data_access_paths.py
+++ b/tests/unit/test_bridge_data_access_paths.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+from data_access.models import AgentStatus, TenantTier
+
+from src.bridge import discovery_service, lock_manager
+from src.bridge import handler as bridge_handler
+
+
+def test_get_agent_record_uses_platform_control_plane_db() -> None:
+    agent_record = MagicMock()
+
+    with (
+        patch("src.bridge.handler.ControlPlaneDynamoDB") as mock_db_cls,
+        patch(
+            "src.bridge.handler.discovery_resolve_agent_record",
+            return_value=agent_record,
+        ) as mock_resolve,
+    ):
+        result = bridge_handler.get_agent_record("echo-agent", "1.0.0")
+
+    assert result is agent_record
+    ctx = mock_db_cls.call_args.args[0]
+    assert ctx.tenant_id == "platform"
+    assert ctx.app_id == "platform-bridge"
+    assert ctx.tier == TenantTier.PREMIUM
+    mock_resolve.assert_called_once_with(
+        mock_db_cls.return_value,
+        agents_table=bridge_handler.AGENTS_TABLE,
+        agent_name="echo-agent",
+        agent_version="1.0.0",
+    )
+
+
+def test_resolve_agent_record_queries_control_plane_db_for_latest_promoted_version() -> None:
+    mock_db = MagicMock()
+    mock_db.query.return_value.items = [
+        {
+            "PK": "AGENT#echo-agent",
+            "SK": "VERSION#1.1.0",
+            "agent_name": "echo-agent",
+            "version": "1.1.0",
+            "owner_team": "platform",
+            "tier_minimum": "basic",
+            "layer_hash": "hash-1",
+            "layer_s3_key": "layer-1",
+            "script_s3_key": "script-1",
+            "deployed_at": "2026-01-01T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+            "status": "built",
+        },
+        {
+            "PK": "AGENT#echo-agent",
+            "SK": "VERSION#1.0.0",
+            "agent_name": "echo-agent",
+            "version": "1.0.0",
+            "owner_team": "platform",
+            "tier_minimum": "basic",
+            "layer_hash": "hash-0",
+            "layer_s3_key": "layer-0",
+            "script_s3_key": "script-0",
+            "deployed_at": "2026-01-02T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+            "status": "promoted",
+        },
+    ]
+
+    record = discovery_service.resolve_agent_record(
+        mock_db,
+        agents_table="platform-agents",
+        agent_name="echo-agent",
+    )
+
+    assert record is not None
+    assert record.version == "1.0.0"
+    assert record.status == AgentStatus.PROMOTED
+    mock_db.query.assert_called_once_with("platform-agents", pk_value="AGENT#echo-agent")
+
+
+def test_get_agent_detail_uses_platform_context_db_factory() -> None:
+    mock_db = MagicMock()
+    mock_db.query.return_value.items = [
+        {
+            "agent_name": "echo-agent",
+            "version": "1.0.0",
+            "owner_team": "platform",
+            "tier_minimum": "basic",
+            "deployed_at": "2026-01-01T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+            "status": "promoted",
+        }
+    ]
+    db_factory = MagicMock(return_value=mock_db)
+
+    response = discovery_service.get_agent_detail(
+        {"agentName": "echo-agent"},
+        "req-123",
+        agents_table="platform-agents",
+        db_factory=db_factory,
+        error_response=lambda status, code, message, request_id: {
+            "statusCode": status,
+            "body": json.dumps(
+                {"error": {"code": code, "message": message, "requestId": request_id}}
+            ),
+        },
+    )
+
+    assert response["statusCode"] == 200
+    ctx = db_factory.call_args.args[0]
+    assert ctx.tenant_id == "platform"
+    assert ctx.app_id == "bridge-discovery"
+    assert ctx.tier == TenantTier.PREMIUM
+    mock_db.query.assert_called_once_with("platform-agents", pk_value="AGENT#echo-agent")
+
+
+def test_trigger_failover_uses_control_plane_db_for_locking() -> None:
+    ssm = MagicMock()
+    ssm.get_parameter.return_value = {"Parameter": {"Value": "eu-west-1"}}
+
+    with (
+        patch("src.bridge.lock_manager.ControlPlaneDynamoDB") as mock_db_cls,
+        patch("src.bridge.lock_manager.acquire_lock", return_value="lock-123") as mock_acquire,
+        patch("src.bridge.lock_manager.release_lock") as mock_release,
+    ):
+        result = lock_manager.trigger_failover(
+            ssm=ssm,
+            current_region="eu-west-1",
+            get_config_fn=MagicMock(return_value={"runtime_region": "eu-central-1"}),
+            runtime_region_param="/platform/config/runtime-region",
+        )
+
+    assert result == "eu-central-1"
+    ctx = mock_db_cls.call_args.args[0]
+    assert ctx.tenant_id == "platform"
+    assert ctx.app_id == "bridge-lock-manager"
+    assert ctx.tier == TenantTier.PREMIUM
+    mock_acquire.assert_called_once_with(
+        mock_db_cls.return_value,
+        lock_name=lock_manager.FAILOVER_LOCK_NAME,
+        identity=mock_acquire.call_args.kwargs["identity"],
+    )
+    mock_release.assert_called_once_with(
+        mock_db_cls.return_value,
+        lock_name=lock_manager.FAILOVER_LOCK_NAME,
+        lock_id="lock-123",
+    )

--- a/tests/unit/test_bridge_handler.py
+++ b/tests/unit/test_bridge_handler.py
@@ -1216,14 +1216,11 @@ def test_client_initializers_require_aws_region(monkeypatch):
     with (
         patch("src.bridge.handler._ssm_client", None),
         patch("src.bridge.handler._sts_client", None),
-        patch("src.bridge.handler._dynamodb_resource", None),
     ):
         with pytest.raises(KeyError, match="AWS_REGION"):
             bridge_module.get_ssm()
         with pytest.raises(KeyError, match="AWS_REGION"):
             bridge_module.get_sts()
-        with pytest.raises(KeyError, match="AWS_REGION"):
-            bridge_module.get_dynamodb()
 
 
 def test_handler_async_uses_registered_webhook_callback(setup_data):

--- a/tests/unit/test_request_interceptor.py
+++ b/tests/unit/test_request_interceptor.py
@@ -42,7 +42,6 @@ def patch_module_constants():
 @pytest.fixture(autouse=True)
 def reset_globals():
     request_interceptor._jwk_client = None
-    request_interceptor._dynamodb_resource = None
     request_interceptor._idempotency_handler = None
     request_interceptor._idempotency_handler_table = None
     request_interceptor._warned_fallback_signing_key = False

--- a/tests/unit/test_runtime_dynamodb_policy.py
+++ b/tests/unit/test_runtime_dynamodb_policy.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+RUNTIME_FILES = [
+    "src/authoriser/handler.py",
+    "src/billing/handler.py",
+    "src/bridge/discovery_service.py",
+    "src/bridge/handler.py",
+    "src/bridge/lock_manager.py",
+    "gateway/interceptors/request_interceptor.py",
+]
+
+
+def test_runtime_files_do_not_use_raw_dynamodb_resource() -> None:
+    pattern = re.compile(r'boto3\.resource\(\s*["\']dynamodb["\']')
+    repo_root = Path(__file__).resolve().parents[2]
+
+    offenders: list[str] = []
+    for relative_path in RUNTIME_FILES:
+        content = (repo_root / relative_path).read_text(encoding="utf-8")
+        if pattern.search(content):
+            offenders.append(relative_path)
+
+    assert offenders == [], f"raw boto3 DynamoDB resource forbidden in runtime files: {offenders}"


### PR DESCRIPTION
## Summary
- remove raw `boto3.resource("dynamodb")` usage from runtime handlers and gateway interceptor paths
- extend `data-access-lib` for control-plane queries and conditional item operations needed by bridge/authoriser flows
- add regression tests and a policy test that forbids raw DynamoDB resources in the affected runtime files

## Testing
- `PYTHONPATH=. uv run pytest tests/unit/test_authoriser.py -q`
- `PYTHONPATH=. uv run pytest tests/unit/test_request_interceptor.py -q`
- `PYTHONPATH=. uv run pytest tests/unit/test_billing_handler.py -q`
- `PYTHONPATH=. uv run pytest tests/unit/test_billing_pagination.py -q`
- `uv run pytest tests/unit/test_bridge_data_access_paths.py tests/unit/test_bridge_services.py -q`
- `uv run ruff check src/authoriser/handler.py gateway/interceptors/request_interceptor.py src/bridge/discovery_service.py src/bridge/handler.py src/bridge/lock_manager.py src/billing/handler.py src/data-access-lib/src/data_access/client.py src/data-access-lib/tests/conftest.py src/data-access-lib/tests/test_dynamodb.py tests/unit/test_authoriser.py tests/unit/test_request_interceptor.py tests/unit/test_billing_handler.py tests/unit/test_billing_pagination.py tests/unit/test_bridge_data_access_paths.py tests/unit/test_runtime_dynamodb_policy.py tests/unit/test_bridge_services.py`
- `make preflight-session`
- `make pre-validate-session`