### PR TITLE
Split issue-tool closeout helpers into a dedicated module

### DIFF
--- a/scripts/issue_tool/cli.py
+++ b/scripts/issue_tool/cli.py
@@ -35,6 +35,24 @@ from scripts.issue_tool.agent_launch import (
     launch_interactive_session,
     resolve_launch_request,
 )
+from scripts.issue_tool.closeout import (
+    cleanup_finished_worktree as _cleanup_finished_worktree,
+)
+from scripts.issue_tool.closeout import (
+    closeout_event as _closeout_event,
+)
+from scripts.issue_tool.closeout import (
+    closeout_report_path as _closeout_report_path,
+)
+from scripts.issue_tool.closeout import (
+    read_closeout_report,
+)
+from scripts.issue_tool.closeout import (
+    verify_cleanup_finished as _verify_cleanup_finished,
+)
+from scripts.issue_tool.closeout import (
+    write_closeout_report as _write_closeout_report,
+)
 from scripts.issue_tool.constants import (
     ANSI_ESCAPE_RE,
     CR_TITLE_RE,
@@ -2264,59 +2282,30 @@ def finish_summary(root: Path, *, path: Path | None = None) -> None:
 
 
 def cleanup_finished_worktree(root: Path, target: WorktreeInfo) -> dict[str, bool]:
-    result = {
-        "worktree_removed": False,
-        "branch_deleted": False,
-        "worktree_pruned": False,
-    }
-    branch = target.branch
-    print("Cleaning up worktree...")
-    try:
-        cwd = Path(os.getcwd()).resolve()
-    except FileNotFoundError:
-        cwd = None
-    if cwd is None or cwd == target.path.resolve() or target.path.resolve() in cwd.parents:
-        os.chdir(root)
-    if target.path.exists():
-        run(["git", "worktree", "remove", str(target.path)], cwd=root)
-        print(f"Removed worktree {target.path}")
-        result["worktree_removed"] = True
-    else:
-        print(f"Worktree path missing, skipping remove: {target.path}")
-    if branch and branch != "(detached)" and WORKTREE_BRANCH_REGEX.fullmatch(branch):
-        if local_branch_exists(root, branch):
-            run(["git", "branch", "-d", branch], cwd=root)
-            print(f"Deleted branch {branch}")
-            result["branch_deleted"] = True
-        else:
-            print(f"Branch already absent, skipping delete: {branch}")
-    run(["git", "worktree", "prune"], cwd=root)
-    print("Pruned stale worktree refs")
-    result["worktree_pruned"] = True
-    return result
+    return _cleanup_finished_worktree(
+        root,
+        target,
+        local_branch_exists_fn=local_branch_exists,
+        os_module=os,
+        run_fn=run,
+    )
 
 
 def closeout_report_path(root: Path, target: WorktreeInfo) -> Path:
-    issue_id = extract_issue_id_from_branch(target.branch) or "unknown"
-    safe_branch = re.sub(r"[^A-Za-z0-9._-]+", "_", target.branch)
-    return root / WORKTREE_CLOSEOUT_DIR / f"issue-{issue_id}-{safe_branch}.json"
+    return _closeout_report_path(
+        root,
+        target,
+        extract_issue_id_from_branch_fn=extract_issue_id_from_branch,
+    )
 
 
 def write_closeout_report(root: Path, target: WorktreeInfo, payload: dict[str, object]) -> Path:
-    path = closeout_report_path(root, target)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    record = {
-        "branch": target.branch,
-        "generated_at": datetime.now(UTC).isoformat(),
-        "worktree_path": str(target.path),
-        **payload,
-    }
-    path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    return path
-
-
-def read_closeout_report(path: Path) -> dict[str, object]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    return _write_closeout_report(
+        root,
+        target,
+        payload,
+        extract_issue_id_from_branch_fn=extract_issue_id_from_branch,
+    )
 
 
 def closeout_event(
@@ -2327,35 +2316,22 @@ def closeout_event(
     repo: str | None,
     issue_id: int | None,
 ) -> dict[str, object]:
-    return {
-        "ts": datetime.now(UTC).isoformat(),
-        "pid": os.getpid(),
-        "stage": stage,
-        "message": message,
-        "branch": target.branch,
-        "worktree_path": str(target.path),
-        "repo": repo,
-        "issue_id": issue_id,
-    }
+    return _closeout_event(
+        stage=stage,
+        message=message,
+        target=target,
+        repo=repo,
+        issue_id=issue_id,
+    )
 
 
 def verify_cleanup_finished(root: Path, target: WorktreeInfo) -> list[str]:
-    issues: list[str] = []
-    current_worktrees = list_worktrees(root)
-    if any(
-        wt.path.resolve() == target.path.resolve() for wt in current_worktrees if wt.path.exists()
-    ):
-        issues.append(f"worktree still registered: {target.path}")
-    if target.path.exists():
-        issues.append(f"worktree path still exists: {target.path}")
-    if (
-        target.branch
-        and target.branch != "(detached)"
-        and WORKTREE_BRANCH_REGEX.fullmatch(target.branch)
-    ):
-        if local_branch_exists(root, target.branch):
-            issues.append(f"local branch still exists: {target.branch}")
-    return issues
+    return _verify_cleanup_finished(
+        root,
+        target,
+        list_worktrees_fn=list_worktrees,
+        local_branch_exists_fn=local_branch_exists,
+    )
 
 
 def close_issue_done(root: Path, *, path: Path | None = None, force: bool = False) -> None:

--- a/scripts/issue_tool/closeout.py
+++ b/scripts/issue_tool/closeout.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.issue_tool.constants import WORKTREE_BRANCH_REGEX, WORKTREE_CLOSEOUT_DIR
+from scripts.issue_tool.git_utils import run
+from scripts.issue_tool.models import WorktreeInfo
+
+
+def cleanup_finished_worktree(
+    root: Path,
+    target: WorktreeInfo,
+    *,
+    local_branch_exists_fn: Callable[[Path, str], bool],
+    os_module=os,
+    run_fn=run,
+) -> dict[str, bool]:
+    result = {
+        "worktree_removed": False,
+        "branch_deleted": False,
+        "worktree_pruned": False,
+    }
+    branch = target.branch
+    print("Cleaning up worktree...")
+    try:
+        cwd = Path(os_module.getcwd()).resolve()
+    except FileNotFoundError:
+        cwd = None
+    if cwd is None or cwd == target.path.resolve() or target.path.resolve() in cwd.parents:
+        os_module.chdir(root)
+    if target.path.exists():
+        run_fn(["git", "worktree", "remove", str(target.path)], cwd=root)
+        print(f"Removed worktree {target.path}")
+        result["worktree_removed"] = True
+    else:
+        print(f"Worktree path missing, skipping remove: {target.path}")
+    if branch and branch != "(detached)" and WORKTREE_BRANCH_REGEX.fullmatch(branch):
+        if local_branch_exists_fn(root, branch):
+            run_fn(["git", "branch", "-d", branch], cwd=root)
+            print(f"Deleted branch {branch}")
+            result["branch_deleted"] = True
+        else:
+            print(f"Branch already absent, skipping delete: {branch}")
+    run_fn(["git", "worktree", "prune"], cwd=root)
+    print("Pruned stale worktree refs")
+    result["worktree_pruned"] = True
+    return result
+
+
+def closeout_report_path(
+    root: Path,
+    target: WorktreeInfo,
+    *,
+    extract_issue_id_from_branch_fn: Callable[[str], int | None],
+) -> Path:
+    issue_id = extract_issue_id_from_branch_fn(target.branch) or "unknown"
+    safe_branch = re.sub(r"[^A-Za-z0-9._-]+", "_", target.branch)
+    return root / WORKTREE_CLOSEOUT_DIR / f"issue-{issue_id}-{safe_branch}.json"
+
+
+def write_closeout_report(
+    root: Path,
+    target: WorktreeInfo,
+    payload: dict[str, object],
+    *,
+    extract_issue_id_from_branch_fn: Callable[[str], int | None],
+) -> Path:
+    path = closeout_report_path(
+        root, target, extract_issue_id_from_branch_fn=extract_issue_id_from_branch_fn
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "branch": target.branch,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "worktree_path": str(target.path),
+        **payload,
+    }
+    path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def read_closeout_report(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def closeout_event(
+    *,
+    stage: str,
+    message: str,
+    target: WorktreeInfo,
+    repo: str | None,
+    issue_id: int | None,
+) -> dict[str, object]:
+    return {
+        "ts": datetime.now(UTC).isoformat(),
+        "pid": os.getpid(),
+        "stage": stage,
+        "message": message,
+        "branch": target.branch,
+        "worktree_path": str(target.path),
+        "repo": repo,
+        "issue_id": issue_id,
+    }
+
+
+def verify_cleanup_finished(
+    root: Path,
+    target: WorktreeInfo,
+    *,
+    list_worktrees_fn: Callable[[Path], list[WorktreeInfo]],
+    local_branch_exists_fn: Callable[[Path, str], bool],
+) -> list[str]:
+    issues: list[str] = []
+    current_worktrees = list_worktrees_fn(root)
+    if any(
+        wt.path.resolve() == target.path.resolve() for wt in current_worktrees if wt.path.exists()
+    ):
+        issues.append(f"worktree still registered: {target.path}")
+    if target.path.exists():
+        issues.append(f"worktree path still exists: {target.path}")
+    if (
+        target.branch
+        and target.branch != "(detached)"
+        and WORKTREE_BRANCH_REGEX.fullmatch(target.branch)
+    ):
+        if local_branch_exists_fn(root, target.branch):
+            issues.append(f"local branch still exists: {target.branch}")
+    return issues

--- a/tests/unit/test_worktree_issues.py
+++ b/tests/unit/test_worktree_issues.py
@@ -412,7 +412,7 @@ def test_write_validation_receipt_writes_issue_scoped_receipt(tmp_path):
     payload = json.loads(receipt_path.read_text(encoding="utf-8"))
     assert payload["issue_number"] == 33
     assert payload["branch"] == "wt/task/33-test"
-    assert payload["head_sha"] == "abc123def456"
+    assert payload["head_sha"] == "abc123def456"  # pragma: allowlist secret
     assert payload["check"] == "validate-pre-push"
     assert payload["result"] == "pass"
 
@@ -1852,6 +1852,8 @@ def test_launch_zellij_batch_session_adds_tabs_to_existing_session(monkeypatch, 
 
 
 def test_close_issue_done_normalizes_labels_for_already_closed_issue(monkeypatch, capsys, tmp_path):
+    from scripts.issue_tool import github_client
+
     root = tmp_path / "repo"
     root.mkdir(parents=True, exist_ok=True)
     target = worktree_issues.WorktreeInfo(
@@ -1905,8 +1907,10 @@ def test_close_issue_done_normalizes_labels_for_already_closed_issue(monkeypatch
         return ""
 
     monkeypatch.setattr(worktree_issues, "gh_text", _gh_text)
+    monkeypatch.setattr(github_client, "gh_text", _gh_text)
     monkeypatch.setattr(worktree_issues, "issue_has_handback_comment", lambda **_kwargs: False)
     monkeypatch.setattr(worktree_issues, "ensure_label_exists", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(github_client, "ensure_label_exists", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         worktree_issues,
         "local_branch_exists",


### PR DESCRIPTION
## Summary
- extract issue-tool closeout/reporting helpers into a dedicated `scripts/issue_tool/closeout.py` module
- keep `scripts/issue_tool/cli.py` as the command surface while delegating the closeout seam to the extracted helper module
- preserve the existing cleanup and closed-issue normalization behavior with the current test seams intact

## Validation
- `uv run pytest tests/unit/test_worktree_issues.py -k 'cleanup_finished_worktree_changes_out_of_target_before_remove or close_issue_done_normalizes_labels_for_already_closed_issue'`
- `make preflight-session`
- `make pre-validate-session`
- `make worktree-push-issue`

Closes #455