### PR TITLE
Make local startup readiness validate seeded state, not just endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,7 @@ dev:
 	docker compose up -d
 	uv run python scripts/wait_for_local_services.py
 	uv run python scripts/dev-bootstrap.py
+	uv run python scripts/wait_for_local_services.py --check-seeded-state
 	@echo ""
 	@echo "==> Local environment ready"
 	@echo "    Try: make dev-invoke"

--- a/docs/development/LOCAL-SETUP.md
+++ b/docs/development/LOCAL-SETUP.md
@@ -40,6 +40,8 @@ This starts:
 - **Mock JWKS endpoint** on :8766 — issues test JWTs
 
 Then seeds LocalStack with two test tenants and all SSM parameters.
+Startup is not considered ready until the post-bootstrap seeded state exists:
+required LocalStack tables, required SSM parameters, and a populated `.env.test`.
 
 ## Verifying the Setup
 
@@ -47,8 +49,9 @@ Then seeds LocalStack with two test tenants and all SSM parameters.
 make dev-invoke
 ```
 
-If this exits cleanly, the local invocation path is wired. Use `make test-int`
-for a stronger end-to-end check once the local stack is running.
+If this exits cleanly, the local invocation path is wired. `make dev` now also
+fails when endpoint health is green but the seeded local state is incomplete.
+Use `make test-int` for a stronger end-to-end check once the local stack is running.
 
 **Note**: The **Mock AgentCore Runtime** returns canned responses (defined in `tests/mocks/mock_runtime/main.py`). It does **not** execute your actual agent code. To test your agent's logic locally, use `make agent-test`.
 

--- a/scripts/wait_for_local_services.py
+++ b/scripts/wait_for_local_services.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.request import urlopen
+
+import boto3
 
 
 @dataclass(frozen=True)
@@ -20,6 +24,36 @@ LOCAL_DEV_SERVICES = (
     ServiceCheck("LocalStack", "http://localhost:4566/_localstack/health"),
     ServiceCheck("mock runtime", "http://localhost:8765/ping"),
     ServiceCheck("mock JWKS", "http://localhost:8766/health"),
+)
+
+DEFAULT_LOCALSTACK_ENDPOINT = "http://localhost:4566"
+DEFAULT_AWS_REGION = "eu-west-2"
+DEFAULT_ENV_TEST_PATH = Path(__file__).resolve().parents[1] / ".env.test"
+
+REQUIRED_TABLES = (
+    "platform-tenants",
+    "platform-agents",
+    "platform-invocations",
+    "platform-jobs",
+    "platform-sessions",
+    "platform-tools",
+    "platform-ops-locks",
+)
+
+REQUIRED_SSM_PARAMETERS = (
+    "/platform/config/runtime-region",
+    "/platform/config/fallback-region",
+    "/platform/config/env",
+    "/platform/config/jwks-url",
+    "/platform/config/api-audience",
+)
+
+REQUIRED_ENV_TEST_KEYS = (
+    "BASIC_TENANT_ID",
+    "BASIC_TENANT_JWT",
+    "PREMIUM_TENANT_ID",
+    "PREMIUM_TENANT_JWT",
+    "ADMIN_JWT",
 )
 
 
@@ -68,6 +102,58 @@ def wait_for_all_services(
         )
 
 
+def verify_seeded_state(
+    *,
+    localstack_endpoint: str,
+    aws_region: str,
+    env_test_path: Path,
+) -> None:
+    """Fail if required local seeded state is missing after dev-bootstrap."""
+    ddb = boto3.client(
+        "dynamodb",
+        region_name=aws_region,
+        endpoint_url=localstack_endpoint,
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "testing"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "testing"),
+    )
+    ssm = boto3.client(
+        "ssm",
+        region_name=aws_region,
+        endpoint_url=localstack_endpoint,
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "testing"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "testing"),
+    )
+
+    table_names = set(ddb.list_tables().get("TableNames", []))
+    missing_tables = [name for name in REQUIRED_TABLES if name not in table_names]
+    if missing_tables:
+        raise RuntimeError(
+            f"Local seeded state missing DynamoDB tables: {', '.join(missing_tables)}"
+        )
+
+    response = ssm.get_parameters(Names=list(REQUIRED_SSM_PARAMETERS))
+    found = {item.get("Name") for item in response.get("Parameters", [])}
+    missing_params = [name for name in REQUIRED_SSM_PARAMETERS if name not in found]
+    if missing_params:
+        raise RuntimeError(f"Local seeded state missing SSM params: {', '.join(missing_params)}")
+
+    if not env_test_path.exists():
+        raise RuntimeError(f"Local seeded state missing env file: {env_test_path}")
+
+    values: dict[str, str] = {}
+    for line in env_test_path.read_text(encoding="utf-8").splitlines():
+        if "=" not in line or line.startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+
+    missing_env_keys = [key for key in REQUIRED_ENV_TEST_KEYS if values.get(key, "") == ""]
+    if missing_env_keys:
+        raise RuntimeError(
+            f"Local seeded state missing env keys or values: {', '.join(missing_env_keys)}"
+        )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Wait until local development dependencies are healthy."
@@ -84,6 +170,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=2.0,
         help="Polling interval between readiness checks",
     )
+    parser.add_argument(
+        "--check-seeded-state",
+        action="store_true",
+        help="Validate LocalStack tables, SSM parameters, and .env.test after dev-bootstrap",
+    )
+    parser.add_argument(
+        "--localstack-endpoint",
+        default=DEFAULT_LOCALSTACK_ENDPOINT,
+        help="LocalStack endpoint used for seeded-state verification",
+    )
+    parser.add_argument(
+        "--aws-region",
+        default=DEFAULT_AWS_REGION,
+        help="AWS region used for LocalStack seeded-state verification",
+    )
+    parser.add_argument(
+        "--env-test-path",
+        default=str(DEFAULT_ENV_TEST_PATH),
+        help="Path to the .env.test file written by dev-bootstrap",
+    )
     return parser.parse_args(argv)
 
 
@@ -94,7 +200,16 @@ def main(argv: list[str] | None = None) -> int:
             timeout_seconds=args.timeout_seconds,
             interval_seconds=args.interval_seconds,
         )
+        if args.check_seeded_state:
+            verify_seeded_state(
+                localstack_endpoint=args.localstack_endpoint,
+                aws_region=args.aws_region,
+                env_test_path=Path(args.env_test_path),
+            )
     except TimeoutError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
     return 0

--- a/tests/unit/test_wait_for_local_services.py
+++ b/tests/unit/test_wait_for_local_services.py
@@ -79,3 +79,48 @@ def test_main_returns_non_zero_when_a_service_never_becomes_ready(monkeypatch, c
 
     assert rc == 1
     assert "boom" in capsys.readouterr().err
+
+
+def test_verify_seeded_state_rejects_missing_env_test_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _FakeDdb:
+        def list_tables(self) -> dict[str, list[str]]:
+            return {"TableNames": list(wait_for_local_services.REQUIRED_TABLES)}
+
+    class _FakeSsm:
+        def get_parameters(self, *, Names: list[str]) -> dict[str, list[dict[str, str]]]:
+            return {"Parameters": [{"Name": name, "Value": "ok"} for name in Names]}
+
+    clients = iter([_FakeDdb(), _FakeSsm()])
+
+    monkeypatch.setattr(
+        wait_for_local_services.boto3,
+        "client",
+        lambda *args, **kwargs: next(clients),
+    )
+
+    with pytest.raises(RuntimeError, match="missing env file"):
+        wait_for_local_services.verify_seeded_state(
+            localstack_endpoint="http://localhost:4566",
+            aws_region="eu-west-2",
+            env_test_path=tmp_path / ".env.test",
+        )
+
+
+def test_main_returns_non_zero_when_seeded_state_is_incomplete(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        wait_for_local_services,
+        "wait_for_all_services",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        wait_for_local_services,
+        "verify_seeded_state",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("missing env file")),
+    )
+
+    rc = wait_for_local_services.main(["--check-seeded-state"])
+
+    assert rc == 1
+    assert "missing env file" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- add a seeded-state verification path for local startup after `dev-bootstrap`
- make `make dev` fail when required LocalStack tables, SSM params, or `.env.test` outputs are missing even if endpoints are healthy
- update local setup docs to describe the stronger readiness contract

## Validation
- `uv run pytest tests/unit/test_wait_for_local_services.py -q`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #456