### PR TITLE
test: enforce tenant api dynamodb boundary

### DIFF
--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -68,7 +68,6 @@ def _dependencies() -> TenantApiDependencies:
     return TenantApiDependencies(
         secretsmanager=session.client("secretsmanager"),
         events=session.client("events"),
-        dynamodb=session.resource("dynamodb"),
         ssm=session.client("ssm"),
         awslambda=session.client("lambda"),
         usage_client=_NoopUsageClient(),

--- a/src/tenant_api/models.py
+++ b/src/tenant_api/models.py
@@ -30,7 +30,6 @@ class CallerIdentity:
 class TenantApiDependencies:
     secretsmanager: Any
     events: Any
-    dynamodb: Any
     ssm: Any
     awslambda: Any
     usage_client: Any

--- a/tests/integration/test_platform_failover_route_integration.py
+++ b/tests/integration/test_platform_failover_route_integration.py
@@ -6,6 +6,7 @@ import json
 import sys
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import boto3
 from moto import mock_aws
@@ -78,10 +79,10 @@ def _failover_event(lock_id: str) -> dict[str, Any]:
         "body": json.dumps({"targetRegion": "eu-central-1", "lockId": lock_id}),
         "requestContext": {
             "authorizer": {
-                "tenantid": "t-admin",
+                "tenantid": "platform",
                 "appid": "app-admin",
                 "tier": "premium",
-                "sub": "user-123",
+                "sub": "ops@example.com",
                 "roles": ["Platform.Admin"],
             }
         },
@@ -119,10 +120,11 @@ def test_failover_route_updates_ssm_and_bridge_reads_new_runtime_region(monkeypa
         deps = tenant_api_handler.TenantApiDependencies(
             secretsmanager=_FakeSecretsManager(),
             events=_FakeEvents(),
-            dynamodb=ddb_resource,
             ssm=ssm,
+            awslambda=MagicMock(),
             usage_client=_FakeUsageClient(),
             memory_provisioner=_FakeMemoryProvisioner(),
+            platform_quota_client=MagicMock(),
         )
         monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
 
@@ -131,7 +133,7 @@ def test_failover_route_updates_ssm_and_bridge_reads_new_runtime_region(monkeypa
         )
 
         assert response["statusCode"] == 200
-        assert json.loads(response["body"])["status"] == "completed"
+        assert json.loads(response["body"])["status"] == "failover_executed"
 
         bridge_handler._ssm_client = None
         bridge_handler._config_cache = {}

--- a/tests/unit/test_billing_pagination.py
+++ b/tests/unit/test_billing_pagination.py
@@ -182,7 +182,6 @@ def test_platform_billing_status_pagination(mock_aws_clients: Any) -> None:
     deps = TenantApiDependencies(
         secretsmanager=MagicMock(),
         events=MagicMock(),
-        dynamodb=boto3.resource("dynamodb", region_name="eu-west-2"),
         ssm=MagicMock(),
         awslambda=MagicMock(),
         usage_client=MagicMock(),

--- a/tests/unit/test_ops_api.py
+++ b/tests/unit/test_ops_api.py
@@ -14,7 +14,6 @@ from src.tenant_api import db_utils as tenant_api_db_utils
 from src.tenant_api import handler as tenant_api_handler
 from src.tenant_api import ops_control
 from tests.unit.test_tenant_api_handler import (
-    FakeDynamoDbResource,
     FakeEvents,
     FakeLambdaClient,
     FakeMemoryProvisioner,
@@ -39,7 +38,6 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     deps = tenant_api_handler.TenantApiDependencies(
         secretsmanager=FakeSecretsManager(),
         events=FakeEvents(),
-        dynamodb=FakeDynamoDbResource(),
         ssm=FakeSsm(),
         awslambda=FakeLambdaClient(),
         usage_client=FakeUsageClient(),

--- a/tests/unit/test_runtime_dynamodb_policy.py
+++ b/tests/unit/test_runtime_dynamodb_policy.py
@@ -9,18 +9,23 @@ RUNTIME_FILES = [
     "src/bridge/discovery_service.py",
     "src/bridge/handler.py",
     "src/bridge/lock_manager.py",
+    "src/tenant_api/handler.py",
     "gateway/interceptors/request_interceptor.py",
 ]
 
 
 def test_runtime_files_do_not_use_raw_dynamodb_resource() -> None:
-    pattern = re.compile(r'boto3\.resource\(\s*["\']dynamodb["\']')
+    patterns = (
+        re.compile(r'boto3\.resource\(\s*["\']dynamodb["\']'),
+        re.compile(r'\bsession\.resource\(\s*["\']dynamodb["\']'),
+        re.compile(r'\bSession\([^)]*\)\.resource\(\s*["\']dynamodb["\']'),
+    )
     repo_root = Path(__file__).resolve().parents[2]
 
     offenders: list[str] = []
     for relative_path in RUNTIME_FILES:
         content = (repo_root / relative_path).read_text(encoding="utf-8")
-        if pattern.search(content):
+        if any(pattern.search(content) for pattern in patterns):
             offenders.append(relative_path)
 
     assert offenders == [], f"raw boto3 DynamoDB resource forbidden in runtime files: {offenders}"

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -438,7 +438,6 @@ def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str
     deps = tenant_api_handler.TenantApiDependencies(
         secretsmanager=FakeSecretsManager(),
         events=FakeEvents(),
-        dynamodb=FakeDynamoDbResource(),
         ssm=FakeSsm(),
         awslambda=FakeLambdaClient(),
         usage_client=FakeUsageClient(),

--- a/tests/unit/test_tenant_api_modules.py
+++ b/tests/unit/test_tenant_api_modules.py
@@ -37,7 +37,6 @@ def module_state(monkeypatch: pytest.MonkeyPatch, fixed_now: Any) -> dict[str, A
     deps = tenant_api_handler.TenantApiDependencies(
         secretsmanager=FakeSecretsManager(),
         events=FakeEvents(),
-        dynamodb=None,
         ssm=FakeSsm(),
         awslambda=FakeLambdaClient(),
         usage_client=FakeUsageClient(),


### PR DESCRIPTION
## Summary
- remove the unused raw DynamoDB resource from tenant API dependency wiring
- extend the runtime DynamoDB guardrail to catch session-based resource construction
- align affected test harnesses with the current tenant API dependency shape and failover contract

## Validation
- uv run pytest tests/unit/test_runtime_dynamodb_policy.py tests/unit/test_ops_api.py tests/unit/test_billing_pagination.py tests/integration/test_platform_failover_route_integration.py -q
- make preflight-session
- make pre-validate-session

Closes #421