### PR TITLE
Externalize AppConfig extension layer version assumptions

### DIFF
--- a/infra/cdk/lib/platform-compute.ts
+++ b/infra/cdk/lib/platform-compute.ts
@@ -48,6 +48,28 @@ export interface PlatformComputeResources {
   readonly dlqs: Record<string, sqs.IQueue>;
 }
 
+const APPCONFIG_EXTENSION_LAYER_ARNS: Record<string, string> = {
+  'eu-west-2':
+    'arn:aws:lambda:eu-west-2:282860088358:layer:AWS-AppConfig-Extension-Arm64:190',
+};
+
+export function resolveAppConfigExtensionLayerArn(scope: Construct): string {
+  const stack = cdk.Stack.of(scope);
+  const override = stack.node.tryGetContext('appConfigExtensionLayerArn');
+  if (typeof override === 'string' && override.trim() !== '') {
+    return override.trim();
+  }
+
+  const arn = APPCONFIG_EXTENSION_LAYER_ARNS[stack.region];
+  if (!arn) {
+    throw new Error(
+      `No AppConfig extension layer ARN configured for region ${stack.region}. ` +
+        'Set CDK context "appConfigExtensionLayerArn" explicitly.',
+    );
+  }
+  return arn;
+}
+
 export function createPlatformCompute(
   scope: Construct,
   props: PlatformComputeProps,
@@ -66,11 +88,10 @@ export function createPlatformCompute(
   const dlqs: Record<string, sqs.IQueue> = {};
   const stack = cdk.Stack.of(scope);
 
-  // AWS AppConfig Lambda Extension Layer (eu-west-2)
   const appConfigExtension = lambda.LayerVersion.fromLayerVersionArn(
     scope,
     'AppConfigExtension',
-    `arn:aws:lambda:${stack.region}:434090535690:layer:AWS-AppConfig-Extension:162`,
+    resolveAppConfigExtensionLayerArn(scope),
   );
 
   const tenantMgmtFn = createPythonLambda({

--- a/infra/cdk/test/platform-compute.test.ts
+++ b/infra/cdk/test/platform-compute.test.ts
@@ -1,0 +1,37 @@
+import * as cdk from 'aws-cdk-lib';
+import { resolveAppConfigExtensionLayerArn } from '../lib/platform-compute';
+
+describe('platform compute AppConfig extension layer resolution', () => {
+  test('uses the explicit ARM64 layer ARN map for eu-west-2 by default', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'PlatformComputeLayerArnTest', {
+      env: {
+        account: '123456789012',
+        region: 'eu-west-2',
+      },
+    });
+
+    expect(resolveAppConfigExtensionLayerArn(stack)).toBe(
+      'arn:aws:lambda:eu-west-2:282860088358:layer:AWS-AppConfig-Extension-Arm64:190',
+    );
+  });
+
+  test('allows an explicit context override for the AppConfig extension layer ARN', () => {
+    const app = new cdk.App({
+      context: {
+        appConfigExtensionLayerArn:
+          'arn:aws:lambda:eu-west-2:111122223333:layer:Custom-AppConfig-Extension-Arm64:7',
+      },
+    });
+    const stack = new cdk.Stack(app, 'PlatformComputeLayerArnOverrideTest', {
+      env: {
+        account: '123456789012',
+        region: 'eu-west-2',
+      },
+    });
+
+    expect(resolveAppConfigExtensionLayerArn(stack)).toBe(
+      'arn:aws:lambda:eu-west-2:111122223333:layer:Custom-AppConfig-Extension-Arm64:7',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace the inline AppConfig Lambda extension ARN with an explicit resolver
- use a region-to-ARN map by default and allow a context override for deliberate updates
- add focused tests that prove the eu-west-2 ARM64 default and override behavior

## Validation
- `cd infra/cdk && npx jest --runInBand --runTestsByPath test/platform-compute.test.ts`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #447