### PR TITLE
refactor: split tenant lifecycle services

### DIFF
--- a/src/tenant_api/tenant_audit_exports.py
+++ b/src/tenant_api/tenant_audit_exports.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from datetime import timedelta
+from typing import Any
+
+from boto3.dynamodb.conditions import Key
+
+try:
+    from . import auth, constants, db_factory, db_utils, http_utils, models, utils, validation
+except (ImportError, ValueError):  # pragma: no cover
+    from src.tenant_api import (
+        auth,
+        constants,
+        db_factory,
+        db_utils,
+        http_utils,
+        models,
+        utils,
+        validation,
+    )
+
+
+def _invocation_timestamp(item: dict[str, Any]) -> str | None:
+    timestamp = utils.str_or_none(item.get("timestamp"))
+    if timestamp is not None:
+        return timestamp
+    sort_key = utils.str_or_none(item.get("SK"))
+    if sort_key is None or not sort_key.startswith("INV#"):
+        return None
+    parts = sort_key.split("#", 2)
+    if len(parts) < 3:
+        return None
+    return utils.str_or_none(parts[1])
+
+
+def _audit_export_sk_condition(*, start_at: Any, end_at: Any) -> Any:
+    start_text = f"INV#{utils.iso(start_at)}" if start_at is not None else None
+    end_text = f"INV#{utils.iso(end_at)}~" if end_at is not None else None
+    if start_text and end_text:
+        return Key("SK").between(start_text, end_text)
+    if start_text:
+        return Key("SK").gte(start_text)
+    if end_text:
+        return Key("SK").lte(end_text)
+    return None
+
+
+def _collect_audit_export_records(
+    *,
+    tenant_id: str,
+    caller: models.CallerIdentity,
+    app_id: str | None,
+    start_at: Any,
+    end_at: Any,
+) -> list[dict[str, Any]]:
+    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+    last_evaluated_key: dict[str, Any] | None = None
+    items: list[dict[str, Any]] = []
+    sk_condition = _audit_export_sk_condition(start_at=start_at, end_at=end_at)
+    start_text = utils.iso(start_at) if start_at is not None else None
+    end_text = utils.iso(end_at) if end_at is not None else None
+
+    while True:
+        page = db.query(
+            db_factory.invocations_table_name(),
+            sk_condition=sk_condition,
+            limit=constants.AUDIT_EXPORT_PAGE_SIZE,
+            exclusive_start_key=last_evaluated_key,
+        )
+        for item in page.items:
+            item_timestamp = _invocation_timestamp(item)
+            if item_timestamp is None:
+                continue
+            if start_text is not None and item_timestamp < start_text:
+                continue
+            if end_text is not None and item_timestamp > end_text:
+                continue
+            items.append(item)
+        last_evaluated_key = page.last_evaluated_key
+        if last_evaluated_key is None:
+            return items
+
+
+def _format_export_timestamp(value: Any) -> str:
+    return value.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _audit_export_url_expiry_seconds() -> int:
+    raw = os.environ.get("AUDIT_EXPORT_URL_EXPIRY_SECONDS")
+    return utils.coerce_positive_int(raw, default=constants.AUDIT_EXPORT_URL_EXPIRY_SECONDS)
+
+
+def _audit_export_key(tenant_id: str, generated_at: Any) -> str:
+    timestamp = _format_export_timestamp(generated_at)
+    nonce = secrets.token_hex(8)
+    return (
+        f"tenants/{tenant_id}/{constants.AUDIT_EXPORT_PREFIX}/audit-export-{timestamp}-{nonce}.json"
+    )
+
+
+def _build_audit_export_payload(
+    *,
+    tenant_id: str,
+    generated_at: Any,
+    start_at: Any,
+    end_at: Any,
+    records: list[dict[str, Any]],
+) -> bytes:
+    payload = {
+        "tenantId": tenant_id,
+        "generatedAt": utils.iso(generated_at),
+        "windowStart": utils.iso(start_at) if start_at is not None else None,
+        "windowEnd": utils.iso(end_at) if end_at is not None else None,
+        "recordCount": len(records),
+        "records": records,
+    }
+    return json.dumps(payload, default=utils.json_default).encode("utf-8")
+
+
+def handle_audit_export(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    auth.require_admin(caller)
+    existing = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if existing is None:
+        return http_utils.error(404, "NOT_FOUND", "Tenant not found")
+
+    query = event.get("queryStringParameters") or {}
+    start_at = validation.parse_optional_utc_timestamp(query.get("start"), field="start")
+    end_at = validation.parse_optional_utc_timestamp(query.get("end"), field="end")
+    if start_at is not None and end_at is not None and start_at > end_at:
+        raise ValueError("start must be less than or equal to end")
+
+    bucket = utils.str_or_none(os.environ.get(constants.AUDIT_EXPORT_BUCKET_ENV))
+    if bucket is None:
+        return http_utils.error(500, "INTERNAL_ERROR", "Audit export bucket is not configured")
+
+    app_id = utils.str_or_none(existing.get("appId"))
+    records = _collect_audit_export_records(
+        tenant_id=tenant_id,
+        caller=caller,
+        app_id=app_id,
+        start_at=start_at,
+        end_at=end_at,
+    )
+    generated_at = utils.now_utc()
+    object_key = _audit_export_key(tenant_id, generated_at)
+    payload = _build_audit_export_payload(
+        tenant_id=tenant_id,
+        generated_at=generated_at,
+        start_at=start_at,
+        end_at=end_at,
+        records=records,
+    )
+
+    try:
+        tenant_s3 = db_factory.s3_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+        tenant_s3.put_object(
+            bucket,
+            object_key,
+            payload,
+            ContentType="application/json",
+        )
+        expires_in = _audit_export_url_expiry_seconds()
+        download_url = tenant_s3.generate_presigned_url(bucket, object_key, expires_in=expires_in)
+    except Exception:
+        return http_utils.error(500, "INTERNAL_ERROR", "Failed to generate audit export")
+
+    expires_at = generated_at + timedelta(seconds=_audit_export_url_expiry_seconds())
+    return http_utils.response(
+        200,
+        {
+            "tenantId": tenant_id,
+            "downloadUrl": download_url,
+            "expiresAt": utils.iso(expires_at),
+        },
+    )

--- a/src/tenant_api/tenant_invites.py
+++ b/src/tenant_api/tenant_invites.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from boto3.dynamodb.conditions import Key
+
+try:
+    from . import auth, db_factory, db_utils, http_utils, models
+except (ImportError, ValueError):  # pragma: no cover
+    from src.tenant_api import auth, db_factory, db_utils, http_utils, models
+
+
+def handle_list_invites(
+    caller: models.CallerIdentity,
+    *,
+    tenant_id: str,
+) -> dict[str, object]:
+    if not auth.can_read_tenant(caller, tenant_id) or not auth.can_manage_tenant_self_service(
+        caller, tenant_id
+    ):
+        raise PermissionError("Access denied")
+
+    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    item = db.get_item(db_factory.tenants_table_name(), db_utils.tenant_key(tenant_id))
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    results = db.query(
+        db_factory.tenants_table_name(),
+        sk_condition=Key("SK").begins_with("INVITE#"),
+    )
+    invites = [
+        {
+            "inviteId": str(invite.get("inviteId", "")),
+            "tenantId": tenant_id,
+            "email": str(invite.get("email", "")),
+            "role": str(invite.get("role", "Agent.Invoke")),
+            "status": str(invite.get("status", "")),
+            "expiresAt": invite.get("expiresAt"),
+        }
+        for invite in results.items
+    ]
+    return http_utils.response(200, {"items": invites})

--- a/src/tenant_api/tenant_lifecycle.py
+++ b/src/tenant_api/tenant_lifecycle.py
@@ -1,44 +1,38 @@
 from __future__ import annotations
 
-import json
-import os
 import secrets
-from datetime import timedelta
 from typing import Any
 
-from boto3.dynamodb.conditions import Key
 from data_access.models import TenantStatus
 
 try:
     from . import (
-        auth,
         constants,
         db_factory,
         db_utils,
-        events,
         http_utils,
-        lifecycle_logic,
         models,
-        secrets_manager,
-        serialization,
+        tenant_audit_exports,
+        tenant_invites,
+        tenant_records,
+        tenant_sessions,
         utils,
-        validation,
     )
 except (ImportError, ValueError):  # pragma: no cover
     from src.tenant_api import (
-        auth,
         constants,
         db_factory,
         db_utils,
-        events,
         http_utils,
-        lifecycle_logic,
         models,
-        secrets_manager,
-        serialization,
+        tenant_audit_exports,
+        tenant_invites,
+        tenant_records,
+        tenant_sessions,
         utils,
-        validation,
     )
+
+tenant_audit_exports.secrets = secrets
 
 
 def handle_create(
@@ -46,64 +40,7 @@ def handle_create(
     caller: models.CallerIdentity,
     deps: models.TenantApiDependencies,
 ) -> dict[str, Any]:
-    auth.require_admin(caller)
-    body = http_utils.require_json_body(event)
-    required = ["tenantId", "appId", "displayName", "tier", "ownerEmail", "ownerTeam", "accountId"]
-    missing = [field for field in required if utils.str_or_none(body.get(field)) is None]
-    if missing:
-        raise ValueError(f"Missing required field(s): {', '.join(missing)}")
-
-    tenant_id = validation.canonical_tenant_id(body["tenantId"])
-    app_id = str(body["appId"]).strip()
-    now = utils.now_utc()
-    tier = lifecycle_logic.normalize_tier(body.get("tier"))
-
-    if db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller, app_id=app_id) is not None:
-        return http_utils.error(409, "CONFLICT", "Tenant already exists")
-
-    memory_info = deps.memory_provisioner.provision(tenant_id=tenant_id, app_id=app_id) or {}
-    api_key_secret_arn = secrets_manager.create_api_key_secret(
-        deps, tenant_id=tenant_id, app_id=app_id
-    )
-
-    attributes: dict[str, Any] = {
-        "tenantId": tenant_id,
-        "appId": app_id,
-        "displayName": str(body["displayName"]).strip(),
-        "tier": tier,
-        "status": TenantStatus.ACTIVE.value,
-        "createdAt": utils.iso(now),
-        "updatedAt": utils.iso(now),
-        "provisioningStatus": "pending",
-        "provisioningUpdatedAt": utils.iso(now),
-        "ownerEmail": str(body["ownerEmail"]).strip(),
-        "ownerTeam": str(body["ownerTeam"]).strip(),
-        "accountId": str(body["accountId"]).strip(),
-        "apiKeySecretArn": api_key_secret_arn,
-    }
-    if body.get("monthlyBudgetUsd") is not None:
-        attributes["monthlyBudgetUsd"] = utils.as_float(
-            body["monthlyBudgetUsd"], field="monthlyBudgetUsd"
-        )
-
-    # Save to DynamoDB
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
-    db.put_item(db_factory.tenants_table_name(), attributes)
-
-    # Emit event
-    events.put_event(
-        deps,
-        detail_type="platform.tenant.created",
-        detail={
-            "tenantId": tenant_id,
-            "appId": app_id,
-            "tier": tier,
-            "accountId": attributes["accountId"],
-            "memoryInfo": memory_info,
-        },
-    )
-
-    return http_utils.response(201, serialization.serialize_tenant(attributes))
+    return tenant_records.handle_create(event, caller, deps)
 
 
 def handle_read(
@@ -111,14 +48,7 @@ def handle_read(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    if not auth.can_read_tenant(caller, tenant_id):
-        raise PermissionError("Access denied")
-
-    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
-    if item is None:
-        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
-
-    return http_utils.response(200, serialization.serialize_tenant(item))
+    return tenant_records.handle_read(caller, tenant_id=tenant_id)
 
 
 def handle_update(
@@ -128,40 +58,7 @@ def handle_update(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    auth.require_admin(caller)
-    body = http_utils.require_json_body(event)
-
-    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
-    if item is None:
-        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
-
-    now = utils.now_utc()
-    updates: dict[str, Any] = {"updatedAt": utils.iso(now)}
-
-    if "displayName" in body:
-        updates["displayName"] = str(body["displayName"]).strip()
-    if "status" in body:
-        updates["status"] = lifecycle_logic.normalize_status(body["status"])
-    if "tier" in body:
-        updates["tier"] = lifecycle_logic.normalize_tier(body["tier"])
-    if "monthlyBudgetUsd" in body:
-        updates["monthlyBudgetUsd"] = utils.as_float(
-            body["monthlyBudgetUsd"], field="monthlyBudgetUsd"
-        )
-
-    expression, names, values = db_utils.build_update_expression(updates)
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
-    db.update_item(
-        db_factory.tenants_table_name(),
-        db_utils.tenant_key(tenant_id),
-        expression,
-        values,
-        expression_attribute_names=names,
-    )
-
-    # Re-fetch for response
-    updated_item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
-    return http_utils.response(200, serialization.serialize_tenant(updated_item or item))
+    return tenant_records.handle_update(event, caller, deps, tenant_id=tenant_id)
 
 
 def handle_delete(
@@ -170,34 +67,7 @@ def handle_delete(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    auth.require_admin(caller)
-
-    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
-    if item is None:
-        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
-
-    now = utils.now_utc()
-    # Soft delete: update status and set purge date
-    updates = {
-        "status": "deleted",
-        "deletedAt": utils.iso(now),
-        "purgeAtEpochSeconds": int(
-            (now + timedelta(days=constants.DELETE_RETENTION_DAYS)).timestamp()
-        ),
-        "updatedAt": utils.iso(now),
-    }
-
-    expression, names, values = db_utils.build_update_expression(updates)
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
-    db.update_item(
-        db_factory.tenants_table_name(),
-        db_utils.tenant_key(tenant_id),
-        expression,
-        values,
-        expression_attribute_names=names,
-    )
-
-    return http_utils.response(204, {})
+    return tenant_records.handle_delete(caller, deps, tenant_id=tenant_id)
 
 
 def handle_tenant_provisioning_event(
@@ -270,111 +140,7 @@ def handle_sessions(
     event: dict[str, Any],
     caller: models.CallerIdentity,
 ) -> dict[str, Any]:
-    # Placeholder for session listing
-    _ = event
-    _ = caller
-    return http_utils.response(200, {"items": []})
-
-
-def _invocation_timestamp(item: dict[str, Any]) -> str | None:
-    timestamp = utils.str_or_none(item.get("timestamp"))
-    if timestamp is not None:
-        return timestamp
-    sort_key = utils.str_or_none(item.get("SK"))
-    if sort_key is None or not sort_key.startswith("INV#"):
-        return None
-    parts = sort_key.split("#", 2)
-    if len(parts) < 3:
-        return None
-    return utils.str_or_none(parts[1])
-
-
-def _audit_export_sk_condition(
-    *,
-    start_at: Any,
-    end_at: Any,
-) -> Any:
-    start_text = f"INV#{utils.iso(start_at)}" if start_at is not None else None
-    end_text = f"INV#{utils.iso(end_at)}~" if end_at is not None else None
-    if start_text and end_text:
-        return Key("SK").between(start_text, end_text)
-    if start_text:
-        return Key("SK").gte(start_text)
-    if end_text:
-        return Key("SK").lte(end_text)
-    return None
-
-
-def _collect_audit_export_records(
-    *,
-    tenant_id: str,
-    caller: models.CallerIdentity,
-    app_id: str | None,
-    start_at: Any,
-    end_at: Any,
-) -> list[dict[str, Any]]:
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
-    last_evaluated_key: dict[str, Any] | None = None
-    items: list[dict[str, Any]] = []
-    sk_condition = _audit_export_sk_condition(start_at=start_at, end_at=end_at)
-    start_text = utils.iso(start_at) if start_at is not None else None
-    end_text = utils.iso(end_at) if end_at is not None else None
-
-    while True:
-        page = db.query(
-            db_factory.invocations_table_name(),
-            sk_condition=sk_condition,
-            limit=constants.AUDIT_EXPORT_PAGE_SIZE,
-            exclusive_start_key=last_evaluated_key,
-        )
-        for item in page.items:
-            item_timestamp = _invocation_timestamp(item)
-            if item_timestamp is None:
-                continue
-            if start_text is not None and item_timestamp < start_text:
-                continue
-            if end_text is not None and item_timestamp > end_text:
-                continue
-            items.append(item)
-        last_evaluated_key = page.last_evaluated_key
-        if last_evaluated_key is None:
-            return items
-
-
-def _format_export_timestamp(value: Any) -> str:
-    return value.strftime("%Y%m%dT%H%M%SZ")
-
-
-def _audit_export_url_expiry_seconds() -> int:
-    raw = os.environ.get("AUDIT_EXPORT_URL_EXPIRY_SECONDS")
-    return utils.coerce_positive_int(raw, default=constants.AUDIT_EXPORT_URL_EXPIRY_SECONDS)
-
-
-def _audit_export_key(tenant_id: str, generated_at: Any) -> str:
-    timestamp = _format_export_timestamp(generated_at)
-    nonce = secrets.token_hex(8)
-    return (
-        f"tenants/{tenant_id}/{constants.AUDIT_EXPORT_PREFIX}/audit-export-{timestamp}-{nonce}.json"
-    )
-
-
-def _build_audit_export_payload(
-    *,
-    tenant_id: str,
-    generated_at: Any,
-    start_at: Any,
-    end_at: Any,
-    records: list[dict[str, Any]],
-) -> bytes:
-    payload = {
-        "tenantId": tenant_id,
-        "generatedAt": utils.iso(generated_at),
-        "windowStart": utils.iso(start_at) if start_at is not None else None,
-        "windowEnd": utils.iso(end_at) if end_at is not None else None,
-        "recordCount": len(records),
-        "records": records,
-    }
-    return json.dumps(payload, default=utils.json_default).encode("utf-8")
+    return tenant_sessions.handle_sessions(event, caller)
 
 
 def handle_audit_export(
@@ -383,65 +149,7 @@ def handle_audit_export(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    auth.require_admin(caller)
-    existing = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
-    if existing is None:
-        return http_utils.error(404, "NOT_FOUND", "Tenant not found")
-
-    query = event.get("queryStringParameters") or {}
-    start_at = validation.parse_optional_utc_timestamp(query.get("start"), field="start")
-    end_at = validation.parse_optional_utc_timestamp(query.get("end"), field="end")
-    if start_at is not None and end_at is not None and start_at > end_at:
-        raise ValueError("start must be less than or equal to end")
-
-    bucket = utils.str_or_none(os.environ.get(constants.AUDIT_EXPORT_BUCKET_ENV))
-    if bucket is None:
-        return http_utils.error(500, "INTERNAL_ERROR", "Audit export bucket is not configured")
-
-    app_id = utils.str_or_none(existing.get("appId"))
-    records = _collect_audit_export_records(
-        tenant_id=tenant_id,
-        caller=caller,
-        app_id=app_id,
-        start_at=start_at,
-        end_at=end_at,
-    )
-    generated_at = utils.now_utc()
-    object_key = _audit_export_key(tenant_id, generated_at)
-    payload = _build_audit_export_payload(
-        tenant_id=tenant_id,
-        generated_at=generated_at,
-        start_at=start_at,
-        end_at=end_at,
-        records=records,
-    )
-
-    try:
-        tenant_s3 = db_factory.s3_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
-        tenant_s3.put_object(
-            bucket,
-            object_key,
-            payload,
-            ContentType="application/json",
-        )
-        expires_in = _audit_export_url_expiry_seconds()
-        download_url = tenant_s3.generate_presigned_url(
-            bucket,
-            object_key,
-            expires_in=expires_in,
-        )
-    except Exception:
-        return http_utils.error(500, "INTERNAL_ERROR", "Failed to generate audit export")
-
-    expires_at = generated_at + timedelta(seconds=_audit_export_url_expiry_seconds())
-    return http_utils.response(
-        200,
-        {
-            "tenantId": tenant_id,
-            "downloadUrl": download_url,
-            "expiresAt": utils.iso(expires_at),
-        },
-    )
+    return tenant_audit_exports.handle_audit_export(event, caller, tenant_id=tenant_id)
 
 
 def handle_list_invites(
@@ -449,33 +157,7 @@ def handle_list_invites(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    if not auth.can_read_tenant(caller, tenant_id) or not auth.can_manage_tenant_self_service(
-        caller, tenant_id
-    ):
-        raise PermissionError("Access denied")
-
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
-    item = db.get_item(db_factory.tenants_table_name(), db_utils.tenant_key(tenant_id))
-    if item is None:
-        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
-
-    results = db.query(
-        db_factory.tenants_table_name(),
-        sk_condition=Key("SK").begins_with("INVITE#"),
-    )
-
-    invites = [
-        {
-            "inviteId": str(invite.get("inviteId", "")),
-            "tenantId": tenant_id,
-            "email": str(invite.get("email", "")),
-            "role": str(invite.get("role", "Agent.Invoke")),
-            "status": str(invite.get("status", "")),
-            "expiresAt": invite.get("expiresAt"),
-        }
-        for invite in results.items
-    ]
-    return http_utils.response(200, {"items": invites})
+    return tenant_invites.handle_list_invites(caller, tenant_id=tenant_id)
 
 
 def dispatch_routes(

--- a/src/tenant_api/tenant_records.py
+++ b/src/tenant_api/tenant_records.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from data_access.models import TenantStatus
+
+try:
+    from . import (
+        auth,
+        constants,
+        db_factory,
+        db_utils,
+        events,
+        http_utils,
+        lifecycle_logic,
+        models,
+        secrets_manager,
+        serialization,
+        utils,
+        validation,
+    )
+except (ImportError, ValueError):  # pragma: no cover
+    from src.tenant_api import (
+        auth,
+        constants,
+        db_factory,
+        db_utils,
+        events,
+        http_utils,
+        lifecycle_logic,
+        models,
+        secrets_manager,
+        serialization,
+        utils,
+        validation,
+    )
+
+
+def handle_create(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+) -> dict[str, Any]:
+    auth.require_admin(caller)
+    body = http_utils.require_json_body(event)
+    required = ["tenantId", "appId", "displayName", "tier", "ownerEmail", "ownerTeam", "accountId"]
+    missing = [field for field in required if utils.str_or_none(body.get(field)) is None]
+    if missing:
+        raise ValueError(f"Missing required field(s): {', '.join(missing)}")
+
+    tenant_id = validation.canonical_tenant_id(body["tenantId"])
+    app_id = str(body["appId"]).strip()
+    now = utils.now_utc()
+    tier = lifecycle_logic.normalize_tier(body.get("tier"))
+
+    if db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller, app_id=app_id) is not None:
+        return http_utils.error(409, "CONFLICT", "Tenant already exists")
+
+    memory_info = deps.memory_provisioner.provision(tenant_id=tenant_id, app_id=app_id) or {}
+    api_key_secret_arn = secrets_manager.create_api_key_secret(
+        deps, tenant_id=tenant_id, app_id=app_id
+    )
+
+    attributes: dict[str, Any] = {
+        "tenantId": tenant_id,
+        "appId": app_id,
+        "displayName": str(body["displayName"]).strip(),
+        "tier": tier,
+        "status": TenantStatus.ACTIVE.value,
+        "createdAt": utils.iso(now),
+        "updatedAt": utils.iso(now),
+        "provisioningStatus": "pending",
+        "provisioningUpdatedAt": utils.iso(now),
+        "ownerEmail": str(body["ownerEmail"]).strip(),
+        "ownerTeam": str(body["ownerTeam"]).strip(),
+        "accountId": str(body["accountId"]).strip(),
+        "apiKeySecretArn": api_key_secret_arn,
+    }
+    if body.get("monthlyBudgetUsd") is not None:
+        attributes["monthlyBudgetUsd"] = utils.as_float(
+            body["monthlyBudgetUsd"], field="monthlyBudgetUsd"
+        )
+
+    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+    db.put_item(db_factory.tenants_table_name(), attributes)
+    events.put_event(
+        deps,
+        detail_type="platform.tenant.created",
+        detail={
+            "tenantId": tenant_id,
+            "appId": app_id,
+            "tier": tier,
+            "accountId": attributes["accountId"],
+            "memoryInfo": memory_info,
+        },
+    )
+    return http_utils.response(201, serialization.serialize_tenant(attributes))
+
+
+def handle_read(
+    caller: models.CallerIdentity,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    if not auth.can_read_tenant(caller, tenant_id):
+        raise PermissionError("Access denied")
+
+    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    return http_utils.response(200, serialization.serialize_tenant(item))
+
+
+def handle_update(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    _ = deps
+    auth.require_admin(caller)
+    body = http_utils.require_json_body(event)
+
+    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    now = utils.now_utc()
+    updates: dict[str, Any] = {"updatedAt": utils.iso(now)}
+    if "displayName" in body:
+        updates["displayName"] = str(body["displayName"]).strip()
+    if "status" in body:
+        updates["status"] = lifecycle_logic.normalize_status(body["status"])
+    if "tier" in body:
+        updates["tier"] = lifecycle_logic.normalize_tier(body["tier"])
+    if "monthlyBudgetUsd" in body:
+        updates["monthlyBudgetUsd"] = utils.as_float(
+            body["monthlyBudgetUsd"], field="monthlyBudgetUsd"
+        )
+
+    expression, names, values = db_utils.build_update_expression(updates)
+    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    db.update_item(
+        db_factory.tenants_table_name(),
+        db_utils.tenant_key(tenant_id),
+        expression,
+        values,
+        expression_attribute_names=names,
+    )
+    updated_item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    return http_utils.response(200, serialization.serialize_tenant(updated_item or item))
+
+
+def handle_delete(
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    _ = deps
+    auth.require_admin(caller)
+
+    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    now = utils.now_utc()
+    updates = {
+        "status": "deleted",
+        "deletedAt": utils.iso(now),
+        "purgeAtEpochSeconds": int(
+            (now + timedelta(days=constants.DELETE_RETENTION_DAYS)).timestamp()
+        ),
+        "updatedAt": utils.iso(now),
+    }
+    expression, names, values = db_utils.build_update_expression(updates)
+    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    db.update_item(
+        db_factory.tenants_table_name(),
+        db_utils.tenant_key(tenant_id),
+        expression,
+        values,
+        expression_attribute_names=names,
+    )
+    return http_utils.response(204, {})

--- a/src/tenant_api/tenant_sessions.py
+++ b/src/tenant_api/tenant_sessions.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from . import http_utils, models
+except (ImportError, ValueError):  # pragma: no cover
+    from src.tenant_api import http_utils, models
+
+
+def handle_sessions(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+) -> dict[str, object]:
+    _ = event
+    _ = caller
+    return http_utils.response(200, {"items": []})

--- a/tests/unit/test_tenant_lifecycle_split.py
+++ b/tests/unit/test_tenant_lifecycle_split.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.tenant_api import tenant_lifecycle
+
+
+def test_handle_create_delegates_to_tenant_records(monkeypatch) -> None:
+    expected = {"statusCode": 201}
+
+    def _fake_handle_create(event: dict[str, Any], caller: Any, deps: Any) -> dict[str, Any]:
+        assert event["httpMethod"] == "POST"
+        assert caller == "caller"
+        assert deps == "deps"
+        return expected
+
+    monkeypatch.setattr(tenant_lifecycle.tenant_records, "handle_create", _fake_handle_create)
+    assert tenant_lifecycle.handle_create({"httpMethod": "POST"}, "caller", "deps") is expected
+
+
+def test_handle_audit_export_delegates_to_audit_module(monkeypatch) -> None:
+    expected = {"statusCode": 200}
+
+    def _fake_handle_audit_export(
+        event: dict[str, Any], caller: Any, *, tenant_id: str
+    ) -> dict[str, Any]:
+        assert event["path"].endswith("/audit-export")
+        assert caller == "caller"
+        assert tenant_id == "t-001"
+        return expected
+
+    monkeypatch.setattr(
+        tenant_lifecycle.tenant_audit_exports,
+        "handle_audit_export",
+        _fake_handle_audit_export,
+    )
+    assert (
+        tenant_lifecycle.handle_audit_export(
+            {"path": "/v1/tenants/t-001/audit-export"},
+            "caller",
+            tenant_id="t-001",
+        )
+        is expected
+    )
+
+
+def test_handle_list_invites_delegates_to_invite_module(monkeypatch) -> None:
+    expected = {"statusCode": 200}
+
+    def _fake_handle_list_invites(caller: Any, *, tenant_id: str) -> dict[str, Any]:
+        assert caller == "caller"
+        assert tenant_id == "t-001"
+        return expected
+
+    monkeypatch.setattr(
+        tenant_lifecycle.tenant_invites,
+        "handle_list_invites",
+        _fake_handle_list_invites,
+    )
+    assert tenant_lifecycle.handle_list_invites("caller", tenant_id="t-001") is expected
+
+
+def test_handle_sessions_delegates_to_session_module(monkeypatch) -> None:
+    expected = {"statusCode": 501}
+
+    def _fake_handle_sessions(event: dict[str, Any], caller: Any) -> dict[str, Any]:
+        assert event["path"] == "/v1/sessions"
+        assert caller == "caller"
+        return expected
+
+    monkeypatch.setattr(tenant_lifecycle.tenant_sessions, "handle_sessions", _fake_handle_sessions)
+    assert tenant_lifecycle.handle_sessions({"path": "/v1/sessions"}, "caller") is expected


### PR DESCRIPTION
## Summary
- extract tenant record, audit export, invite listing, and sessions logic behind focused tenant lifecycle modules
- keep tenant lifecycle route dispatch stable while shrinking the monolithic module
- add direct wrapper tests for the new split points and keep audit/invite path validation green

## Validation
- uv run ruff check src/tenant_api/tenant_lifecycle.py src/tenant_api/tenant_records.py src/tenant_api/tenant_audit_exports.py src/tenant_api/tenant_invites.py src/tenant_api/tenant_sessions.py tests/unit/test_tenant_lifecycle_split.py
- uv run pytest tests/unit/test_tenant_api_handler.py -k "audit_export or list_invites_succeeds" tests/unit/test_tenant_lifecycle_split.py -q
- make preflight-session
- make pre-validate-session

Closes #419