### PR TITLE
test: add repo guardrail checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # =============================================================================
 
 .PHONY: help help-all bootstrap ensure-tools validate-local validate-local-full
-.PHONY: validate-local-prereqs validate-python validate-openapi validate-cdk validate-cdk-ts validate-cdk-ts-push validate-cdk-synth
+.PHONY: validate-local-prereqs validate-python validate-openapi validate-guardrails validate-cdk validate-cdk-ts validate-cdk-ts-push validate-cdk-synth
 .PHONY: validate-pre-push validate-secrets-diff validate-secrets-push validate-secrets-full
 .PHONY: docs-sync-audit docs-sync-stamp rules-sync-audit
 .PHONY: dev dev-stop dev-logs dev-invoke
@@ -221,10 +221,15 @@ validate-python:
 	uv run ruff format --check .
 	cd infra/cdk && npx --no-install pyright --project ../../pyrightconfig.json
 	@$(MAKE) --no-print-directory validate-openapi
+	@$(MAKE) --no-print-directory validate-guardrails
 
 ## validate-openapi: Validate canonical OpenAPI route contract
 validate-openapi:
 	uv run pytest tests/unit/test_openapi_contract_routes.py
+
+## validate-guardrails: Validate repo safety guardrails for critical modules
+validate-guardrails:
+	uv run pytest tests/unit/test_runtime_dynamodb_policy.py tests/unit/test_repo_guardrails.py
 
 ## validate-agent-manifest: Validate agent pyproject.toml [tool.agentcore] section
 validate-agent-manifest:

--- a/tests/unit/test_repo_guardrails.py
+++ b/tests/unit/test_repo_guardrails.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SECURITY_CRITICAL_FILE_LIMITS = {
+    "src/bridge/handler.py": 650,
+    "src/authoriser/handler.py": 560,
+    "gateway/interceptors/request_interceptor.py": 600,
+    "gateway/interceptors/response_interceptor.py": 320,
+    "src/tenant_api/handler.py": 380,
+    "infra/cdk/lib/platform-stack.ts": 1250,
+}
+
+ALLOWED_PRODUCTION_HANDLER_IMPORTS = {
+    "src/tenant_api/admin_ops_handler.py",
+    "src/tenant_api/agent_registry_handler.py",
+    "src/tenant_api/ops_control.py",
+    "src/tenant_api/tenant_mgmt_handler.py",
+    "src/tenant_api/webhook_registry_handler.py",
+}
+
+
+def test_security_critical_files_stay_under_guardrail_limits() -> None:
+    offenders: list[str] = []
+
+    for relative_path, max_lines in SECURITY_CRITICAL_FILE_LIMITS.items():
+        line_count = sum(1 for _ in (REPO_ROOT / relative_path).open("r", encoding="utf-8"))
+        if line_count > max_lines:
+            offenders.append(f"{relative_path} ({line_count} > {max_lines})")
+
+    assert offenders == [], (
+        "security-critical modules exceeded size guardrails; split them before they become the "
+        f"next monolith: {offenders}"
+    )
+
+
+def test_production_code_does_not_add_new_handler_to_handler_imports() -> None:
+    patterns = (
+        re.compile(r"^\s*from\s+src\.[\w.]+\.handler\s+import\b", re.MULTILINE),
+        re.compile(r"^\s*from\s+src\.[\w.]+\s+import\s+handler\b", re.MULTILINE),
+        re.compile(r"^\s*import\s+handler\s+as\s+\w+", re.MULTILINE),
+    )
+
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "src").rglob("*.py")):
+        relative_path = path.relative_to(REPO_ROOT).as_posix()
+        if relative_path in ALLOWED_PRODUCTION_HANDLER_IMPORTS:
+            continue
+        content = path.read_text(encoding="utf-8")
+        if any(pattern.search(content) for pattern in patterns):
+            offenders.append(relative_path)
+
+    assert offenders == [], (
+        "production handler-to-handler imports are limited to explicit shim allowlist entries: "
+        f"{offenders}"
+    )


### PR DESCRIPTION
## Summary
- add a guardrail suite for oversized security-critical modules and new handler-to-handler production imports
- wire the guardrail suite into validate-python so it runs in the enforced pre-push path
- keep the checks small and baseline-oriented so they prevent new sprawl without blocking current cleanup work

Closes #427