### PR TITLE
Enforce zip-agent layer metadata invariants

### DIFF
--- a/src/bridge/discovery_service.py
+++ b/src/bridge/discovery_service.py
@@ -151,7 +151,10 @@ def resolve_agent_record(
             agents_table, {"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{agent_version}"}
         )
         if item and is_invokable_agent_status(_coerce_optional_string(item.get("status"))):
-            return _agent_record_from_item(item)
+            try:
+                return _agent_record_from_item(item)
+            except ValueError:
+                return None
         return None
 
     # Query for all versions and pick latest promoted
@@ -167,11 +170,22 @@ def resolve_agent_record(
         return None
 
     sorted_items = sorted(promoted_items, key=_agent_record_sort_key, reverse=True)
-    return _agent_record_from_item(sorted_items[0])
+    for item in sorted_items:
+        try:
+            return _agent_record_from_item(item)
+        except ValueError:
+            continue
+    return None
 
 
 def _agent_record_from_item(item: dict[str, Any]) -> AgentRecord:
     from data_access.models import AgentAgUiConfig, AgentRecord, AgentStatus
+
+    runtime_arn = _coerce_optional_string(item.get("runtime_arn"))
+    layer_hash = str(item.get("layer_hash", "")).strip()
+    layer_s3_key = str(item.get("layer_s3_key", "")).strip()
+    if runtime_arn is None and (layer_hash == "" or layer_s3_key == ""):
+        raise ValueError("Incomplete zip-agent layer metadata")
 
     ag_ui_item = item.get("ag_ui", {})
     return AgentRecord(
@@ -179,14 +193,14 @@ def _agent_record_from_item(item: dict[str, Any]) -> AgentRecord:
         version=str(item.get("version", "")),
         owner_team=str(item.get("owner_team", "")),
         tier_minimum=TenantTier(str(item.get("tier_minimum", TenantTier.BASIC.value))),
-        layer_hash=str(item.get("layer_hash", "")),
-        layer_s3_key=str(item.get("layer_s3_key", "")),
+        layer_hash=layer_hash,
+        layer_s3_key=layer_s3_key,
         script_s3_key=str(item.get("script_s3_key", "")),
         deployed_at=str(item.get("deployed_at", "")),
         invocation_mode=InvocationMode(str(item.get("invocation_mode", InvocationMode.SYNC.value))),
         streaming_enabled=bool(item.get("streaming_enabled", False)),
         status=AgentStatus(str(item.get("status", AgentStatus.PROMOTED.value))),
-        runtime_arn=_coerce_optional_string(item.get("runtime_arn")),
+        runtime_arn=runtime_arn,
         estimated_duration_seconds=item.get("estimated_duration_seconds"),
         ag_ui=AgentAgUiConfig(
             enabled=bool(ag_ui_item.get("enabled", False)),

--- a/src/tenant_api/agent_registry.py
+++ b/src/tenant_api/agent_registry.py
@@ -50,6 +50,26 @@ _REGISTER_MUTABLE_FIELDS = frozenset(
 )
 
 
+def _requires_zip_layer_metadata(item: dict[str, Any]) -> bool:
+    runtime_arn = str(item.get("runtime_arn", "")).strip()
+    return runtime_arn == ""
+
+
+def _validate_layer_metadata_invariants(item: dict[str, Any]) -> None:
+    if not _requires_zip_layer_metadata(item):
+        return
+
+    missing_fields: list[str] = []
+    if str(item.get("layer_hash", "")).strip() == "":
+        missing_fields.append("layerHash")
+    if str(item.get("layer_s3_key", "")).strip() == "":
+        missing_fields.append("layerS3Key")
+
+    if missing_fields:
+        joined = ", ".join(missing_fields)
+        raise ValueError(f"Zip-agent registration requires non-empty {joined}")
+
+
 def handle_list_agents(
     event: dict[str, Any],
     caller: models.CallerIdentity,
@@ -122,6 +142,8 @@ def handle_register_agent(
         "endpoint": str(body.get("agUiEndpoint", "")).strip() or None,
     }
     item["ag_ui"] = ag_ui
+
+    _validate_layer_metadata_invariants(item)
 
     db.put_item(db_factory.agents_table_name(), item)
 

--- a/tests/unit/test_bridge_data_access_paths.py
+++ b/tests/unit/test_bridge_data_access_paths.py
@@ -86,6 +86,51 @@ def test_resolve_agent_record_queries_control_plane_db_for_latest_promoted_versi
     mock_db.query.assert_called_once_with("platform-agents", pk_value="AGENT#echo-agent")
 
 
+def test_resolve_agent_record_skips_promoted_records_with_missing_zip_layer_metadata() -> None:
+    mock_db = MagicMock()
+    mock_db.query.return_value.items = [
+        {
+            "PK": "AGENT#echo-agent",
+            "SK": "VERSION#1.1.0",
+            "agent_name": "echo-agent",
+            "version": "1.1.0",
+            "owner_team": "platform",
+            "tier_minimum": "basic",
+            "layer_hash": "",
+            "layer_s3_key": "",
+            "script_s3_key": "script-1",
+            "deployed_at": "2026-01-03T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+            "status": "promoted",
+        },
+        {
+            "PK": "AGENT#echo-agent",
+            "SK": "VERSION#1.0.0",
+            "agent_name": "echo-agent",
+            "version": "1.0.0",
+            "owner_team": "platform",
+            "tier_minimum": "basic",
+            "layer_hash": "hash-0",
+            "layer_s3_key": "layer-0",
+            "script_s3_key": "script-0",
+            "deployed_at": "2026-01-02T00:00:00Z",
+            "invocation_mode": "sync",
+            "streaming_enabled": False,
+            "status": "promoted",
+        },
+    ]
+
+    record = discovery_service.resolve_agent_record(
+        mock_db,
+        agents_table="platform-agents",
+        agent_name="echo-agent",
+    )
+
+    assert record is not None
+    assert record.version == "1.0.0"
+
+
 def test_get_agent_detail_uses_platform_context_db_factory() -> None:
     mock_db = MagicMock()
     mock_db.query.return_value.items = [

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -2387,6 +2387,62 @@ def test_platform_register_agent_rejects_non_built_initial_status(
     assert ("AGENT#echo-agent", "VERSION#1.2.1") not in fake_state["db"].items
 
 
+def test_platform_register_agent_rejects_missing_zip_layer_metadata(
+    fake_state: dict[str, Any],
+) -> None:
+    event = _event(
+        method="POST",
+        body={
+            "agentName": "echo-agent",
+            "version": "1.2.2",
+            "ownerTeam": "platform",
+            "tierMinimum": "basic",
+            "layerHash": "",
+            "layerS3Key": "",
+            "scriptS3Key": "scripts/1.2.2.zip",
+            "invocationMode": "sync",
+        },
+        roles=["Platform.Admin"],
+        caller_tenant_id="platform",
+    )
+    event["path"] = "/v1/platform/agents"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 400
+    assert ("AGENT#echo-agent", "VERSION#1.2.2") not in fake_state["db"].items
+
+
+def test_platform_register_agent_allows_container_without_zip_layer_metadata(
+    fake_state: dict[str, Any],
+) -> None:
+    event = _event(
+        method="POST",
+        body={
+            "agentName": "echo-agent",
+            "version": "1.2.6",
+            "ownerTeam": "platform",
+            "tierMinimum": "basic",
+            "layerHash": "",
+            "layerS3Key": "",
+            "scriptS3Key": "",
+            "runtimeArn": "arn:runtime:echo-agent",
+            "invocationMode": "sync",
+        },
+        roles=["Platform.Admin"],
+        caller_tenant_id="platform",
+    )
+    event["path"] = "/v1/platform/agents"
+
+    response = _invoke(event)
+
+    assert response["statusCode"] == 201
+    item = fake_state["db"].items[("AGENT#echo-agent", "VERSION#1.2.6")]
+    assert item["runtime_arn"] == "arn:runtime:echo-agent"
+    assert item["layer_hash"] == ""
+    assert item["layer_s3_key"] == ""
+
+
 def test_platform_promote_agent_updates_metadata_and_emits_event(
     fake_state: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
## Summary
- reject zip-agent registrations that omit required `layerHash` / `layerS3Key`
- keep container/runtimeArn-based registrations valid without zip layer metadata
- make bridge discovery fail closed on incomplete legacy zip-agent records instead of materializing them as valid

## Validation
- `uv run pytest tests/unit/test_tenant_api_handler.py -k 'missing_zip_layer_metadata or container_without_zip_layer_metadata'`
- `uv run pytest tests/unit/test_bridge_data_access_paths.py -k 'missing_zip_layer_metadata or latest_promoted_version'`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #449