### PR TITLE
fix: harden spa deep-link fallback and caching

### DIFF
--- a/infra/cdk/lib/platform-stack.ts
+++ b/infra/cdk/lib/platform-stack.ts
@@ -351,6 +351,23 @@ export class PlatformStack extends cdk.Stack {
       },
     });
 
+    const spaRouteRewriteFunction = new cloudfront.Function(this, 'SpaRouteRewriteFunction', {
+      comment: 'Rewrite SPA deep links to index.html without masking missing asset failures',
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri || '/';
+  var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
+
+  if (uri === '/' || lastSegment.indexOf('.') === -1) {
+    request.uri = '/index.html';
+  }
+
+  return request;
+}
+      `),
+    });
+
     this.spaDistribution = new cloudfront.CfnDistribution(this, 'SpaDistribution', {
       distributionConfig: {
         enabled: true,
@@ -364,20 +381,6 @@ export class PlatformStack extends cdk.Stack {
           includeCookies: false,
           prefix: 'spa-cloudfront/',
         },
-        customErrorResponses: [
-          {
-            errorCode: 403,
-            responsePagePath: '/index.html',
-            responseCode: 200,
-            errorCachingMinTtl: 0,
-          },
-          {
-            errorCode: 404,
-            responsePagePath: '/index.html',
-            responseCode: 200,
-            errorCachingMinTtl: 0,
-          },
-        ],
         origins: [
           {
             id: 'SpaS3Origin',
@@ -394,9 +397,27 @@ export class PlatformStack extends cdk.Stack {
           compress: true,
           allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
           cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
-          cachePolicyId: cloudfront.CachePolicy.CACHING_OPTIMIZED.cachePolicyId,
+          cachePolicyId: cloudfront.CachePolicy.CACHING_DISABLED.cachePolicyId,
           responseHeadersPolicyId: spaResponseHeadersPolicy.attrId,
+          functionAssociations: [
+            {
+              eventType: 'viewer-request',
+              functionArn: spaRouteRewriteFunction.functionArn,
+            },
+          ],
         },
+        cacheBehaviors: [
+          {
+            pathPattern: 'assets/*',
+            targetOriginId: 'SpaS3Origin',
+            viewerProtocolPolicy: 'redirect-to-https',
+            compress: true,
+            allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+            cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+            cachePolicyId: cloudfront.CachePolicy.CACHING_OPTIMIZED.cachePolicyId,
+            responseHeadersPolicyId: spaResponseHeadersPolicy.attrId,
+          },
+        ],
         restrictions: {
           geoRestriction: {
             restrictionType: 'none',

--- a/infra/cdk/test/platform-stack.test.ts
+++ b/infra/cdk/test/platform-stack.test.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { PlatformStack } from '../lib/platform-stack';
 
@@ -368,23 +369,41 @@ describe('PlatformStack (TASK-023)', () => {
     });
   });
 
-  test('configures CloudFront custom error responses for SPA route fallback', () => {
+  test('configures CloudFront route fallback without masking missing asset failures', () => {
+    template.resourceCountIs('AWS::CloudFront::Function', 1);
+
     template.hasResourceProperties('AWS::CloudFront::Distribution', {
       DistributionConfig: Match.objectLike({
-        CustomErrorResponses: [
-          {
-            ErrorCode: 403,
-            ResponseCode: 200,
-            ResponsePagePath: '/index.html',
-            ErrorCachingMinTTL: 0,
-          },
-          {
-            ErrorCode: 404,
-            ResponseCode: 200,
-            ResponsePagePath: '/index.html',
-            ErrorCachingMinTTL: 0,
-          },
-        ],
+        DefaultCacheBehavior: Match.objectLike({
+          FunctionAssociations: Match.arrayWith([
+            Match.objectLike({
+              EventType: 'viewer-request',
+              FunctionARN: Match.anyValue(),
+            }),
+          ]),
+        }),
+      }),
+    });
+
+    const distributions = template.findResources('AWS::CloudFront::Distribution');
+    const [distribution] = Object.values(distributions) as Array<{
+      Properties?: { DistributionConfig?: Record<string, unknown> };
+    }>;
+    expect(distribution.Properties?.DistributionConfig).not.toHaveProperty('CustomErrorResponses');
+  });
+
+  test('distinguishes SPA shell caching from immutable asset caching', () => {
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          CachePolicyId: cloudfront.CachePolicy.CACHING_DISABLED.cachePolicyId,
+        }),
+        CacheBehaviors: Match.arrayWith([
+          Match.objectLike({
+            PathPattern: 'assets/*',
+            CachePolicyId: cloudfront.CachePolicy.CACHING_OPTIMIZED.cachePolicyId,
+          }),
+        ]),
       }),
     });
   });


### PR DESCRIPTION
## Summary
- move SPA deep-link fallback to a viewer-request CloudFront Function that only rewrites extensionless routes
- split SPA shell and asset caching so `index.html` stays uncached while `assets/*` remains optimized
- add CDK regression coverage for the rewrite function and cache-policy split

## Validation
- cd infra/cdk && npx --no-install tsc --noEmit
- cd infra/cdk && npx --no-install jest --runInBand platform-stack.test.ts
- make preflight-session
- make pre-validate-session