### PR TITLE
Enforce bootstrap account and region intent explicitly

### DIFF
--- a/docs/bootstrap-guide.md
+++ b/docs/bootstrap-guide.md
@@ -18,6 +18,17 @@ The platform bootstrap flow assumes one AWS account per environment.
 Record the AWS account ID for the target environment — needed for CDK bootstrap
 and IAM role verification.
 
+Before running any bootstrap step, export:
+
+```bash
+export BOOTSTRAP_ACCOUNT_ID=<target-account-id>
+export PLATFORM_HOME_REGION=eu-west-2
+export AWS_REGION=$PLATFORM_HOME_REGION
+```
+
+The bootstrap flow now fails closed if the active caller account does not match
+`BOOTSTRAP_ACCOUNT_ID` or if `AWS_REGION` does not match `PLATFORM_HOME_REGION`.
+
 ## Entra App Registration (manual — see entra-setup.md)
 
 This step cannot be automated. An Entra admin must create the app registration
@@ -82,6 +93,9 @@ The script checks what already exists before creating resources.
 
 To re-run a specific step using the corresponding make target:
 ```bash
+export BOOTSTRAP_ACCOUNT_ID=<target-account-id>
+export PLATFORM_HOME_REGION=eu-west-2
+export AWS_REGION=$PLATFORM_HOME_REGION
 make bootstrap-secrets ENV=dev          # re-run step: seed-secrets
 make bootstrap-gitlab-oidc ENV=dev      # re-run step: gitlab-oidc
 make bootstrap-post-deploy ENV=dev      # re-run step: post-deploy
@@ -90,6 +104,9 @@ make bootstrap-verify ENV=dev           # re-run step: verify
 
 Or call bootstrap.py directly with the step name:
 ```bash
+export BOOTSTRAP_ACCOUNT_ID=<target-account-id>
+export PLATFORM_HOME_REGION=eu-west-2
+export AWS_REGION=$PLATFORM_HOME_REGION
 uv run python scripts/bootstrap.py --step seed-secrets --env dev
 ```
 

--- a/docs/operations/RUNBOOK-000-bootstrap.md
+++ b/docs/operations/RUNBOOK-000-bootstrap.md
@@ -10,6 +10,17 @@ Bootstrap the platform from scratch into a new AWS environment. Run once per env
 - Entra app registration completed (see docs/entra-setup.md)
 - Record: Entra client ID, Entra tenant ID, GitLab project ID
 
+Export the target bootstrap contract before any step:
+
+```bash
+export BOOTSTRAP_ACCOUNT_ID=<target-account-id>
+export PLATFORM_HOME_REGION=eu-west-2
+export AWS_REGION=$PLATFORM_HOME_REGION
+```
+
+Bootstrap now fails closed when the active caller account does not match
+`BOOTSTRAP_ACCOUNT_ID` or when `AWS_REGION` is not the home region.
+
 ## Steps (run in order — each must succeed before proceeding)
 
 ### Step 1: CDK Bootstrap (all regions)

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -111,6 +111,14 @@ def require_aws_region() -> str:
     return region
 
 
+def require_bootstrap_account_id() -> str:
+    """Read the intended bootstrap AWS account from environment and fail closed if missing."""
+    account_id = os.environ.get("BOOTSTRAP_ACCOUNT_ID", "").strip()
+    if not account_id:
+        raise RuntimeError("BOOTSTRAP_ACCOUNT_ID must be set")
+    return account_id
+
+
 def _input_value(env_name: str, prompt: str, *, secret: bool) -> str:
     """Read from env first; fall back to interactive prompt."""
     from_env = os.environ.get(env_name)
@@ -160,6 +168,7 @@ def run_command(command: list[str], *, cwd: Path | None = None) -> dict[str, Any
 def build_context(env_name: str) -> BootstrapContext:
     """Create runtime context from environment + caller identity."""
     aws_region = require_aws_region()
+    intended_account_id = require_bootstrap_account_id()
     home_region = os.environ.get("PLATFORM_HOME_REGION", DEFAULT_HOME_REGION)
     runtime_region = os.environ.get("PLATFORM_RUNTIME_REGION", DEFAULT_RUNTIME_REGION)
     fallback_region = os.environ.get("PLATFORM_FALLBACK_REGION", DEFAULT_FALLBACK_REGION)
@@ -173,6 +182,17 @@ def build_context(env_name: str) -> BootstrapContext:
     identity = sts.get_caller_identity()
     account_id = str(identity["Account"])
     caller_arn = str(identity["Arn"])
+
+    if account_id != intended_account_id:
+        raise RuntimeError(
+            "Active AWS account does not match BOOTSTRAP_ACCOUNT_ID "
+            f"(active={account_id} expected={intended_account_id})"
+        )
+    if aws_region != home_region:
+        raise RuntimeError(
+            "AWS_REGION must match PLATFORM_HOME_REGION for bootstrap execution "
+            f"(aws_region={aws_region} home_region={home_region})"
+        )
 
     return BootstrapContext(
         env=env_name,
@@ -378,7 +398,7 @@ def step_seed_secrets(ctx: BootstrapContext) -> dict[str, Any]:
         ),
     }
 
-    secrets_client = boto3.client("secretsmanager", region_name=ctx.aws_region)
+    secrets_client = boto3.client("secretsmanager", region_name=ctx.home_region)
     secret_names: list[str] = []
     created = 0
     updated = 0
@@ -406,7 +426,7 @@ def step_seed_secrets(ctx: BootstrapContext) -> dict[str, Any]:
 
 def validate_seed_secrets(ctx: BootstrapContext) -> dict[str, Any]:
     """Validate required secrets exist."""
-    secrets_client = boto3.client("secretsmanager", region_name=ctx.aws_region)
+    secrets_client = boto3.client("secretsmanager", region_name=ctx.home_region)
     found: list[str] = []
     for template in SECRET_TEMPLATES.values():
         secret_name = template.format(env=ctx.env)

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -42,6 +42,58 @@ def _ctx() -> object:
     )
 
 
+def test_build_context_requires_expected_account_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    monkeypatch.delenv("BOOTSTRAP_ACCOUNT_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="BOOTSTRAP_ACCOUNT_ID must be set"):
+        bootstrap.build_context("dev")
+
+
+def test_build_context_rejects_account_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    monkeypatch.setenv("BOOTSTRAP_ACCOUNT_ID", "999988887777")
+
+    class FakeSts:
+        def get_caller_identity(self) -> dict[str, str]:
+            return {
+                "Account": "111122223333",
+                "Arn": "arn:aws:iam::111122223333:user/bootstrap-user",
+            }
+
+    monkeypatch.setattr(
+        bootstrap.boto3,
+        "client",
+        lambda service_name, region_name=None: FakeSts(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Active AWS account does not match BOOTSTRAP_ACCOUNT_ID",
+    ):
+        bootstrap.build_context("dev")
+
+
+def test_build_context_rejects_non_home_region_shell(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_REGION", "eu-central-1")
+    monkeypatch.setenv("BOOTSTRAP_ACCOUNT_ID", "111122223333")
+    monkeypatch.setenv("PLATFORM_HOME_REGION", _REGION)
+
+    class FakeSts:
+        def get_caller_identity(self) -> dict[str, str]:
+            return {
+                "Account": "111122223333",
+                "Arn": "arn:aws:iam::111122223333:user/bootstrap-user",
+            }
+
+    monkeypatch.setattr(bootstrap.boto3, "client", lambda service_name, region_name=None: FakeSts())
+
+    with pytest.raises(RuntimeError, match="AWS_REGION must match PLATFORM_HOME_REGION"):
+        bootstrap.build_context("dev")
+
+
 def test_parse_args_supports_first_deploy_step() -> None:
     args = bootstrap.parse_args(["--step", "first-deploy", "--env", "dev"])
     assert args.step == "first-deploy"
@@ -122,6 +174,46 @@ def test_upsert_secret_create_then_update() -> None:
     assert first == "created"
     assert second in {"created", "updated"}
     assert final_value == "value-2"
+
+
+def test_step_seed_secrets_uses_home_region_for_secret_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class FakeSecretsClient:
+        def create_secret(self, **_kwargs: object) -> None:
+            return None
+
+        def put_secret_value(self, **_kwargs: object) -> None:
+            return None
+
+    def _fake_client(service_name: str, *, region_name: str) -> FakeSecretsClient:
+        assert service_name == "secretsmanager"
+        calls.append(region_name)
+        return FakeSecretsClient()
+
+    monkeypatch.setattr(bootstrap.boto3, "client", _fake_client)
+    monkeypatch.setenv("BOOTSTRAP_ENTRA_CLIENT_ID", "client-id")
+    monkeypatch.setenv("BOOTSTRAP_ENTRA_TENANT_ID", "tenant-id")
+    monkeypatch.setenv("BOOTSTRAP_ENTRA_CLIENT_SECRET", "secret-value")
+    monkeypatch.setenv("BOOTSTRAP_PLATFORM_PRIVATE_KEY_PASSPHRASE", "passphrase")
+
+    ctx = bootstrap.BootstrapContext(
+        env="dev",
+        aws_region="eu-central-1",
+        home_region="eu-west-2",
+        runtime_region="eu-west-1",
+        fallback_region="eu-central-1",
+        account_id="111122223333",
+        caller_arn="arn:aws:iam::111122223333:user/bootstrap-user",
+        report_bucket="platform-bootstrap-reports-dev",
+        report_key="bootstrap-report.json",
+    )
+
+    bootstrap.step_seed_secrets(ctx)
+
+    assert calls == ["eu-west-2"]
 
 
 @mock_aws


### PR DESCRIPTION
## Summary
- require an explicit `BOOTSTRAP_ACCOUNT_ID` for bootstrap execution
- fail closed when the active caller account or `AWS_REGION` does not match the intended bootstrap account/home-region contract
- seed bootstrap secrets through the home region and document the enforced operator contract in the bootstrap guide and runbook

## Validation
- `uv run pytest tests/unit/test_bootstrap.py`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #459