### PR TITLE
refactor: isolate billing integrations

### DIFF
--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -18,9 +18,7 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-import boto3
 from aws_lambda_powertools import Logger, Tracer
-from aws_lambda_powertools.utilities.parameters import SSMProvider
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Attr, Key
 from data_access.client import ControlPlaneDynamoDB, TenantScopedDynamoDB
@@ -30,6 +28,8 @@ from data_access.models import (
     TenantTier,
 )
 
+from src.billing.integrations import BillingIntegrations, build_billing_integrations
+
 logger = Logger(service="billing")
 tracer = Tracer()
 
@@ -38,43 +38,19 @@ TENANTS_TABLE = os.environ["TENANTS_TABLE_NAME"]
 INVOCATIONS_TABLE = os.environ["INVOCATIONS_TABLE_NAME"]
 EVENT_BUS_NAME = os.environ.get("EVENT_BUS_NAME", "default")
 
-# Boto3 clients — lazy initialisation (matches handler convention; avoids import-time failures)
-_ssm = None
-_events = None
-_cloudwatch = None
-_pricing_provider = None
+# Billing AWS integrations — lazy initialisation to avoid import-time failures
+_integrations: BillingIntegrations | None = None
 
 
 def _aws_region() -> str:
     return os.environ["AWS_REGION"]
 
 
-def _get_ssm() -> Any:
-    global _ssm
-    if _ssm is None:
-        _ssm = boto3.client("ssm", region_name=_aws_region())
-    return _ssm
-
-
-def _get_events() -> Any:
-    global _events
-    if _events is None:
-        _events = boto3.client("events", region_name=_aws_region())
-    return _events
-
-
-def _get_cloudwatch() -> Any:
-    global _cloudwatch
-    if _cloudwatch is None:
-        _cloudwatch = boto3.client("cloudwatch", region_name=_aws_region())
-    return _cloudwatch
-
-
-def _get_pricing_provider() -> SSMProvider:
-    global _pricing_provider
-    if _pricing_provider is None:
-        _pricing_provider = SSMProvider(boto3_client=_get_ssm())
-    return _pricing_provider
+def _get_integrations() -> BillingIntegrations:
+    global _integrations
+    if _integrations is None:
+        _integrations = build_billing_integrations(region=_aws_region())
+    return _integrations
 
 
 class PricingResolutionError(RuntimeError):
@@ -85,7 +61,7 @@ def _get_pricing(tier: str) -> dict[str, float]:
     """Fetch pricing for a tier from SSM."""
     path = f"/platform/billing/pricing/{tier}"
     try:
-        parsed = _get_pricing_provider().get(path, max_age=300, transform="json")
+        parsed = _get_integrations().pricing_provider.get(path, max_age=300, transform="json")
     except Exception as exc:
         raise PricingResolutionError(f"Failed to fetch pricing parameter {path} from SSM") from exc
 
@@ -259,7 +235,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
             {"Name": "TenantId", "Value": tenant_id},
             {"Name": "Tier", "Value": tier},
         ]
-        _get_cloudwatch().put_metric_data(
+        _get_integrations().cloudwatch.put_metric_data(
             Namespace="Platform/Billing",
             MetricData=[
                 {
@@ -313,7 +289,7 @@ def _process_tenant(tenant: dict[str, Any], date_to_process: datetime) -> None:
             )
 
             # Publish event
-            _get_events().put_events(
+            _get_integrations().events.put_events(
                 Entries=[
                     {
                         "Source": "platform.billing",

--- a/src/billing/integrations.py
+++ b/src/billing/integrations.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import boto3
+from aws_lambda_powertools.utilities.parameters import SSMProvider
+
+
+@dataclass(frozen=True)
+class BillingIntegrations:
+    ssm: Any
+    events: Any
+    cloudwatch: Any
+    pricing_provider: SSMProvider
+
+
+def build_billing_integrations(*, region: str) -> BillingIntegrations:
+    ssm = boto3.client("ssm", region_name=region)
+    return BillingIntegrations(
+        ssm=ssm,
+        events=boto3.client("events", region_name=region),
+        cloudwatch=boto3.client("cloudwatch", region_name=region),
+        pricing_provider=SSMProvider(boto3_client=ssm),
+    )

--- a/tests/unit/test_billing_handler.py
+++ b/tests/unit/test_billing_handler.py
@@ -22,13 +22,15 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import boto3
 import pytest
 from moto import mock_aws
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.billing.integrations import BillingIntegrations
 
 # Set environment variables for handler
 os.environ["AWS_REGION"] = "eu-west-2"
@@ -54,10 +56,7 @@ BUDGET = 5.0
 @pytest.fixture
 def mock_aws_clients() -> Generator[None, None, None]:
     with mock_aws():
-        billing_handler._ssm = None
-        billing_handler._events = None
-        billing_handler._cloudwatch = None
-        billing_handler._pricing_provider = None
+        billing_handler._integrations = None
 
         # Setup DynamoDB
         ddb = boto3.resource("dynamodb", region_name="eu-west-2")
@@ -108,10 +107,7 @@ def mock_aws_clients() -> Generator[None, None, None]:
 
         yield
 
-        billing_handler._ssm = None
-        billing_handler._events = None
-        billing_handler._cloudwatch = None
-        billing_handler._pricing_provider = None
+        billing_handler._integrations = None
 
 
 def _seed_tenant(ddb: Any, *, status: str = "active", budget: float = BUDGET) -> None:
@@ -334,7 +330,14 @@ def test_billing_emits_token_metrics(mock_aws_clients: Any) -> None:
 
     # Run handler with cloudwatch patch
     event = {"date": yesterday.date().isoformat()}
-    with patch("src.billing.handler._cloudwatch") as mock_cw:
+    mock_cw = MagicMock()
+    billing_handler._integrations = BillingIntegrations(
+        ssm=boto3.client("ssm", region_name="eu-west-2"),
+        events=boto3.client("events", region_name="eu-west-2"),
+        cloudwatch=mock_cw,
+        pricing_provider=billing_handler._get_integrations().pricing_provider,
+    )
+    try:
         lambda_handler(event, MagicMock())
 
         # Verify put_metric_data was called with token metrics
@@ -351,3 +354,5 @@ def test_billing_emits_token_metrics(mock_aws_clients: Any) -> None:
                 assert m["Value"] == 1000.0
             if m["MetricName"] == "OutputTokens":
                 assert m["Value"] == 500.0
+    finally:
+        billing_handler._integrations = None

--- a/tests/unit/test_billing_integrations.py
+++ b/tests/unit/test_billing_integrations.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.billing import integrations
+
+
+class FakeBoto3:
+    def __init__(self) -> None:
+        self.clients: dict[tuple[str, str], object] = {}
+
+    def client(self, service_name: str, *, region_name: str) -> object:
+        key = (service_name, region_name)
+        return self.clients.setdefault(key, object())
+
+
+def test_build_billing_integrations_creates_clients_and_pricing_provider(monkeypatch) -> None:
+    fake_boto3 = FakeBoto3()
+    pricing_provider = object()
+
+    monkeypatch.setattr(integrations, "boto3", fake_boto3)
+    monkeypatch.setattr(integrations, "SSMProvider", lambda *, boto3_client: pricing_provider)
+
+    deps = integrations.build_billing_integrations(region="eu-west-2")
+
+    assert deps.ssm is fake_boto3.client("ssm", region_name="eu-west-2")
+    assert deps.events is fake_boto3.client("events", region_name="eu-west-2")
+    assert deps.cloudwatch is fake_boto3.client("cloudwatch", region_name="eu-west-2")
+    assert deps.pricing_provider is pricing_provider


### PR DESCRIPTION
## Summary
- move billing AWS client and pricing-provider setup into a dedicated integration module
- replace four raw cached globals in the handler with one cached integration seam
- add direct builder coverage and update billing tests to patch the new seam explicitly

## Validation
- uv run pytest tests/unit/test_billing_integrations.py tests/unit/test_billing_handler.py tests/unit/test_billing_pagination.py -q
- make preflight-session
- make pre-validate-session

Closes #423