### PR TITLE
refactor: extract tenant api dependency factories

### DIFF
--- a/src/tenant_api/dependency_factories.py
+++ b/src/tenant_api/dependency_factories.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import boto3
+
+from src.tenant_api import utils
+from src.tenant_api.constants import (
+    AGENTCORE_CONCURRENT_SESSIONS_METRIC,
+    AGENTCORE_CONCURRENT_SESSIONS_NAMESPACE,
+    AGENTCORE_QUOTA_LOOKBACK_MINUTES,
+    AGENTCORE_QUOTA_NAME,
+)
+from src.tenant_api.models import TenantApiDependencies
+
+
+class _NoopUsageClient:
+    def get_tenant_usage(self, *, tenant_id: str, app_id: str | None) -> dict[str, Any]:
+        return {"tenantId": tenant_id, "appId": app_id}
+
+
+class _NoopMemoryProvisioner:
+    def provision(self, *, tenant_id: str, app_id: str) -> dict[str, Any]:
+        return {}
+
+
+class _AwsPlatformQuotaClient:
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    def get_utilisation(
+        self,
+        *,
+        active_region: str,
+        fallback_region: str | None,
+    ) -> list[dict[str, Any]]:
+        regions: list[str] = []
+        for region in (active_region, fallback_region):
+            if region and region not in regions:
+                regions.append(region)
+
+        return [self._build_region_entry(region) for region in regions]
+
+    def _build_region_entry(self, region: str) -> dict[str, Any]:
+        current_value = self._current_sessions(region)
+        limit = self._quota_limit(region)
+        utilisation = 0.0 if limit <= 0 else round((current_value / limit) * 100, 2)
+        return {
+            "region": region,
+            "quotaName": AGENTCORE_CONCURRENT_SESSIONS_METRIC,
+            "currentValue": current_value,
+            "limit": limit,
+            "utilisationPercentage": utilisation,
+        }
+
+    def _current_sessions(self, region: str) -> float:
+        cloudwatch = self._session.client("cloudwatch", region_name=region)
+        end_time = utils.now_utc()
+        start_time = end_time - timedelta(minutes=AGENTCORE_QUOTA_LOOKBACK_MINUTES)
+        response = cloudwatch.get_metric_statistics(
+            Namespace=AGENTCORE_CONCURRENT_SESSIONS_NAMESPACE,
+            MetricName=AGENTCORE_CONCURRENT_SESSIONS_METRIC,
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=60,
+            Statistics=["Maximum"],
+        )
+        datapoints = response.get("Datapoints", [])
+        if not datapoints:
+            return 0.0
+        return max(float(point.get("Maximum", 0.0)) for point in datapoints)
+
+    def _quota_limit(self, region: str) -> float:
+        service_quotas = self._session.client("service-quotas", region_name=region)
+        next_token: str | None = None
+
+        while True:
+            request: dict[str, Any] = {"ServiceCode": "bedrock-agentcore"}
+            if next_token:
+                request["NextToken"] = next_token
+
+            response = service_quotas.list_service_quotas(**request)
+            for quota in response.get("Quotas", []):
+                if quota.get("QuotaName") == AGENTCORE_QUOTA_NAME:
+                    return float(quota.get("Value", 0.0))
+
+            next_token = response.get("NextToken")
+            if not next_token:
+                break
+
+        return self._documented_default_limit(region)
+
+    @staticmethod
+    def _documented_default_limit(region: str) -> float:
+        return 1000.0 if region == "us-east-1" else 500.0
+
+
+def build_tenant_api_dependencies(*, region: str) -> TenantApiDependencies:
+    session = boto3.session.Session(region_name=region)
+    return TenantApiDependencies(
+        secretsmanager=session.client("secretsmanager"),
+        events=session.client("events"),
+        ssm=session.client("ssm"),
+        awslambda=session.client("lambda"),
+        usage_client=_NoopUsageClient(),
+        memory_provisioner=_NoopMemoryProvisioner(),
+        platform_quota_client=_AwsPlatformQuotaClient(session),
+    )

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import json
 import os
 import secrets
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any
 
-import boto3
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.logging import correlation_paths
 from boto3.dynamodb.conditions import Key
@@ -40,6 +39,7 @@ from src.tenant_api import (
     constants,
     db_factory,
     db_utils,
+    dependency_factories,
     events,
     http_utils,
     lifecycle_logic,
@@ -51,110 +51,19 @@ from src.tenant_api import (
 )
 from src.tenant_api.constants import (
     ADMIN_ROLES,
-    AGENTCORE_CONCURRENT_SESSIONS_METRIC,
-    AGENTCORE_CONCURRENT_SESSIONS_NAMESPACE,
-    AGENTCORE_QUOTA_LOOKBACK_MINUTES,
-    AGENTCORE_QUOTA_NAME,
     TENANT_PROVISIONING_STATUSES,
 )
 from src.tenant_api.models import CallerIdentity, TenantApiDependencies
 
 logger = Logger(service="tenant-api")
 
+_NoopUsageClient = dependency_factories._NoopUsageClient
+_NoopMemoryProvisioner = dependency_factories._NoopMemoryProvisioner
+_AwsPlatformQuotaClient = dependency_factories._AwsPlatformQuotaClient
+
 
 def _dependencies() -> TenantApiDependencies:
-    region = os.environ["AWS_REGION"]
-    session = boto3.session.Session(region_name=region)
-    return TenantApiDependencies(
-        secretsmanager=session.client("secretsmanager"),
-        events=session.client("events"),
-        ssm=session.client("ssm"),
-        awslambda=session.client("lambda"),
-        usage_client=_NoopUsageClient(),
-        memory_provisioner=_NoopMemoryProvisioner(),
-        platform_quota_client=_AwsPlatformQuotaClient(session),
-    )
-
-
-class _NoopUsageClient:
-    def get_tenant_usage(self, *, tenant_id: str, app_id: str | None) -> dict[str, Any]:
-        return {"tenantId": tenant_id, "appId": app_id}
-
-
-class _NoopMemoryProvisioner:
-    def provision(self, *, tenant_id: str, app_id: str) -> dict[str, Any]:
-        return {}
-
-
-class _AwsPlatformQuotaClient:
-    def __init__(self, session: Any) -> None:
-        self._session = session
-
-    def get_utilisation(
-        self,
-        *,
-        active_region: str,
-        fallback_region: str | None,
-    ) -> list[dict[str, Any]]:
-        regions: list[str] = []
-        for region in (active_region, fallback_region):
-            if region and region not in regions:
-                regions.append(region)
-
-        return [self._build_region_entry(region) for region in regions]
-
-    def _build_region_entry(self, region: str) -> dict[str, Any]:
-        current_value = self._current_sessions(region)
-        limit = self._quota_limit(region)
-        utilisation = 0.0 if limit <= 0 else round((current_value / limit) * 100, 2)
-        return {
-            "region": region,
-            "quotaName": AGENTCORE_CONCURRENT_SESSIONS_METRIC,
-            "currentValue": current_value,
-            "limit": limit,
-            "utilisationPercentage": utilisation,
-        }
-
-    def _current_sessions(self, region: str) -> float:
-        cloudwatch = self._session.client("cloudwatch", region_name=region)
-        end_time = utils.now_utc()
-        start_time = end_time - timedelta(minutes=AGENTCORE_QUOTA_LOOKBACK_MINUTES)
-        response = cloudwatch.get_metric_statistics(
-            Namespace=AGENTCORE_CONCURRENT_SESSIONS_NAMESPACE,
-            MetricName=AGENTCORE_CONCURRENT_SESSIONS_METRIC,
-            StartTime=start_time,
-            EndTime=end_time,
-            Period=60,
-            Statistics=["Maximum"],
-        )
-        datapoints = response.get("Datapoints", [])
-        if not datapoints:
-            return 0.0
-        return max(float(point.get("Maximum", 0.0)) for point in datapoints)
-
-    def _quota_limit(self, region: str) -> float:
-        service_quotas = self._session.client("service-quotas", region_name=region)
-        next_token: str | None = None
-
-        while True:
-            request: dict[str, Any] = {"ServiceCode": "bedrock-agentcore"}
-            if next_token:
-                request["NextToken"] = next_token
-
-            response = service_quotas.list_service_quotas(**request)
-            for quota in response.get("Quotas", []):
-                if quota.get("QuotaName") == AGENTCORE_QUOTA_NAME:
-                    return float(quota.get("Value", 0.0))
-
-            next_token = response.get("NextToken")
-            if not next_token:
-                break
-
-        return self._documented_default_limit(region)
-
-    @staticmethod
-    def _documented_default_limit(region: str) -> float:
-        return 1000.0 if region == "us-east-1" else 500.0
+    return dependency_factories.build_tenant_api_dependencies(region=os.environ["AWS_REGION"])
 
 
 def _optional_ssm_parameter(ssm: Any, name: str) -> str | None:

--- a/tests/unit/test_tenant_api_dependency_factories.py
+++ b/tests/unit/test_tenant_api_dependency_factories.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.tenant_api import dependency_factories
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.clients: dict[str, Any] = {}
+
+    def client(self, service_name: str, *, region_name: str | None = None) -> Any:
+        key = f"{service_name}:{region_name or 'default'}"
+        return self.clients.setdefault(key, object())
+
+
+def test_build_tenant_api_dependencies_uses_session_factories(monkeypatch) -> None:
+    session = FakeSession()
+
+    monkeypatch.setattr(
+        dependency_factories.boto3.session,
+        "Session",
+        lambda *, region_name: session if region_name == "eu-west-2" else None,
+    )
+
+    deps = dependency_factories.build_tenant_api_dependencies(region="eu-west-2")
+
+    assert deps.secretsmanager is session.client("secretsmanager")
+    assert deps.events is session.client("events")
+    assert deps.ssm is session.client("ssm")
+    assert deps.awslambda is session.client("lambda")
+    assert isinstance(deps.usage_client, dependency_factories._NoopUsageClient)
+    assert isinstance(deps.memory_provisioner, dependency_factories._NoopMemoryProvisioner)
+    assert isinstance(deps.platform_quota_client, dependency_factories._AwsPlatformQuotaClient)


### PR DESCRIPTION
## Summary
- move tenant API AWS session and default dependency wiring into a dedicated factory module
- keep handler `_dependencies()` as a narrow composition-root seam
- add direct unit coverage for the new dependency factory and keep quota-client behavior covered

## Validation
- uv run pytest tests/unit/test_tenant_api_dependency_factories.py tests/unit/test_tenant_api_handler.py -k "tenant_api_dependencies_uses_session_factories or aws_platform_quota_client" -q
- make preflight-session
- make pre-validate-session

Closes #422