### PR TITLE
Stabilize worktree closeout after self-removal

### DIFF
--- a/scripts/issue_tool/git_utils.py
+++ b/scripts/issue_tool/git_utils.py
@@ -32,7 +32,12 @@ def eprint(msg: str) -> None:
 
 def repo_root() -> Path:
     try:
-        return Path(run(["git", "rev-parse", "--show-toplevel"]).stdout.strip())
+        common_dir = Path(
+            run(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]).stdout.strip()
+        )
+        if common_dir.name == ".git":
+            return common_dir.parent.resolve()
+        return Path(run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()).resolve()
     except subprocess.CalledProcessError as exc:
         raise CliError("Not inside a git repository") from exc
 

--- a/tests/unit/test_issue_tool_git_utils.py
+++ b/tests/unit/test_issue_tool_git_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.issue_tool import git_utils
+
+
+def test_repo_root_prefers_git_common_dir_parent(monkeypatch) -> None:
+    root = Path("/tmp/repo")
+
+    def _run(cmd, **_kwargs):
+        if cmd == ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]:
+            return subprocess.CompletedProcess(cmd, 0, str(root / ".git"), "")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(git_utils, "run", _run)
+
+    assert git_utils.repo_root() == root


### PR DESCRIPTION
## Summary
- anchor issue-tool repo resolution to Git’s common directory instead of the current linked worktree
- keep closeout and branch cleanup anchored to the primary repo after the active worktree is removed
- add a focused regression test for `repo_root()` alongside the existing cleanup behavior test

## Validation
- `uv run pytest tests/unit/test_issue_tool_git_utils.py tests/unit/test_worktree_issues.py -k 'repo_root_prefers_git_common_dir_parent or cleanup_finished_worktree_changes_out_of_target_before_remove'`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #458