### PR TITLE
refactor: harden spa api client streaming and retries

### DIFF
--- a/spa/src/api/client.test.ts
+++ b/spa/src/api/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { ApiClient, ApiError, type AccessTokenProvider, type TokenRequestOptions } from "./client";
+import { ApiClient, type AccessTokenProvider, type TokenRequestOptions } from "./client";
 
 function createResponse(status: number, body: unknown, contentType = "application/json"): Response {
   const payload = typeof body === "string" ? body : JSON.stringify(body);
@@ -65,7 +65,9 @@ describe("ApiClient", () => {
     const tokenProvider = vi.fn<AccessTokenProvider>().mockResolvedValue("token-1");
     const fetchImpl = vi
       .fn<typeof fetch>()
-      .mockResolvedValue(createResponse(403, { error: { code: "FORBIDDEN" } }));
+      .mockResolvedValue(
+        createResponse(503, { error: { code: "UPSTREAM_UNAVAILABLE" }, retryAfterSeconds: 30 }),
+      );
 
     const client = new ApiClient({
       baseUrl: "https://api.example.com",
@@ -73,7 +75,13 @@ describe("ApiClient", () => {
       fetchImpl,
     });
 
-    await expect(client.request("/v1/agents")).rejects.toBeInstanceOf(ApiError);
+    await expect(client.request("/v1/agents")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+      code: "UPSTREAM_UNAVAILABLE",
+      retryAfterSeconds: 30,
+      isRetryable: true,
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
@@ -159,5 +167,41 @@ describe("ApiClient", () => {
 
     await client.request("/v1/health");
     expect(observedOptions).toEqual([undefined]);
+  });
+
+  it("retries transient network failures for idempotent requests", async () => {
+    const tokenProvider = vi.fn<AccessTokenProvider>().mockResolvedValue("token-1");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("network down"))
+      .mockResolvedValueOnce(createResponse(200, { ok: true }));
+
+    const client = new ApiClient({
+      baseUrl: "https://api.example.com",
+      getAccessToken: tokenProvider,
+      fetchImpl,
+    });
+
+    await expect(client.request<{ ok: boolean }>("/v1/health")).resolves.toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry transient network failures for non-idempotent requests", async () => {
+    const tokenProvider = vi.fn<AccessTokenProvider>().mockResolvedValue("token-1");
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new TypeError("network down"));
+
+    const client = new ApiClient({
+      baseUrl: "https://api.example.com",
+      getAccessToken: tokenProvider,
+      fetchImpl,
+    });
+
+    await expect(
+      client.request("/v1/agents/echo-agent/invoke", {
+        method: "POST",
+        body: JSON.stringify({ input: "hello" }),
+      }),
+    ).rejects.toThrow("network down");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/spa/src/api/client.ts
+++ b/spa/src/api/client.ts
@@ -33,10 +33,31 @@ export type SseEvent = {
   raw: string;
 };
 
+type ApiErrorBody = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+  message?: string;
+  retryAfterSeconds?: number;
+};
+
+type RetryableRequest = {
+  path: string;
+  init?: RequestInit;
+  accept?: string;
+  retryNetworkErrors?: boolean;
+};
+
+const NETWORK_RETRY_DELAYS_MS = [200, 400];
+
 export class ApiError extends Error {
   readonly status: number;
   readonly response: Response;
   readonly body: unknown;
+  readonly code?: string;
+  readonly retryAfterSeconds?: number;
+  readonly isRetryable: boolean;
 
   constructor(message: string, response: Response, body: unknown) {
     super(message);
@@ -44,6 +65,11 @@ export class ApiError extends Error {
     this.status = response.status;
     this.response = response;
     this.body = body;
+
+    const parsedBody = isApiErrorBody(body) ? body : undefined;
+    this.code = parsedBody?.error?.code;
+    this.retryAfterSeconds = resolveRetryAfterSeconds(response, parsedBody);
+    this.isRetryable = isRetryableStatus(response.status);
   }
 }
 
@@ -51,11 +77,17 @@ export class ApiClient {
   private readonly baseUrl: string;
   private readonly getAccessToken: AccessTokenProvider;
   private readonly fetchImpl: typeof fetch;
+  private readonly requestExecutor: AuthenticatedRequestExecutor;
 
   constructor(options: ApiClientOptions) {
     this.baseUrl = (options.baseUrl ?? apiBaseUrl).replace(/\/+$/, "");
     this.getAccessToken = options.getAccessToken;
     this.fetchImpl = options.fetchImpl ?? fetch;
+    this.requestExecutor = new AuthenticatedRequestExecutor({
+      getAccessToken: this.getAccessToken,
+      fetchImpl: this.fetchImpl,
+      resolveUrl: (path) => this.resolveUrl(path),
+    });
   }
 
   async request<TResponse>(path: string, init?: RequestInit): Promise<TResponse> {
@@ -64,7 +96,11 @@ export class ApiClient {
   }
 
   async requestRaw(path: string, init?: RequestInit): Promise<Response> {
-    return this.requestWithAuth(path, init, false);
+    return this.requestExecutor.execute({
+      path,
+      init,
+      retryNetworkErrors: isIdempotentRequest(init),
+    });
   }
 
   async bffTokenRefresh(
@@ -111,75 +147,17 @@ export class ApiClient {
   }
 
   async *stream(path: string, init?: RequestInit): AsyncGenerator<SseEvent> {
-    const requestInit: RequestInit = {
-      ...init,
-      headers: mergeHeaders(init?.headers, {
-        Accept: "text/event-stream",
-      }),
-    };
-
-    const response = await this.requestWithAuth(path, requestInit, false);
+    const response = await this.requestExecutor.execute({
+      path,
+      init,
+      accept: "text/event-stream",
+      retryNetworkErrors: false,
+    });
     if (!response.body) {
       throw new Error("Expected streaming response body");
     }
 
-    const decoder = new TextDecoder();
-    const reader = response.body.getReader();
-    let buffer = "";
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-
-      buffer += decoder.decode(value, { stream: true });
-      const messages = extractSseMessages(buffer);
-      buffer = messages.remainder;
-      for (const message of messages.events) {
-        yield message;
-      }
-    }
-
-    buffer += decoder.decode();
-    if (buffer.trim()) {
-      const message = parseSseEvent(buffer);
-      if (message) {
-        yield message;
-      }
-    }
-  }
-
-  private async requestWithAuth(
-    path: string,
-    init: RequestInit | undefined,
-    hasRetried: boolean,
-  ): Promise<Response> {
-    const token = await this.getAccessToken(
-      hasRetried
-        ? {
-            forceRefresh: true,
-            scopes: defaultScopes,
-          }
-        : undefined,
-    );
-
-    const response = await this.fetchImpl(this.resolveUrl(path), {
-      ...init,
-      headers: mergeHeaders(init?.headers, {
-        Authorization: `Bearer ${token}`,
-      }),
-    });
-
-    if (response.status === 401 && !hasRetried) {
-      return this.requestWithAuth(path, init, true);
-    }
-
-    if (!response.ok) {
-      throw await toApiError(response);
-    }
-
-    return response;
+    yield* new SseClient(response).read();
   }
 
   private resolveUrl(path: string): string {
@@ -190,22 +168,145 @@ export class ApiClient {
   }
 }
 
-function extractSseMessages(buffer: string): { events: SseEvent[]; remainder: string } {
-  const events: SseEvent[] = [];
-  let remainder = buffer;
+class AuthenticatedRequestExecutor {
+  private readonly getAccessToken: AccessTokenProvider;
+  private readonly fetchImpl: typeof fetch;
+  private readonly resolveUrl: (path: string) => string;
 
-  while (true) {
-    const boundary = remainder.indexOf("\n\n");
-    if (boundary === -1) {
-      return { events, remainder };
+  constructor(options: {
+    getAccessToken: AccessTokenProvider;
+    fetchImpl: typeof fetch;
+    resolveUrl: (path: string) => string;
+  }) {
+    this.getAccessToken = options.getAccessToken;
+    this.fetchImpl = options.fetchImpl;
+    this.resolveUrl = options.resolveUrl;
+  }
+
+  async execute(request: RetryableRequest): Promise<Response> {
+    let networkAttempt = 0;
+
+    while (true) {
+      try {
+        return await this.executeWithAuthRetry(request);
+      } catch (error) {
+        if (
+          !request.retryNetworkErrors ||
+          networkAttempt >= NETWORK_RETRY_DELAYS_MS.length ||
+          !isRetryableNetworkError(error)
+        ) {
+          throw error;
+        }
+
+        await waitForDelay(NETWORK_RETRY_DELAYS_MS[networkAttempt]);
+        networkAttempt += 1;
+      }
+    }
+  }
+
+  private async executeWithAuthRetry(request: RetryableRequest): Promise<Response> {
+    let forceRefresh = false;
+
+    while (true) {
+      const token = await this.getAccessToken(
+        forceRefresh
+          ? {
+              forceRefresh: true,
+              scopes: defaultScopes,
+            }
+          : undefined,
+      );
+
+      const response = await this.fetchImpl(this.resolveUrl(request.path), {
+        ...request.init,
+        headers: mergeHeaders(request.init?.headers, {
+          Authorization: `Bearer ${token}`,
+          ...(request.accept ? { Accept: request.accept } : {}),
+        }),
+      });
+
+      if (response.status === 401 && !forceRefresh) {
+        forceRefresh = true;
+        continue;
+      }
+
+      if (!response.ok) {
+        throw await toApiError(response);
+      }
+
+      return response;
+    }
+  }
+}
+
+class SseClient {
+  private readonly response: Response;
+
+  constructor(response: Response) {
+    this.response = response;
+  }
+
+  async *read(): AsyncGenerator<SseEvent> {
+    if (!this.response.body) {
+      throw new Error("Expected streaming response body");
     }
 
-    const chunk = remainder.slice(0, boundary);
-    remainder = remainder.slice(boundary + 2);
+    const decoder = new TextDecoder();
+    const reader = this.response.body.getReader();
+    const parser = new SseParser();
 
-    const parsed = parseSseEvent(chunk);
-    if (parsed) {
-      events.push(parsed);
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      for (const message of parser.push(decoder.decode(value, { stream: true }))) {
+        yield message;
+      }
+    }
+
+    for (const message of parser.flush(decoder.decode())) {
+      yield message;
+    }
+  }
+}
+
+class SseParser {
+  private buffer = "";
+
+  push(chunk: string): SseEvent[] {
+    this.buffer += chunk;
+    return this.drain();
+  }
+
+  flush(chunk = ""): SseEvent[] {
+    this.buffer += chunk;
+    if (!this.buffer.trim()) {
+      return [];
+    }
+
+    const finalEvent = parseSseEvent(this.buffer);
+    this.buffer = "";
+    return finalEvent ? [finalEvent] : [];
+  }
+
+  private drain(): SseEvent[] {
+    const events: SseEvent[] = [];
+
+    while (true) {
+      const boundary = this.buffer.indexOf("\n\n");
+      if (boundary === -1) {
+        return events;
+      }
+
+      const chunk = this.buffer.slice(0, boundary);
+      this.buffer = this.buffer.slice(boundary + 2);
+
+      const parsed = parseSseEvent(chunk);
+      if (parsed) {
+        events.push(parsed);
+      }
     }
   }
 }
@@ -282,6 +383,45 @@ async function toApiError(response: Response): Promise<ApiError> {
     ? await response.json()
     : await response.text();
   return new ApiError(`HTTP ${response.status}`, response, body);
+}
+
+function isApiErrorBody(body: unknown): body is ApiErrorBody {
+  return typeof body === "object" && body !== null;
+}
+
+function resolveRetryAfterSeconds(
+  response: Response,
+  body: ApiErrorBody | undefined,
+): number | undefined {
+  const retryAfterHeader = response.headers.get("retry-after");
+  if (retryAfterHeader) {
+    const parsed = Number.parseInt(retryAfterHeader, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return body?.retryAfterSeconds;
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function isIdempotentRequest(init: RequestInit | undefined): boolean {
+  const method = init?.method?.toUpperCase() ?? "GET";
+  return method === "GET" || method === "HEAD" || method === "OPTIONS";
+}
+
+function isRetryableNetworkError(error: unknown): boolean {
+  if (error instanceof DOMException) {
+    return error.name !== "AbortError";
+  }
+  return error instanceof TypeError;
+}
+
+async function waitForDelay(delayMs: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 // Global instance for convenience (populated after AuthProvider initialization or used with a mock)


### PR DESCRIPTION
## Summary
- extract authenticated request execution so auth refresh and transient network retry behavior live in one place
- move streaming decoding into dedicated SSE helpers instead of mixing parser state into the public client methods
- enrich `ApiError` with retry and code metadata and extend the client tests for transient failures

## Validation
- `cd spa && npx eslint src/api/client.ts src/api/client.test.ts --max-warnings 0`
- `cd spa && VITE_ENTRA_CLIENT_ID=test-client-id VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/test-tenant-id VITE_ENTRA_SCOPES=api://platform-dev/Agent.Invoke VITE_ENTRA_REDIRECT_URI=http://localhost:3000 VITE_ENTRA_POST_LOGOUT_REDIRECT_URI=http://localhost:3000 VITE_API_BASE_URL=https://api.example.test npx vitest run src/api/client.test.ts --coverage.enabled=false`
- `git push -u origin wt/task/179-refactor-spa-api-client` (repo pre-push validation passed)