### PR TITLE
docs: bound platform agent diagnostics surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -296,6 +296,29 @@ Operator
 Design rule: platform agents assist and orchestrate control-plane operations; they do
 not bypass the control plane.
 
+### Read-Only Platform-Agent Diagnostics Surface
+
+The bounded read-only platform-agent surface is intentionally narrow and limited to
+authoritative control-plane signals:
+
+- `GET /v1/platform/agents`: canonical release and governance state from
+  `platform-agents`
+- `GET /v1/platform/quota`: live quota utilisation from Service Quotas and CloudWatch
+- `GET /v1/platform/billing/status`: billing summaries from control-plane records
+
+These routes may be summarized by platform-agent runbook assistance because they
+stay within platform-owned control-plane state and do not require direct customer
+invocation content.
+
+The following are explicitly outside the read-only platform-agent diagnostics surface
+unless and until they are reintroduced with authoritative backing:
+
+- synthetic or de-scoped `/v1/platform/ops/*` summary endpoints
+- raw customer invocation/session convenience views
+- AG-UI bootstrap/runtime connectivity flows
+- mutating control-plane actions such as failover, release promotion, rollback, or
+  agent registration
+
 ## Configuration Ownership Model
 
 The platform splits configuration ownership by change semantics rather than by

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -848,7 +848,10 @@ paths:
       tags: [Platform]
       operationId: platformListAgents
       summary: List all agents for operators
-      description: Returns all registered agent versions with canonical release state and governance metadata.
+      description: >
+        Returns all registered agent versions with canonical release state and governance
+        metadata from `platform-agents`. This route is part of the bounded read-only
+        platform-agent diagnostics surface.
       x-required-roles:
         - Platform.Admin
         - Platform.Operator
@@ -945,7 +948,9 @@ paths:
       operationId: getPlatformQuota
       summary: Get platform quota status
       description: >
-        Returns the current AgentCore quota utilisation across regions.
+        Returns the current AgentCore quota utilisation across regions from authoritative
+        Service Quotas and CloudWatch signals. This route is part of the bounded read-only
+        platform-agent diagnostics surface.
       x-required-roles:
         - Platform.Admin
         - Platform.Operator
@@ -972,6 +977,51 @@ paths:
                           type: number
                         utilisationPercentage:
                           type: number
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/platform/billing/status:
+    get:
+      tags: [Platform]
+      operationId: getPlatformBillingStatus
+      summary: Get platform billing summaries
+      description: >
+        Returns monthly tenant billing summaries from authoritative control-plane billing
+        records. This route is part of the bounded read-only platform-agent diagnostics
+        surface.
+      x-required-roles:
+        - Platform.Admin
+        - Platform.Operator
+      responses:
+        "200":
+          description: Monthly billing summaries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  yearMonth:
+                    type: string
+                  summaries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        tenantId:
+                          type: string
+                        totalInputTokens:
+                          type: integer
+                        totalOutputTokens:
+                          type: integer
+                        totalCostUsd:
+                          type: number
+                        lastUpdated:
+                          type: string
+                          format: date-time
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":

--- a/src/tenant_api/ops_control.py
+++ b/src/tenant_api/ops_control.py
@@ -31,6 +31,14 @@ PLATFORM_ADMIN_PATHS = {
     "/v1/platform/billing/status",
 }
 
+READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES = frozenset(
+    {
+        ("GET", "/v1/platform/agents"),
+        ("GET", "/v1/platform/quota"),
+        ("GET", "/v1/platform/billing/status"),
+    }
+)
+
 
 def handle_platform_failover(
     event: dict[str, Any],

--- a/tests/unit/test_ops_api.py
+++ b/tests/unit/test_ops_api.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src.tenant_api import db_utils as tenant_api_db_utils
 from src.tenant_api import handler as tenant_api_handler
+from src.tenant_api import ops_control
 from tests.unit.test_tenant_api_handler import (
     FakeDynamoDbResource,
     FakeEvents,
@@ -145,3 +146,21 @@ def test_de_scoped_ops_routes_do_not_expose_placeholder_success(
 
     assert response["statusCode"] == 405
     assert _body(response)["error"]["code"] == "METHOD_NOT_ALLOWED"
+
+
+def test_platform_agent_read_only_surface_is_bounded_to_authoritative_routes() -> None:
+    assert ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES == {
+        ("GET", "/v1/platform/agents"),
+        ("GET", "/v1/platform/quota"),
+        ("GET", "/v1/platform/billing/status"),
+    }
+    assert ("POST", "/v1/platform/failover") not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
+    assert ("POST", "/v1/platform/agents") not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
+    assert (
+        ("GET", "/v1/platform/ops/top-tenants")
+        not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
+    )
+    assert (
+        ("GET", "/v1/platform/ops/tenants/{tenant}/invocations")
+        not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
+    )

--- a/tests/unit/test_ops_api.py
+++ b/tests/unit/test_ops_api.py
@@ -157,10 +157,10 @@ def test_platform_agent_read_only_surface_is_bounded_to_authoritative_routes() -
     assert ("POST", "/v1/platform/failover") not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
     assert ("POST", "/v1/platform/agents") not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
     assert (
-        ("GET", "/v1/platform/ops/top-tenants")
-        not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
-    )
+        "GET",
+        "/v1/platform/ops/top-tenants",
+    ) not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
     assert (
-        ("GET", "/v1/platform/ops/tenants/{tenant}/invocations")
-        not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES
-    )
+        "GET",
+        "/v1/platform/ops/tenants/{tenant}/invocations",
+    ) not in ops_control.READ_ONLY_PLATFORM_DIAGNOSTIC_ROUTES


### PR DESCRIPTION
## Summary
- document the bounded read-only platform-agent diagnostics surface in architecture and OpenAPI
- add the missing billing-status OpenAPI contract for the existing authoritative read-only route
- add a route-set constant and unit test that keep read-only diagnostics distinct from mutation and de-scoped synthetic ops paths

## Validation
- `uv run ruff check src/tenant_api/ops_control.py tests/unit/test_ops_api.py`
- `uv run pytest tests/unit/test_ops_api.py tests/unit/test_openapi_contract_routes.py -q`
- `git push -u origin wt/task/389-platform-agent-readonly-surface` (repo pre-push validation passed)