### PR TITLE
Make agent layer builds concurrency-safe and hash-scoped

### DIFF
--- a/scripts/build_layer.py
+++ b/scripts/build_layer.py
@@ -28,6 +28,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 import tomllib
 import zipfile
 from pathlib import Path
@@ -155,6 +156,13 @@ def build_dependencies(dependencies: list[str], target_dir: Path) -> None:
     ]
     logger.info("Building arm64 dependencies for %d packages", len(dependencies))
     subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def create_build_workspace(agent_name: str, dep_hash: str) -> Path:
+    """Create a unique workspace under an agent/hash-scoped build root."""
+    scoped_root = BUILD_DIR / "layer-builds" / agent_name / dep_hash
+    scoped_root.mkdir(parents=True, exist_ok=True)
+    return Path(tempfile.mkdtemp(prefix="run-", dir=scoped_root))
 
 
 def _extract_wheel_tags(wheel_text: str) -> list[str]:
@@ -289,17 +297,21 @@ def run(agent_name: str, env: str) -> int:
     lockfile = read_agent_lockfile(agent_name)
     dep_hash = compute_dependency_hash(deps, lockfile_content=lockfile)
 
-    deps_dir = BUILD_DIR / "deps"
-    zip_path = BUILD_DIR / f"{agent_name}-deps-{dep_hash}.zip"
-    build_dependencies(deps, deps_dir)
-    verify_arm64_artifacts(deps_dir)
-    create_layer_zip(deps_dir, zip_path)
-    verify_arm64_zip(zip_path)
+    workspace_dir = create_build_workspace(agent_name, dep_hash)
+    deps_dir = workspace_dir / "deps"
+    zip_path = workspace_dir / f"{agent_name}-deps-{dep_hash}.zip"
+    try:
+        build_dependencies(deps, deps_dir)
+        verify_arm64_artifacts(deps_dir)
+        create_layer_zip(deps_dir, zip_path)
+        verify_arm64_zip(zip_path)
 
-    bucket = resolve_layer_bucket(env, aws_region)
-    key = f"layers/{zip_path.name}"
-    upload_layer_zip(zip_path, bucket=bucket, key=key, aws_region=aws_region)
-    put_layer_metadata(agent_name, env, dep_hash, key, aws_region)
+        bucket = resolve_layer_bucket(env, aws_region)
+        key = f"layers/{zip_path.name}"
+        upload_layer_zip(zip_path, bucket=bucket, key=key, aws_region=aws_region)
+        put_layer_metadata(agent_name, env, dep_hash, key, aws_region)
+    finally:
+        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     logger.info("Layer published for %s: s3://%s/%s", agent_name, bucket, key)
     print(f"LAYER_BUILT agent={agent_name} hash={dep_hash} s3=s3://{bucket}/{key}")

--- a/tests/unit/test_build_layer.py
+++ b/tests/unit/test_build_layer.py
@@ -91,6 +91,22 @@ def test_build_dependencies_uses_required_arm64_flags(
     assert captured["check"] is True
 
 
+def test_create_build_workspace_is_agent_hash_scoped_and_unique(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bl, "BUILD_DIR", tmp_path / ".build")
+
+    first = bl.create_build_workspace("echo-agent", "abc123")
+    second = bl.create_build_workspace("echo-agent", "abc123")
+
+    expected_root = tmp_path / ".build" / "layer-builds" / "echo-agent" / "abc123"
+    assert first.parent == expected_root
+    assert second.parent == expected_root
+    assert first != second
+    assert first.exists()
+    assert second.exists()
+
+
 def test_verify_arm64_zip_accepts_arm64_wheel_and_binary(tmp_path: Path) -> None:
     deps_dir = tmp_path / "deps"
     _write_arm64_deps_fixture(deps_dir)
@@ -127,8 +143,10 @@ def test_run_uploads_zip_and_updates_ssm(tmp_path: Path, monkeypatch: pytest.Mon
     monkeypatch.setenv("AWS_REGION", _REGION)
     monkeypatch.setenv("PLATFORM_LAYER_BUCKET", bucket)
     monkeypatch.setattr(bl, "BUILD_DIR", tmp_path / ".build")
+    captured: dict[str, Path] = {}
 
     def _fake_build_dependencies(_deps: list[str], target_dir: Path) -> None:
+        captured["deps_dir"] = target_dir
         _write_arm64_deps_fixture(target_dir)
 
     monkeypatch.setattr(bl, "build_dependencies", _fake_build_dependencies)
@@ -141,6 +159,10 @@ def test_run_uploads_zip_and_updates_ssm(tmp_path: Path, monkeypatch: pytest.Mon
         lockfile_content=bl.read_agent_lockfile("echo-agent"),
     )
     expected_key = f"layers/echo-agent-deps-{expected_hash}.zip"
+    expected_workspace_root = tmp_path / ".build" / "layer-builds" / "echo-agent" / expected_hash
+
+    assert captured["deps_dir"].parent.parent == expected_workspace_root
+    assert not captured["deps_dir"].parent.exists()
 
     ssm = boto3.client("ssm", region_name=_REGION)
     hash_param = ssm.get_parameter(Name="/platform/layers/dev/echo-agent/hash")


### PR DESCRIPTION
## Summary
- move layer dependency staging into a unique per-run workspace under an agent/hash-scoped build root
- keep the published layer zip name and hash contract stable while removing shared mutable `.build/deps` state
- add unit coverage that proves the workspace path is scoped and unique and that `run()` cleans up the per-run workspace

## Validation
- `uv run pytest tests/unit/test_build_layer.py`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #445