### PR TITLE
refactor: extract response interceptor services

### DIFF
--- a/gateway/interceptors/response_interceptor.py
+++ b/gateway/interceptors/response_interceptor.py
@@ -13,7 +13,6 @@ ADRs: ADR-004
 
 import json
 import os
-import re
 import time
 from typing import Any
 
@@ -22,6 +21,8 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from data_access import TenantScopedDynamoDB
 from data_access.models import TenantContext, TenantTier
+
+from gateway.interceptors import response_redaction, response_tools
 
 logger = Logger(service="gateway-response-interceptor")
 tracer = Tracer()
@@ -34,19 +35,8 @@ PII_PATTERNS_PARAM = os.environ.get("PII_PATTERNS_PARAM", "/platform/gateway/pii
 PII_CACHE_TTL_SECONDS = 60
 PII_REDACTION_TOKEN = "[REDACTED]"
 
-DEFAULT_PII_PATTERN_STRINGS: tuple[str, ...] = (
-    r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",  # email
-    r"[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z]\s*\d{2}\s*\d{2}\s*\d{2}\s*[A-D]",  # UK NI
-    r"\d{3}\s*\d{3}\s*\d{4}",  # NHS
-    r"\d{2}-\d{2}-\d{2}",  # sort code
-    r"\b\d{8}\b",  # account number
-)
-
-# ---------------------------------------------------------------------------
-# Global clients and cache
-# ---------------------------------------------------------------------------
 _ssm_client = None
-_pii_patterns: list[re.Pattern[str]] = []
+_pii_patterns: list[Any] = []
 _pii_cache_expiry: float = 0
 
 
@@ -58,31 +48,7 @@ def get_ssm() -> Any:
     return _ssm_client
 
 
-def _compile_patterns(patterns: list[str]) -> list[re.Pattern[str]]:
-    compiled: list[re.Pattern[str]] = []
-    for pattern_str in patterns:
-        try:
-            compiled.append(re.compile(pattern_str, re.IGNORECASE))
-        except re.error:
-            logger.warning("Invalid PII regex pattern from SSM", pattern=pattern_str)
-    return compiled
-
-
-def _parse_patterns(raw_patterns: str | None) -> list[str]:
-    if not raw_patterns:
-        return []
-
-    decoded = json.loads(raw_patterns)
-    if isinstance(decoded, dict):
-        return [value for value in decoded.values() if isinstance(value, str)]
-    if isinstance(decoded, list):
-        return [value for value in decoded if isinstance(value, str)]
-
-    logger.warning("Unexpected PII patterns format in SSM parameter", type=type(decoded).__name__)
-    return []
-
-
-def load_pii_patterns() -> list[re.Pattern[str]]:
+def load_pii_patterns() -> list[Any]:
     """Fetch and compile PII redaction patterns from SSM with cache."""
     global _pii_patterns, _pii_cache_expiry
     now = time.time()
@@ -91,51 +57,34 @@ def load_pii_patterns() -> list[re.Pattern[str]]:
 
     try:
         ssm = get_ssm()
-        response = ssm.get_parameter(Name=PII_PATTERNS_PARAM, WithDecryption=False)
-        raw_patterns = response.get("Parameter", {}).get("Value")
-        compiled = _compile_patterns(_parse_patterns(raw_patterns))
-        if not compiled:
-            logger.warning("PII pattern set empty, using built-in defaults")
-            compiled = _compile_patterns(list(DEFAULT_PII_PATTERN_STRINGS))
-        _pii_patterns = compiled
+        _pii_patterns = response_redaction.load_patterns(
+            get_parameter=ssm.get_parameter,
+            parameter_name=PII_PATTERNS_PARAM,
+            logger=logger,
+        )
         _pii_cache_expiry = now + PII_CACHE_TTL_SECONDS
     except Exception:
         logger.exception("Failed to load PII patterns from SSM, using defaults")
-        _pii_patterns = _compile_patterns(list(DEFAULT_PII_PATTERN_STRINGS))
+        _pii_patterns = response_redaction.default_patterns(logger=logger)
         _pii_cache_expiry = now + PII_CACHE_TTL_SECONDS
 
     return _pii_patterns
 
 
 def redact_pii(data: Any) -> Any:
-    """Recursively redact PII from strings, lists, and dicts."""
-    patterns = load_pii_patterns()
-
-    if isinstance(data, str):
-        redacted = data
-        for pattern in patterns:
-            redacted = pattern.sub(PII_REDACTION_TOKEN, redacted)
-        return redacted
-    if isinstance(data, dict):
-        return {k: redact_pii(v) for k, v in data.items()}
-    if isinstance(data, list):
-        return [redact_pii(v) for v in data]
-    return data
+    return response_redaction.redact_pii(
+        data,
+        patterns=load_pii_patterns(),
+        redaction_token=PII_REDACTION_TOKEN,
+    )
 
 
 def is_tier_sufficient(current_tier: TenantTier, required_tier: TenantTier) -> bool:
-    """Check if the current tenant tier meets the tool's minimum tier requirement."""
-    order = {TenantTier.BASIC: 0, TenantTier.STANDARD: 1, TenantTier.PREMIUM: 2}
-    return order.get(current_tier, 0) >= order.get(required_tier, 0)
+    return response_tools.is_tier_sufficient(current_tier, required_tier)
 
 
 def _parse_tier(value: Any) -> TenantTier:
-    if isinstance(value, TenantTier):
-        return value
-    try:
-        return TenantTier(str(value).lower())
-    except ValueError:
-        return TenantTier.BASIC
+    return response_tools.parse_tier(value)
 
 
 def _resolve_tool_minimum_tier(
@@ -144,27 +93,13 @@ def _resolve_tool_minimum_tier(
     context: TenantContext,
     db: TenantScopedDynamoDB | None,
 ) -> TenantTier:
-    payload_tier = tool.get("tierMinimum") or tool.get("tier_minimum")
-    if payload_tier is not None:
-        return _parse_tier(payload_tier)
-
-    tool_name = tool.get("name")
-    if not tool_name or db is None:
-        return TenantTier.BASIC
-
-    try:
-        tool_record = db.get_item(TOOLS_TABLE, {"PK": f"TOOL#{tool_name}", "SK": "GLOBAL"})
-        if not tool_record:
-            tool_record = db.get_item(
-                TOOLS_TABLE, {"PK": f"TOOL#{tool_name}", "SK": f"TENANT#{context.tenant_id}"}
-            )
-    except Exception:
-        logger.exception("Unable to resolve tool tier from registry", tool_name=tool_name)
-        return TenantTier.BASIC
-
-    if not tool_record:
-        return TenantTier.BASIC
-    return _parse_tier(tool_record.get("tier_minimum"))
+    return response_tools.resolve_tool_minimum_tier(
+        tool=tool,
+        context=context,
+        db=db,
+        tools_table=TOOLS_TABLE,
+        logger=logger,
+    )
 
 
 def filter_tools(body: dict[str, Any], context: TenantContext) -> dict[str, Any]:
@@ -173,26 +108,12 @@ def filter_tools(body: dict[str, Any], context: TenantContext) -> dict[str, Any]
     if not isinstance(tools, list):
         return body
 
-    db: TenantScopedDynamoDB | None = None
-    try:
-        db = TenantScopedDynamoDB(context)
-    except Exception:
-        logger.exception(
-            "Failed to initialize tool registry client; using payload tier values only"
-        )
-
-    filtered_tools: list[Any] = []
-
-    for tool in tools:
-        if not isinstance(tool, dict):
-            filtered_tools.append(tool)
-            continue
-
-        required_tier = _resolve_tool_minimum_tier(tool=tool, context=context, db=db)
-        if is_tier_sufficient(context.tier, required_tier):
-            filtered_tools.append(tool)
-
-    return {**body, "tools": filtered_tools}
+    return response_tools.filter_tools(
+        body,
+        context,
+        tools_table=TOOLS_TABLE,
+        logger=logger,
+    )
 
 
 def _header_value(headers: dict[str, Any], key: str, default: Any = None) -> Any:

--- a/gateway/interceptors/response_redaction.py
+++ b/gateway/interceptors/response_redaction.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+DEFAULT_PII_PATTERN_STRINGS: tuple[str, ...] = (
+    r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",
+    r"[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z]\s*\d{2}\s*\d{2}\s*\d{2}\s*[A-D]",
+    r"\d{3}\s*\d{3}\s*\d{4}",
+    r"\d{2}-\d{2}-\d{2}",
+    r"\b\d{8}\b",
+)
+
+
+def compile_patterns(patterns: list[str], *, logger: Any) -> list[re.Pattern[str]]:
+    compiled: list[re.Pattern[str]] = []
+    for pattern_str in patterns:
+        try:
+            compiled.append(re.compile(pattern_str, re.IGNORECASE))
+        except re.error:
+            logger.warning("Invalid PII regex pattern from SSM", pattern=pattern_str)
+    return compiled
+
+
+def parse_patterns(raw_patterns: str | None, *, logger: Any) -> list[str]:
+    if not raw_patterns:
+        return []
+
+    decoded = json.loads(raw_patterns)
+    if isinstance(decoded, dict):
+        return [value for value in decoded.values() if isinstance(value, str)]
+    if isinstance(decoded, list):
+        return [value for value in decoded if isinstance(value, str)]
+
+    logger.warning("Unexpected PII patterns format in SSM parameter", type=type(decoded).__name__)
+    return []
+
+
+def load_patterns(
+    *,
+    get_parameter: Any,
+    parameter_name: str,
+    logger: Any,
+) -> list[re.Pattern[str]]:
+    response = get_parameter(Name=parameter_name, WithDecryption=False)
+    raw_patterns = response.get("Parameter", {}).get("Value")
+    compiled = compile_patterns(parse_patterns(raw_patterns, logger=logger), logger=logger)
+    if compiled:
+        return compiled
+
+    logger.warning("PII pattern set empty, using built-in defaults")
+    return compile_patterns(list(DEFAULT_PII_PATTERN_STRINGS), logger=logger)
+
+
+def default_patterns(*, logger: Any) -> list[re.Pattern[str]]:
+    return compile_patterns(list(DEFAULT_PII_PATTERN_STRINGS), logger=logger)
+
+
+def redact_pii(data: Any, *, patterns: list[re.Pattern[str]], redaction_token: str) -> Any:
+    if isinstance(data, str):
+        redacted = data
+        for pattern in patterns:
+            redacted = pattern.sub(redaction_token, redacted)
+        return redacted
+    if isinstance(data, dict):
+        return {
+            key: redact_pii(value, patterns=patterns, redaction_token=redaction_token)
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [
+            redact_pii(value, patterns=patterns, redaction_token=redaction_token) for value in data
+        ]
+    return data

--- a/gateway/interceptors/response_tools.py
+++ b/gateway/interceptors/response_tools.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+from data_access import TenantScopedDynamoDB
+from data_access.models import TenantContext, TenantTier
+
+
+def is_tier_sufficient(current_tier: TenantTier, required_tier: TenantTier) -> bool:
+    order = {TenantTier.BASIC: 0, TenantTier.STANDARD: 1, TenantTier.PREMIUM: 2}
+    return order.get(current_tier, 0) >= order.get(required_tier, 0)
+
+
+def parse_tier(value: Any) -> TenantTier:
+    if isinstance(value, TenantTier):
+        return value
+    try:
+        return TenantTier(str(value).lower())
+    except ValueError:
+        return TenantTier.BASIC
+
+
+def resolve_tool_minimum_tier(
+    *,
+    tool: dict[str, Any],
+    context: TenantContext,
+    db: TenantScopedDynamoDB | None,
+    tools_table: str,
+    logger: Any,
+) -> TenantTier:
+    payload_tier = tool.get("tierMinimum") or tool.get("tier_minimum")
+    if payload_tier is not None:
+        return parse_tier(payload_tier)
+
+    tool_name = tool.get("name")
+    if not tool_name or db is None:
+        return TenantTier.BASIC
+
+    try:
+        tool_record = db.get_item(tools_table, {"PK": f"TOOL#{tool_name}", "SK": "GLOBAL"})
+        if not tool_record:
+            tool_record = db.get_item(
+                tools_table, {"PK": f"TOOL#{tool_name}", "SK": f"TENANT#{context.tenant_id}"}
+            )
+    except Exception:
+        logger.exception("Unable to resolve tool tier from registry", tool_name=tool_name)
+        return TenantTier.BASIC
+
+    if not tool_record:
+        return TenantTier.BASIC
+    return parse_tier(tool_record.get("tier_minimum"))
+
+
+def filter_tools(
+    body: dict[str, Any],
+    context: TenantContext,
+    *,
+    tools_table: str,
+    logger: Any,
+) -> dict[str, Any]:
+    tools = body.get("tools", [])
+    if not isinstance(tools, list):
+        return body
+
+    db: TenantScopedDynamoDB | None = None
+    try:
+        db = TenantScopedDynamoDB(context)
+    except Exception:
+        logger.exception(
+            "Failed to initialize tool registry client; using payload tier values only"
+        )
+
+    filtered_tools: list[Any] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            filtered_tools.append(tool)
+            continue
+
+        required_tier = resolve_tool_minimum_tier(
+            tool=tool,
+            context=context,
+            db=db,
+            tools_table=tools_table,
+            logger=logger,
+        )
+        if is_tier_sufficient(context.tier, required_tier):
+            filtered_tools.append(tool)
+
+    return {**body, "tools": filtered_tools}

--- a/tests/unit/test_response_interceptor_services.py
+++ b/tests/unit/test_response_interceptor_services.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "data-access-lib" / "src"))
+
+from data_access.models import TenantContext, TenantTier
+
+from gateway.interceptors import response_redaction, response_tools
+
+
+def test_load_patterns_uses_defaults_when_parameter_is_empty() -> None:
+    get_parameter = MagicMock(return_value={"Parameter": {"Value": "[]"}})
+    logger = MagicMock()
+
+    patterns = response_redaction.load_patterns(
+        get_parameter=get_parameter,
+        parameter_name="/platform/gateway/pii-patterns/default",
+        logger=logger,
+    )
+
+    assert patterns
+    assert any(pattern.search("user@example.com") for pattern in patterns)
+
+
+def test_filter_tools_respects_payload_tier_without_registry_lookup() -> None:
+    context = TenantContext(
+        tenant_id="t-001",
+        app_id="app-001",
+        tier=TenantTier.BASIC,
+        sub="tester",
+    )
+    logger = MagicMock()
+
+    body = {
+        "tools": [
+            {"name": "calculator", "tierMinimum": "basic"},
+            {"name": "heavy-compute", "tierMinimum": "premium"},
+        ]
+    }
+
+    filtered = response_tools.filter_tools(
+        body,
+        context,
+        tools_table="platform-tools",
+        logger=logger,
+    )
+
+    assert filtered["tools"] == [{"name": "calculator", "tierMinimum": "basic"}]


### PR DESCRIPTION
## Summary
- extract response redaction logic into a focused service module
- extract tool filtering and tier-resolution logic into a focused service module
- keep interceptor cache and fallback behavior stable while tightening direct tests

## Validation
- uv run pytest tests/unit/test_response_interceptor.py tests/unit/test_response_interceptor_services.py tests/integration/test_response_interceptor_flow.py -q
- make preflight-session
- make pre-validate-session

Closes #425