### PR TITLE
refactor: extract webhook delivery services

### DIFF
--- a/src/webhook_delivery/events.py
+++ b/src/webhook_delivery/events.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from boto3.dynamodb.types import TypeDeserializer
+
+WEBHOOK_SIGNATURE_HEADER = "X-Platform-Signature"
+WEBHOOK_SIGNATURE_ALGORITHM = "HMAC-SHA256"
+
+_deserializer = TypeDeserializer()
+
+
+@dataclass(frozen=True)
+class RetryMessage:
+    tenant_id: str
+    app_id: str
+    job_id: str
+    attempt: int
+
+
+def parse_retry_record(record: dict[str, Any]) -> RetryMessage | None:
+    body = json.loads(str(record.get("body", "{}")))
+    tenant_id = coerce_optional_string(body.get("tenantId"))
+    app_id = coerce_optional_string(body.get("appId"))
+    job_id = coerce_optional_string(body.get("jobId"))
+    attempt = int(body.get("attempt", 2))
+
+    if tenant_id is None or app_id is None or job_id is None:
+        return None
+    return RetryMessage(tenant_id=tenant_id, app_id=app_id, job_id=job_id, attempt=attempt)
+
+
+def deserialize_image(image: Any) -> dict[str, Any]:
+    if not isinstance(image, dict):
+        return {}
+    return {key: _deserializer.deserialize(value) for key, value in image.items()}
+
+
+def should_process_stream_transition(
+    new_image: dict[str, Any],
+    old_image: dict[str, Any] | None,
+    *,
+    terminal_job_events: dict[str, str],
+) -> bool:
+    if not new_image:
+        return False
+
+    status = coerce_optional_string(new_image.get("status"))
+    if status not in terminal_job_events:
+        return False
+
+    if coerce_optional_string(new_image.get("webhook_url")) is None:
+        return False
+
+    if bool(new_image.get("webhook_delivered", False)):
+        return False
+
+    if old_image:
+        old_status = coerce_optional_string(old_image.get("status"))
+        if old_status in terminal_job_events:
+            return False
+
+    return True
+
+
+def build_payload(job_item: dict[str, Any], event_name: str) -> dict[str, Any]:
+    return {
+        "event": event_name,
+        "jobId": str(job_item.get("job_id", "")),
+        "tenantId": str(job_item.get("tenant_id", "")),
+        "agentName": str(job_item.get("agent_name", "")),
+        "status": str(job_item.get("status", "")),
+        "createdAt": coerce_optional_string(job_item.get("created_at")),
+        "completedAt": coerce_optional_string(job_item.get("completed_at")),
+        "errorMessage": coerce_optional_string(job_item.get("error_message")),
+    }
+
+
+def sign_payload(payload_bytes: bytes, secret: str) -> str:
+    digest = hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def build_signed_request(
+    job_item: dict[str, Any],
+    event_name: str,
+    signature_secret: str,
+) -> tuple[bytes, dict[str, str]]:
+    payload = build_payload(job_item, event_name)
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return payload_bytes, {
+        "Content-Type": "application/json",
+        WEBHOOK_SIGNATURE_HEADER: sign_payload(payload_bytes, signature_secret),
+    }
+
+
+def coerce_optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)

--- a/src/webhook_delivery/handler.py
+++ b/src/webhook_delivery/handler.py
@@ -1,27 +1,14 @@
-"""
-webhook_delivery.handler — Async webhook delivery Lambda.
-
-Consumes terminal job transitions from the platform-jobs DynamoDB stream and
-uses an SQS retry queue for delivery retries. Delivery is signed with
-HMAC-SHA256 using the webhook registration secret stored in platform-jobs.
-"""
+"""webhook_delivery.handler — Async webhook delivery Lambda."""
 
 from __future__ import annotations
 
-import hashlib
-import hmac
-import json
 import os
-from datetime import UTC, datetime
 from typing import Any
 
-import boto3
-import requests
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from boto3.dynamodb.types import TypeDeserializer
-from data_access import TenantContext, TenantScopedDynamoDB
-from data_access.models import TenantTier
+
+from . import integrations, service
 
 logger = Logger(service="webhook-delivery")
 tracer = Tracer()
@@ -32,8 +19,6 @@ WEBHOOK_RETRY_QUEUE_URL = os.environ.get("WEBHOOK_RETRY_QUEUE_URL")
 WEBHOOK_DLQ_URL = os.environ.get("WEBHOOK_DLQ_URL")
 WEBHOOK_MAX_RETRY_ATTEMPTS = int(os.environ.get("WEBHOOK_MAX_RETRY_ATTEMPTS", "3"))
 WEBHOOK_HTTP_TIMEOUT_SECONDS = int(os.environ.get("WEBHOOK_HTTP_TIMEOUT_SECONDS", "10"))
-WEBHOOK_SIGNATURE_HEADER = "X-Platform-Signature"
-WEBHOOK_SIGNATURE_ALGORITHM = "HMAC-SHA256"
 
 TERMINAL_JOB_EVENTS = {
     "completed": "job.completed",
@@ -43,24 +28,6 @@ WEBHOOK_DELIVERY_DELIVERED = "delivered"
 WEBHOOK_DELIVERY_FAILED = "failed"
 WEBHOOK_DELIVERY_RETRYING = "retrying"
 WEBHOOK_DELIVERY_SKIPPED = "skipped"
-
-_deserializer = TypeDeserializer()
-_sqs_client = None
-_http_session = None
-
-
-def get_sqs():
-    global _sqs_client
-    if _sqs_client is None:
-        _sqs_client = boto3.client("sqs", region_name=os.environ["AWS_REGION"])
-    return _sqs_client
-
-
-def get_http_session():
-    global _http_session
-    if _http_session is None:
-        _http_session = requests.Session()
-    return _http_session
 
 
 @tracer.capture_lambda_handler
@@ -94,335 +61,30 @@ def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
     return {"status": "ok"}
 
 
+def _delivery_config() -> service.DeliveryConfig:
+    return service.DeliveryConfig(
+        region=os.environ["AWS_REGION"],
+        jobs_table=JOBS_TABLE,
+        tenants_table=TENANTS_TABLE,
+        retry_queue_url=WEBHOOK_RETRY_QUEUE_URL,
+        dlq_url=WEBHOOK_DLQ_URL,
+        max_retry_attempts=WEBHOOK_MAX_RETRY_ATTEMPTS,
+        http_timeout_seconds=WEBHOOK_HTTP_TIMEOUT_SECONDS,
+        delivered_status=WEBHOOK_DELIVERY_DELIVERED,
+        failed_status=WEBHOOK_DELIVERY_FAILED,
+        retrying_status=WEBHOOK_DELIVERY_RETRYING,
+        skipped_status=WEBHOOK_DELIVERY_SKIPPED,
+        terminal_job_events=TERMINAL_JOB_EVENTS,
+    )
+
+
 def _handle_stream_record(record: dict[str, Any]) -> None:
-    dynamodb_record = record.get("dynamodb", {})
-    new_image = _deserialize_image(dynamodb_record.get("NewImage"))
-    old_image = _deserialize_image(dynamodb_record.get("OldImage"))
-    if not _should_process_stream_transition(new_image, old_image):
-        return
-    _attempt_delivery(new_image, attempt=1)
+    service.process_stream_record(record, config=_delivery_config(), logger=logger)
 
 
 def _handle_retry_record(record: dict[str, Any]) -> None:
-    body = json.loads(str(record.get("body", "{}")))
-    tenant_id = _coerce_optional_string(body.get("tenantId"))
-    app_id = _coerce_optional_string(body.get("appId"))
-    job_id = _coerce_optional_string(body.get("jobId"))
-    attempt = int(body.get("attempt", 2))
-
-    if tenant_id is None or app_id is None or job_id is None:
-        logger.warning("Ignoring malformed retry message")
-        return
-
-    tenant_context = TenantContext(
-        tenant_id=tenant_id,
-        app_id=app_id,
-        tier=TenantTier.BASIC,
-        sub="webhook-delivery",
-    )
-    db = TenantScopedDynamoDB(tenant_context)
-    job_item = db.get_item(JOBS_TABLE, {"PK": f"TENANT#{tenant_id}", "SK": f"JOB#{job_id}"})
-    if job_item is None:
-        logger.warning("Ignoring retry for missing job", extra={"job_id": job_id})
-        return
-    _attempt_delivery(job_item, attempt=attempt)
-
-
-def _attempt_delivery(job_item: dict[str, Any], *, attempt: int) -> None:
-    tenant_context = _tenant_context_from_job(job_item)
-    job_id = str(job_item.get("job_id", ""))
-    logger.append_keys(appid=tenant_context.app_id, tenantid=tenant_context.tenant_id, jobid=job_id)
-
-    event_name = TERMINAL_JOB_EVENTS.get(str(job_item.get("status", "")))
-    webhook_url = _coerce_optional_string(job_item.get("webhook_url"))
-    if event_name is None or webhook_url is None or bool(job_item.get("webhook_delivered", False)):
-        return
-
-    webhook_id = _coerce_optional_string(job_item.get("webhook_id"))
-    if webhook_id is None:
-        _mark_delivery_state(
-            tenant_context,
-            job_id=job_id,
-            delivered=False,
-            status=WEBHOOK_DELIVERY_FAILED,
-            attempts=attempt,
-            error="Job is missing webhook_id required for signed delivery",
-        )
-        _send_to_dlq(job_item, attempt, "missing-webhook-id")
-        return
-
-    registration = _get_webhook_registration(tenant_context, webhook_id)
-    if registration is None:
-        _mark_delivery_state(
-            tenant_context,
-            job_id=job_id,
-            delivered=False,
-            status=WEBHOOK_DELIVERY_FAILED,
-            attempts=attempt,
-            error=f"Webhook registration '{webhook_id}' not found",
-        )
-        _send_to_dlq(job_item, attempt, "missing-webhook-registration")
-        return
-
-    if str(registration.get("status", "active")) != "active":
-        _mark_delivery_state(
-            tenant_context,
-            job_id=job_id,
-            delivered=False,
-            status=WEBHOOK_DELIVERY_SKIPPED,
-            attempts=attempt,
-            error="Webhook registration disabled",
-        )
-        return
-
-    subscribed_events = registration.get("events") or []
-    if event_name not in subscribed_events:
-        _mark_delivery_state(
-            tenant_context,
-            job_id=job_id,
-            delivered=False,
-            status=WEBHOOK_DELIVERY_SKIPPED,
-            attempts=attempt,
-            error=f"Webhook is not subscribed to {event_name}",
-        )
-        return
-
-    signature_secret = _coerce_optional_string(registration.get("signature_secret"))
-    if signature_secret is None:
-        _mark_delivery_state(
-            tenant_context,
-            job_id=job_id,
-            delivered=False,
-            status=WEBHOOK_DELIVERY_FAILED,
-            attempts=attempt,
-            error="Webhook registration missing signature secret",
-        )
-        _send_to_dlq(job_item, attempt, "missing-signature-secret")
-        return
-
-    payload = _build_payload(job_item, event_name)
-    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    headers = {
-        "Content-Type": "application/json",
-        WEBHOOK_SIGNATURE_HEADER: _sign_payload(payload_bytes, signature_secret),
-    }
-
-    try:
-        response = get_http_session().post(
-            webhook_url,
-            data=payload_bytes,
-            headers=headers,
-            timeout=WEBHOOK_HTTP_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-    except requests.RequestException as exc:
-        _handle_delivery_failure(
-            tenant_context=tenant_context,
-            job_item=job_item,
-            attempt=attempt,
-            error=str(exc),
-        )
-        return
-
-    _mark_delivery_state(
-        tenant_context,
-        job_id=job_id,
-        delivered=True,
-        status=WEBHOOK_DELIVERY_DELIVERED,
-        attempts=attempt,
-        error=None,
-    )
-    logger.info("Webhook delivered")
-
-
-def _handle_delivery_failure(
-    *,
-    tenant_context: TenantContext,
-    job_item: dict[str, Any],
-    attempt: int,
-    error: str,
-) -> None:
-    job_id = str(job_item.get("job_id", ""))
-    if attempt <= WEBHOOK_MAX_RETRY_ATTEMPTS:
-        _mark_delivery_state(
-            tenant_context,
-            job_id=job_id,
-            delivered=False,
-            status=WEBHOOK_DELIVERY_RETRYING,
-            attempts=attempt,
-            error=error,
-        )
-        _enqueue_retry(job_item, attempt + 1, delay_seconds=min(900, 2**attempt))
-        logger.warning(
-            "Webhook delivery failed, retry queued",
-            extra={"attempt": attempt, "error": error},
-        )
-        return
-
-    _mark_delivery_state(
-        tenant_context,
-        job_id=job_id,
-        delivered=False,
-        status=WEBHOOK_DELIVERY_FAILED,
-        attempts=attempt,
-        error=error,
-    )
-    _send_to_dlq(job_item, attempt, error)
-    logger.error("Webhook delivery exhausted retries", extra={"attempt": attempt, "error": error})
-
-
-def _mark_delivery_state(
-    tenant_context: TenantContext,
-    *,
-    job_id: str,
-    delivered: bool,
-    status: str,
-    attempts: int,
-    error: str | None,
-) -> None:
-    db = TenantScopedDynamoDB(tenant_context)
-    db.update_item(
-        JOBS_TABLE,
-        {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": f"JOB#{job_id}"},
-        (
-            "SET webhook_delivered = :delivered, "
-            "webhook_delivery_status = :status, "
-            "webhook_delivery_attempts = :attempts, "
-            "webhook_delivery_error = :error, "
-            "webhook_last_attempt_at = :last_attempt_at"
-        ),
-        {
-            ":delivered": delivered,
-            ":status": status,
-            ":attempts": attempts,
-            ":error": error,
-            ":last_attempt_at": datetime.now(UTC).isoformat(),
-        },
-    )
-
-
-def _enqueue_retry(job_item: dict[str, Any], attempt: int, *, delay_seconds: int) -> None:
-    if WEBHOOK_RETRY_QUEUE_URL is None:
-        raise RuntimeError("WEBHOOK_RETRY_QUEUE_URL is not configured")
-
-    # Add jitter to delay to prevent thundering herd
-    from src.bridge.utils import get_retry_jitter
-
-    jittered_delay = int(get_retry_jitter(float(delay_seconds)))
-
-    get_sqs().send_message(
-        QueueUrl=WEBHOOK_RETRY_QUEUE_URL,
-        DelaySeconds=max(0, min(900, jittered_delay)),
-        MessageBody=json.dumps(
-            {
-                "tenantId": job_item.get("tenant_id"),
-                "appId": job_item.get("app_id"),
-                "jobId": job_item.get("job_id"),
-                "attempt": attempt,
-            }
-        ),
-    )
-
-
-def _send_to_dlq(job_item: dict[str, Any], attempt: int, reason: str) -> None:
-    if WEBHOOK_DLQ_URL is None:
-        return
-
-    get_sqs().send_message(
-        QueueUrl=WEBHOOK_DLQ_URL,
-        MessageBody=json.dumps(
-            {
-                "tenantId": job_item.get("tenant_id"),
-                "appId": job_item.get("app_id"),
-                "jobId": job_item.get("job_id"),
-                "webhookId": job_item.get("webhook_id"),
-                "attempt": attempt,
-                "reason": reason,
-            }
-        ),
-    )
-
-
-def _get_webhook_registration(
-    tenant_context: TenantContext, webhook_id: str
-) -> dict[str, Any] | None:
-    db = TenantScopedDynamoDB(tenant_context)
-    record = db.get_item(
-        TENANTS_TABLE,
-        {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": f"WEBHOOK#{webhook_id}"},
-    )
-    if record is None:
-        return None
-    if str(record.get("tenant_id", "")) != tenant_context.tenant_id:
-        return None
-    return record
-
-
-def _tenant_context_from_job(job_item: dict[str, Any]) -> TenantContext:
-    tenant_id = _coerce_optional_string(job_item.get("tenant_id"))
-    app_id = _coerce_optional_string(job_item.get("app_id"))
-    if tenant_id is None or app_id is None:
-        raise ValueError("Job record is missing tenant_id or app_id")
-    return TenantContext(
-        tenant_id=tenant_id,
-        app_id=app_id,
-        tier=TenantTier.BASIC,
-        sub="webhook-delivery",
-    )
-
-
-def _build_payload(job_item: dict[str, Any], event_name: str) -> dict[str, Any]:
-    return {
-        "event": event_name,
-        "jobId": str(job_item.get("job_id", "")),
-        "tenantId": str(job_item.get("tenant_id", "")),
-        "agentName": str(job_item.get("agent_name", "")),
-        "status": str(job_item.get("status", "")),
-        "createdAt": _coerce_optional_string(job_item.get("created_at")),
-        "completedAt": _coerce_optional_string(job_item.get("completed_at")),
-        "errorMessage": _coerce_optional_string(job_item.get("error_message")),
-    }
+    service.process_retry_record(record, config=_delivery_config(), logger=logger)
 
 
 def _sign_payload(payload_bytes: bytes, secret: str) -> str:
-    digest = hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
-    return f"sha256={digest}"
-
-
-def _should_process_stream_transition(
-    new_image: dict[str, Any], old_image: dict[str, Any] | None
-) -> bool:
-    if not new_image:
-        return False
-
-    status = _coerce_optional_string(new_image.get("status"))
-    if status not in TERMINAL_JOB_EVENTS:
-        return False
-
-    if _coerce_optional_string(new_image.get("webhook_url")) is None:
-        return False
-
-    if bool(new_image.get("webhook_delivered", False)):
-        return False
-
-    if old_image:
-        old_status = _coerce_optional_string(old_image.get("status"))
-        if old_status in TERMINAL_JOB_EVENTS:
-            return False
-
-    return True
-
-
-def _deserialize_image(image: Any) -> dict[str, Any]:
-    if not isinstance(image, dict):
-        return {}
-    return {key: _deserializer.deserialize(value) for key, value in image.items()}
-
-
-def _coerce_optional_string(value: Any) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        stripped = value.strip()
-        return stripped or None
-    return str(value)
+    return service.events.sign_payload(payload_bytes, secret)

--- a/src/webhook_delivery/integrations.py
+++ b/src/webhook_delivery/integrations.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import boto3
+import requests
+
+_sqs_client = None
+_http_session = None
+
+
+def get_sqs(*, region: str):
+    global _sqs_client
+    if _sqs_client is None:
+        _sqs_client = boto3.client("sqs", region_name=region)
+    return _sqs_client
+
+
+def get_http_session():
+    global _http_session
+    if _http_session is None:
+        _http_session = requests.Session()
+    return _http_session
+
+
+def deliver_webhook(
+    *,
+    webhook_url: str,
+    payload_bytes: bytes,
+    headers: dict[str, str],
+    timeout_seconds: int,
+) -> None:
+    response = get_http_session().post(
+        webhook_url,
+        data=payload_bytes,
+        headers=headers,
+        timeout=timeout_seconds,
+    )
+    response.raise_for_status()
+
+
+def enqueue_retry(
+    *,
+    region: str,
+    queue_url: str,
+    tenant_id: str,
+    app_id: str,
+    job_id: str,
+    attempt: int,
+    delay_seconds: int,
+) -> None:
+    get_sqs(region=region).send_message(
+        QueueUrl=queue_url,
+        DelaySeconds=delay_seconds,
+        MessageBody=json.dumps(
+            {
+                "tenantId": tenant_id,
+                "appId": app_id,
+                "jobId": job_id,
+                "attempt": attempt,
+            }
+        ),
+    )
+
+
+def send_to_dlq(
+    *,
+    region: str,
+    queue_url: str | None,
+    job_item: dict[str, Any],
+    attempt: int,
+    reason: str,
+) -> None:
+    if queue_url is None:
+        return
+
+    get_sqs(region=region).send_message(
+        QueueUrl=queue_url,
+        MessageBody=json.dumps(
+            {
+                "tenantId": job_item.get("tenant_id"),
+                "appId": job_item.get("app_id"),
+                "jobId": job_item.get("job_id"),
+                "webhookId": job_item.get("webhook_id"),
+                "attempt": attempt,
+                "reason": reason,
+            }
+        ),
+    )

--- a/src/webhook_delivery/persistence.py
+++ b/src/webhook_delivery/persistence.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from data_access import TenantContext, TenantScopedDynamoDB
+from data_access.models import TenantTier
+
+from . import events
+
+
+def load_retry_job(
+    *,
+    jobs_table: str,
+    tenant_id: str,
+    app_id: str,
+    job_id: str,
+) -> dict[str, Any] | None:
+    tenant_context = TenantContext(
+        tenant_id=tenant_id,
+        app_id=app_id,
+        tier=TenantTier.BASIC,
+        sub="webhook-delivery",
+    )
+    db = TenantScopedDynamoDB(tenant_context)
+    return db.get_item(jobs_table, {"PK": f"TENANT#{tenant_id}", "SK": f"JOB#{job_id}"})
+
+
+def tenant_context_from_job(job_item: dict[str, Any]) -> TenantContext:
+    tenant_id = events.coerce_optional_string(job_item.get("tenant_id"))
+    app_id = events.coerce_optional_string(job_item.get("app_id"))
+    if tenant_id is None or app_id is None:
+        raise ValueError("Job record is missing tenant_id or app_id")
+    return TenantContext(
+        tenant_id=tenant_id,
+        app_id=app_id,
+        tier=TenantTier.BASIC,
+        sub="webhook-delivery",
+    )
+
+
+def get_webhook_registration(
+    *,
+    tenants_table: str,
+    tenant_context: TenantContext,
+    webhook_id: str,
+) -> dict[str, Any] | None:
+    db = TenantScopedDynamoDB(tenant_context)
+    record = db.get_item(
+        tenants_table,
+        {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": f"WEBHOOK#{webhook_id}"},
+    )
+    if record is None:
+        return None
+    if str(record.get("tenant_id", "")) != tenant_context.tenant_id:
+        return None
+    return record
+
+
+def mark_delivery_state(
+    *,
+    jobs_table: str,
+    tenant_context: TenantContext,
+    job_id: str,
+    delivered: bool,
+    status: str,
+    attempts: int,
+    error: str | None,
+) -> None:
+    db = TenantScopedDynamoDB(tenant_context)
+    db.update_item(
+        jobs_table,
+        {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": f"JOB#{job_id}"},
+        (
+            "SET webhook_delivered = :delivered, "
+            "webhook_delivery_status = :status, "
+            "webhook_delivery_attempts = :attempts, "
+            "webhook_delivery_error = :error, "
+            "webhook_last_attempt_at = :last_attempt_at"
+        ),
+        {
+            ":delivered": delivered,
+            ":status": status,
+            ":attempts": attempts,
+            ":error": error,
+            ":last_attempt_at": datetime.now(UTC).isoformat(),
+        },
+    )

--- a/src/webhook_delivery/retry_policy.py
+++ b/src/webhook_delivery/retry_policy.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from src.bridge.utils import get_retry_jitter
+
+
+def should_retry(*, attempt: int, max_retry_attempts: int) -> bool:
+    return attempt <= max_retry_attempts
+
+
+def retry_delay_seconds(*, attempt: int) -> int:
+    base_delay = min(900, 2**attempt)
+    jittered_delay = int(get_retry_jitter(float(base_delay)))
+    if base_delay > 0:
+        return max(1, min(900, jittered_delay))
+    return 0

--- a/src/webhook_delivery/service.py
+++ b/src/webhook_delivery/service.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+from aws_lambda_powertools import Logger
+
+from . import events, integrations, persistence, retry_policy
+
+
+@dataclass(frozen=True)
+class DeliveryConfig:
+    region: str
+    jobs_table: str
+    tenants_table: str
+    retry_queue_url: str | None
+    dlq_url: str | None
+    max_retry_attempts: int
+    http_timeout_seconds: int
+    delivered_status: str
+    failed_status: str
+    retrying_status: str
+    skipped_status: str
+    terminal_job_events: dict[str, str]
+
+
+def process_stream_record(
+    record: dict[str, Any], *, config: DeliveryConfig, logger: Logger
+) -> None:
+    dynamodb_record = record.get("dynamodb", {})
+    new_image = events.deserialize_image(dynamodb_record.get("NewImage"))
+    old_image = events.deserialize_image(dynamodb_record.get("OldImage"))
+    if not events.should_process_stream_transition(
+        new_image,
+        old_image,
+        terminal_job_events=config.terminal_job_events,
+    ):
+        return
+    attempt_delivery(new_image, attempt=1, config=config, logger=logger)
+
+
+def process_retry_record(record: dict[str, Any], *, config: DeliveryConfig, logger: Logger) -> None:
+    retry_message = events.parse_retry_record(record)
+    if retry_message is None:
+        logger.warning("Ignoring malformed retry message")
+        return
+
+    job_item = persistence.load_retry_job(
+        jobs_table=config.jobs_table,
+        tenant_id=retry_message.tenant_id,
+        app_id=retry_message.app_id,
+        job_id=retry_message.job_id,
+    )
+    if job_item is None:
+        logger.warning("Ignoring retry for missing job", extra={"job_id": retry_message.job_id})
+        return
+    attempt_delivery(job_item, attempt=retry_message.attempt, config=config, logger=logger)
+
+
+def attempt_delivery(
+    job_item: dict[str, Any],
+    *,
+    attempt: int,
+    config: DeliveryConfig,
+    logger: Logger,
+) -> None:
+    tenant_context = persistence.tenant_context_from_job(job_item)
+    job_id = str(job_item.get("job_id", ""))
+    logger.append_keys(appid=tenant_context.app_id, tenantid=tenant_context.tenant_id, jobid=job_id)
+
+    event_name = config.terminal_job_events.get(str(job_item.get("status", "")))
+    webhook_url = events.coerce_optional_string(job_item.get("webhook_url"))
+    if event_name is None or webhook_url is None or bool(job_item.get("webhook_delivered", False)):
+        return
+
+    webhook_id = events.coerce_optional_string(job_item.get("webhook_id"))
+    if webhook_id is None:
+        _mark_and_send_dlq(
+            config=config,
+            tenant_context=tenant_context,
+            job_id=job_id,
+            job_item=job_item,
+            attempt=attempt,
+            error="Job is missing webhook_id required for signed delivery",
+            reason="missing-webhook-id",
+            logger=logger,
+        )
+        return
+
+    registration = persistence.get_webhook_registration(
+        tenants_table=config.tenants_table,
+        tenant_context=tenant_context,
+        webhook_id=webhook_id,
+    )
+    if registration is None:
+        _mark_and_send_dlq(
+            config=config,
+            tenant_context=tenant_context,
+            job_id=job_id,
+            job_item=job_item,
+            attempt=attempt,
+            error=f"Webhook registration '{webhook_id}' not found",
+            reason="missing-webhook-registration",
+            logger=logger,
+        )
+        return
+
+    if str(registration.get("status", "active")) != "active":
+        persistence.mark_delivery_state(
+            jobs_table=config.jobs_table,
+            tenant_context=tenant_context,
+            job_id=job_id,
+            delivered=False,
+            status=config.skipped_status,
+            attempts=attempt,
+            error="Webhook registration disabled",
+        )
+        return
+
+    subscribed_events = registration.get("events") or []
+    if event_name not in subscribed_events:
+        persistence.mark_delivery_state(
+            jobs_table=config.jobs_table,
+            tenant_context=tenant_context,
+            job_id=job_id,
+            delivered=False,
+            status=config.skipped_status,
+            attempts=attempt,
+            error=f"Webhook is not subscribed to {event_name}",
+        )
+        return
+
+    signature_secret = events.coerce_optional_string(registration.get("signature_secret"))
+    if signature_secret is None:
+        _mark_and_send_dlq(
+            config=config,
+            tenant_context=tenant_context,
+            job_id=job_id,
+            job_item=job_item,
+            attempt=attempt,
+            error="Webhook registration missing signature secret",
+            reason="missing-signature-secret",
+            logger=logger,
+        )
+        return
+
+    payload_bytes, headers = events.build_signed_request(job_item, event_name, signature_secret)
+
+    try:
+        integrations.deliver_webhook(
+            webhook_url=webhook_url,
+            payload_bytes=payload_bytes,
+            headers=headers,
+            timeout_seconds=config.http_timeout_seconds,
+        )
+    except requests.RequestException as exc:
+        handle_delivery_failure(
+            tenant_context=tenant_context,
+            job_item=job_item,
+            attempt=attempt,
+            error=str(exc),
+            config=config,
+            logger=logger,
+        )
+        return
+
+    persistence.mark_delivery_state(
+        jobs_table=config.jobs_table,
+        tenant_context=tenant_context,
+        job_id=job_id,
+        delivered=True,
+        status=config.delivered_status,
+        attempts=attempt,
+        error=None,
+    )
+    logger.info("Webhook delivered")
+
+
+def handle_delivery_failure(
+    *,
+    tenant_context,
+    job_item: dict[str, Any],
+    attempt: int,
+    error: str,
+    config: DeliveryConfig,
+    logger: Logger,
+) -> None:
+    job_id = str(job_item.get("job_id", ""))
+    if retry_policy.should_retry(attempt=attempt, max_retry_attempts=config.max_retry_attempts):
+        persistence.mark_delivery_state(
+            jobs_table=config.jobs_table,
+            tenant_context=tenant_context,
+            job_id=job_id,
+            delivered=False,
+            status=config.retrying_status,
+            attempts=attempt,
+            error=error,
+        )
+        if config.retry_queue_url is None:
+            raise RuntimeError("WEBHOOK_RETRY_QUEUE_URL is not configured")
+        integrations.enqueue_retry(
+            region=config.region,
+            queue_url=config.retry_queue_url,
+            tenant_id=str(job_item.get("tenant_id", "")),
+            app_id=str(job_item.get("app_id", "")),
+            job_id=job_id,
+            attempt=attempt + 1,
+            delay_seconds=retry_policy.retry_delay_seconds(attempt=attempt),
+        )
+        logger.warning(
+            "Webhook delivery failed, retry queued",
+            extra={"attempt": attempt, "error": error},
+        )
+        return
+
+    persistence.mark_delivery_state(
+        jobs_table=config.jobs_table,
+        tenant_context=tenant_context,
+        job_id=job_id,
+        delivered=False,
+        status=config.failed_status,
+        attempts=attempt,
+        error=error,
+    )
+    integrations.send_to_dlq(
+        region=config.region,
+        queue_url=config.dlq_url,
+        job_item=job_item,
+        attempt=attempt,
+        reason=error,
+    )
+    logger.error("Webhook delivery exhausted retries", extra={"attempt": attempt, "error": error})
+
+
+def _mark_and_send_dlq(
+    *,
+    config: DeliveryConfig,
+    tenant_context,
+    job_id: str,
+    job_item: dict[str, Any],
+    attempt: int,
+    error: str,
+    reason: str,
+    logger: Logger,
+) -> None:
+    persistence.mark_delivery_state(
+        jobs_table=config.jobs_table,
+        tenant_context=tenant_context,
+        job_id=job_id,
+        delivered=False,
+        status=config.failed_status,
+        attempts=attempt,
+        error=error,
+    )
+    integrations.send_to_dlq(
+        region=config.region,
+        queue_url=config.dlq_url,
+        job_item=job_item,
+        attempt=attempt,
+        reason=reason,
+    )

--- a/tests/unit/test_webhook_delivery_handler.py
+++ b/tests/unit/test_webhook_delivery_handler.py
@@ -69,6 +69,8 @@ def setup_delivery_env(aws_credentials):
 
         webhook_handler._sqs_client = None
         webhook_handler._http_session = None
+        webhook_handler.integrations._sqs_client = None
+        webhook_handler.integrations._http_session = None
         webhook_handler.JOBS_TABLE = "platform-jobs"
         webhook_handler.TENANTS_TABLE = "platform-tenants"
         webhook_handler.WEBHOOK_RETRY_QUEUE_URL = retry_queue_url
@@ -143,7 +145,7 @@ def test_delivers_signed_webhook_and_marks_job_delivered(setup_delivery_env):
     response = MagicMock()
     response.raise_for_status.return_value = None
 
-    with patch.object(webhook_handler, "get_http_session") as mock_get_http_session:
+    with patch.object(webhook_handler.integrations, "get_http_session") as mock_get_http_session:
         mock_post = MagicMock(return_value=response)
         mock_get_http_session.return_value.post = mock_post
         result = webhook_handler.handler(
@@ -178,7 +180,7 @@ def test_queues_retry_after_delivery_failure(setup_delivery_env):
     _seed_registration(tenants_table)
     job_item = _seed_job(jobs_table)
 
-    with patch.object(webhook_handler, "get_http_session") as mock_get_http_session:
+    with patch.object(webhook_handler.integrations, "get_http_session") as mock_get_http_session:
         mock_get_http_session.return_value.post = MagicMock(
             side_effect=requests.RequestException("temporary failure")
         )
@@ -213,7 +215,7 @@ def test_marks_job_failed_and_sends_dlq_after_retries_exhausted(setup_delivery_e
     _seed_registration(tenants_table)
     _seed_job(jobs_table)
 
-    with patch.object(webhook_handler, "get_http_session") as mock_get_http_session:
+    with patch.object(webhook_handler.integrations, "get_http_session") as mock_get_http_session:
         mock_get_http_session.return_value.post = MagicMock(
             side_effect=requests.RequestException("still failing")
         )

--- a/tests/unit/test_webhook_delivery_services.py
+++ b/tests/unit/test_webhook_delivery_services.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+
+from src.webhook_delivery import events, retry_policy
+
+
+def test_parse_retry_record_returns_none_for_missing_fields():
+    assert events.parse_retry_record({"body": json.dumps({"tenantId": "t-001"})}) is None
+
+
+def test_parse_retry_record_parses_expected_payload():
+    message = events.parse_retry_record(
+        {
+            "body": json.dumps(
+                {
+                    "tenantId": "t-001",
+                    "appId": "app-001",
+                    "jobId": "job-123",
+                    "attempt": 3,
+                }
+            )
+        }
+    )
+
+    assert message is not None
+    assert message.tenant_id == "t-001"
+    assert message.app_id == "app-001"
+    assert message.job_id == "job-123"
+    assert message.attempt == 3
+
+
+def test_retry_policy_caps_jittered_delay():
+    delay = retry_policy.retry_delay_seconds(attempt=12)
+    assert 1 <= delay <= 900


### PR DESCRIPTION
## Summary
- extract webhook event decoding, retry policy, persistence, and integration seams into focused modules
- keep the Lambda handler as the stable dispatch surface while preserving realistic end-to-end delivery tests
- fix retry delay behavior so delivery retries still use a positive queue delay

## Validation
- uv run ruff check src/webhook_delivery tests/unit/test_webhook_delivery_handler.py tests/unit/test_webhook_delivery_services.py
- uv run pytest tests/unit/test_webhook_delivery_handler.py tests/unit/test_webhook_delivery_services.py -q
- make preflight-session
- make pre-validate-session

Closes #424