### PR TITLE
Split Bridge handler into thin adapter and runtime services

### DIFF
--- a/src/bridge/discovery_service.py
+++ b/src/bridge/discovery_service.py
@@ -188,6 +188,16 @@ def _agent_record_from_item(item: dict[str, Any]) -> AgentRecord:
         raise ValueError("Incomplete zip-agent layer metadata")
 
     ag_ui_item = item.get("ag_ui", {})
+    if not isinstance(ag_ui_item, dict):
+        ag_ui_item = {}
+    if not ag_ui_item and any(
+        key in item for key in ("ag_ui_enabled", "ag_ui_transport", "ag_ui_endpoint")
+    ):
+        ag_ui_item = {
+            "enabled": bool(item.get("ag_ui_enabled", False)),
+            "transport": str(item.get("ag_ui_transport", AgUiTransport.SSE.value)),
+            "endpoint": _coerce_optional_string(item.get("ag_ui_endpoint")),
+        }
     return AgentRecord(
         agent_name=str(item.get("agent_name", "")),
         version=str(item.get("version", "")),

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import secrets
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -24,7 +23,6 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Key
-from botocore.config import Config
 from botocore.exceptions import (
     ClientError,
     ConnectTimeoutError,
@@ -47,22 +45,20 @@ from data_access.models import (
 )
 
 from src.bridge import (
-    config_provider,
     constants,
     lock_manager,
     role_resolver,
+    route_adapter,
+    runtime_calls,
+    runtime_dependencies,
     telemetry,
-)
-from src.bridge.config_provider import (
-    ConfigProvider,
-    config_defaults,
-    fetch_ssm_config,
 )
 from src.bridge.constants import (
     AG_UI_SCOPE_NAME,
-    AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS,
-    AGENTCORE_RUNTIME_READ_TIMEOUT_SECONDS,
     AGENTS_TABLE,
+    BFF_SESSION_KEEPALIVE_PATH,
+    BFF_TOKEN_REFRESH_PATH,
+    ENTRA_AUDIENCE,
     IAM_ROLE_ARN_PATTERN,
     INVOCATION_TTL_SECONDS,
     INVOCATIONS_TABLE,
@@ -73,9 +69,13 @@ from src.bridge.constants import (
     OPS_LOCKS_TABLE,
     RUNTIME_ARN_PATTERN,
     RUNTIME_REGION_PARAM,
+    SESSIONS_TABLE,
     TENANTS_TABLE,
 )
 
+from .discovery_service import (
+    get_agent_detail as discovery_get_agent_detail,
+)
 from .discovery_service import (
     get_job_status as discovery_get_job_status,
 )
@@ -91,64 +91,18 @@ from .runtime_orchestrator import build_runtime_orchestrator
 logger = Logger(service="bridge")
 tracer = Tracer()
 
-
-def _aws_region() -> str:
-    return os.environ["AWS_REGION"]
-
-
-def get_capability_client() -> TenantCapabilityClient:
-    return TenantCapabilityClient()
+_ssm_client: Any | None = None
+_sts_client: Any | None = None
+_cloudwatch_client: Any | None = None
 
 
-def get_ssm() -> Any:
-    return boto3.client("ssm", region_name=_aws_region())
-
-
-def get_sts() -> Any:
-    return boto3.client("sts", region_name=_aws_region())
-
-
-def get_cloudwatch() -> Any:
-    return boto3.client("cloudwatch", region_name=_aws_region())
-
-
-def get_http_session() -> requests.Session:
-    return requests.Session()
-
-
-def get_config(force_refresh: bool = False) -> dict[str, Any]:
-    provider = ConfigProvider(
-        fetcher=lambda: fetch_ssm_config(get_ssm(), get_http_session()),
-        fallback_factory=config_defaults,
-        ttl_seconds=60,
-    )
-    return provider.get(force_refresh=force_refresh)
-
-
-def get_runtime_client(region: str, credentials: dict[str, Any] | None = None) -> Any:
-    session_kwargs: dict[str, Any] = {"region_name": region}
-    if credentials:
-        session_kwargs.update(
-            {
-                "aws_access_key_id": credentials["AccessKeyId"],
-                "aws_secret_access_key": credentials["SecretAccessKey"],
-                "aws_session_token": credentials["SessionToken"],
-            }
-        )
-
-    session = boto3.Session(**session_kwargs)
-    client_kwargs: dict[str, Any] = {
-        "service_name": "bedrock-agentcore",
-        "region_name": region,
-        "config": Config(
-            connect_timeout=AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS,
-            read_timeout=AGENTCORE_RUNTIME_READ_TIMEOUT_SECONDS,
-            retries={"max_attempts": 1, "mode": "standard"},
-        ),
-    }
-    if os.environ.get("BEDROCK_AGENTCORE_DP_ENDPOINT"):
-        client_kwargs["endpoint_url"] = os.environ.get("BEDROCK_AGENTCORE_DP_ENDPOINT")
-    return session.client(**client_kwargs)
+get_capability_client = runtime_dependencies.get_capability_client
+get_ssm = runtime_dependencies.get_ssm
+get_sts = runtime_dependencies.get_sts
+get_cloudwatch = runtime_dependencies.get_cloudwatch
+get_http_session = runtime_dependencies.get_http_session
+get_config = runtime_dependencies.get_config
+get_runtime_client = runtime_dependencies.get_runtime_client
 
 
 def trigger_failover(current_region: str) -> str:
@@ -173,24 +127,27 @@ _assume_tenant_role = role_resolver.assume_tenant_role
 _AGENTS_TABLE = AGENTS_TABLE
 
 
-def get_platform_context() -> TenantContext:
-    return TenantContext(
-        tenant_id="platform",
-        app_id="platform-bridge",
-        tier=TenantTier.PREMIUM,
-        sub="bridge-lambda",
+def _get_execution_role_arn_from_ssm(tenant_id: str) -> str | None:
+    return _resolve_tenant_execution_role(get_ssm(), tenant_id=tenant_id)
+
+
+def assume_tenant_role(tenant_id: str, role_arn: str) -> dict[str, Any]:
+    return _assume_tenant_role(
+        get_sts(),
+        role_arn=role_arn,
+        session_name=f"invoke-{tenant_id[:8]}",
     )
 
 
+def get_platform_context() -> TenantContext:
+    return runtime_dependencies.get_platform_context()
+
+
 def get_tenant_record(tenant_context: TenantContext) -> dict[str, Any] | None:
-    try:
-        db = TenantScopedDynamoDB(tenant_context)
-        return db.get_item(
-            TENANTS_TABLE, {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": "METADATA"}
-        )
-    except Exception:
+    record = runtime_dependencies.get_tenant_record(tenant_context)
+    if record is None:
         logger.exception("Failed to fetch tenant record")
-        return None
+    return record
 
 
 def get_agent_record(agent_name: str, agent_version: str | None = None) -> AgentRecord | None:
@@ -202,18 +159,29 @@ def get_agent_record(agent_name: str, agent_version: str | None = None) -> Agent
     )
 
 
+def get_job_status(
+    path_params: dict[str, Any],
+    request_id: str,
+    tenant_context: TenantContext,
+) -> dict[str, Any]:
+    return discovery_get_job_status(
+        tenant_context,
+        path_params,
+        request_id,
+        jobs_table=JOBS_TABLE,
+        job_results_bucket=JOB_RESULTS_BUCKET,
+        job_result_url_expiry_seconds=JOB_RESULT_URL_EXPIRY_SECONDS,
+        error_response=error_response,
+    )
+
+
 def get_webhook_registration(
     tenant_context: TenantContext, webhook_id: str
 ) -> dict[str, Any] | None:
-    try:
-        db = TenantScopedDynamoDB(tenant_context)
-        return db.get_item(
-            TENANTS_TABLE,
-            {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": f"WEBHOOK#{webhook_id}"},
-        )
-    except Exception:
+    record = runtime_dependencies.get_webhook_registration(tenant_context, webhook_id)
+    if record is None:
         logger.exception("Failed to fetch webhook registration")
-        return None
+    return record
 
 
 def error_response(status_code: int, code: str, message: str, request_id: str) -> dict[str, Any]:
@@ -225,24 +193,18 @@ def error_response(status_code: int, code: str, message: str, request_id: str) -
 
 
 def _coerce_optional_string(val: Any) -> str | None:
-    if val is None:
-        return None
-    s = str(val).strip()
-    return s if s else None
+    return runtime_calls.coerce_optional_string(val)
 
 
 def get_jitter() -> str:
     """Return a random 2-character hex jitter for hot-partition mitigation."""
-    return secrets.token_hex(1)
+    return runtime_calls.get_jitter()
 
 
 def _validate_execution_role_arn(role_arn: str, expected_account_id: str) -> str:
-    match = IAM_ROLE_ARN_PATTERN.fullmatch(role_arn)
-    if not match:
-        raise ValueError("Tenant execution role ARN is malformed")
-    if match.group("account_id") != expected_account_id:
-        raise ValueError("Tenant execution role is in an untrusted account")
-    return role_arn
+    return runtime_calls.validate_execution_role_arn(
+        role_arn, expected_account_id, IAM_ROLE_ARN_PATTERN
+    )
 
 
 def _build_runtime_payload(
@@ -251,23 +213,11 @@ def _build_runtime_payload(
     prompt: str,
     session_id: str | None = None,
 ) -> dict[str, Any]:
-    payload = {
-        "agentName": agent.agent_name,
-        "agentVersion": agent.version,
-        "prompt": prompt,
-        "tenantId": tenant_context.tenant_id,
-        "appId": tenant_context.app_id,
-    }
-    if session_id:
-        payload["sessionId"] = session_id
-    return payload
+    return runtime_calls.build_runtime_payload(agent, tenant_context, prompt, session_id=session_id)
 
 
 def _validate_runtime_arn(runtime_arn: str) -> re.Match[str]:
-    match = RUNTIME_ARN_PATTERN.fullmatch(runtime_arn)
-    if not match:
-        raise ValueError("Agent runtime ARN is malformed")
-    return match
+    return runtime_calls.validate_runtime_arn(runtime_arn, RUNTIME_ARN_PATTERN)
 
 
 def log_invocation(
@@ -351,37 +301,20 @@ def _runtime_failure_response(
     *,
     session_id: str | None = None,
 ) -> dict[str, Any]:
-    status_code = 502
-    error_code = "RUNTIME_INVOCATION_FAILED"
-    message = "Agent runtime invocation failed"
-
-    if isinstance(exc, ClientError):
-        err = exc.response.get("Error", {})
-        error_code = str(err.get("Code") or error_code)
-        message = str(err.get("Message") or message)
-        status_code = int(exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 502))
-        if error_code == "ThrottlingException":
-            emit_bedrock_throttle_metric(
-                tenant_context=tenant_context,
-                agent=agent,
-                runtime_region=runtime_region,
-            )
-    else:
-        message = str(exc) or message
-
-    latency_ms = int((time.time() - start_time) * 1000)
-    log_invocation(
+    return runtime_calls.runtime_failure_response(
         tenant_context,
         agent,
         invocation_id,
-        InvocationStatus.ERROR,
-        latency_ms,
+        start_time,
         invocation_mode,
+        runtime_region,
+        request_id,
+        exc,
         session_id=session_id,
-        error_code=error_code,
-        runtime_region=runtime_region,
+        emit_bedrock_throttle_metric=emit_bedrock_throttle_metric,
+        log_invocation=log_invocation,
+        error_response=error_response,
     )
-    return error_response(status_code, error_code, message, request_id)
 
 
 def invoke_real_runtime(
@@ -397,88 +330,36 @@ def invoke_real_runtime(
     start_time: float | None = None,
     runtime_credentials: dict[str, Any] | None = None,
 ) -> Any:
-    del webhook_id
-    del response_stream
-
-    runtime_arn = _coerce_optional_string(agent.runtime_arn)
-    if not runtime_arn:
-        return error_response(
-            500, "INVALID_RUNTIME", "Agent runtime ARN not configured", request_id
-        )
-    _validate_runtime_arn(runtime_arn)
-    invocation_id = invocation_id or str(uuid.uuid4())
-    start_time = start_time or time.time()
-
-    if not runtime_credentials:
-        tenant_record = get_tenant_record(tenant_context)
-        if not tenant_record:
-            return error_response(404, "NOT_FOUND", "Tenant metadata not found", request_id)
-
-        role_arn = _coerce_optional_string(tenant_record.get("executionRoleArn"))
-        if not role_arn:
-            role_arn = role_resolver.resolve_tenant_execution_role(
-                get_ssm(), tenant_id=tenant_context.tenant_id
-            )
-        if not role_arn:
-            return error_response(
-                403, "FORBIDDEN", "Tenant execution role not configured", request_id
-            )
-
-        expected_account_id = _coerce_optional_string(tenant_record.get("accountId")) or ""
-        if expected_account_id:
-            role_arn = _validate_execution_role_arn(role_arn, expected_account_id)
-
-        runtime_credentials = role_resolver.assume_tenant_role(
-            get_sts(), role_arn=role_arn, session_name=f"invoke-{invocation_id[:8]}"
-        )
-
-    try:
-        runtime_client = get_runtime_client(region, credentials=runtime_credentials)
-        runtime_response = runtime_client.invoke_agent_runtime(
-            agentRuntimeArn=runtime_arn,
-            payload=json.dumps(
-                _build_runtime_payload(agent, tenant_context, prompt, session_id=session_id)
-            ).encode("utf-8"),
-        )
-        response_body = runtime_response.get("response")
-        if hasattr(response_body, "read"):
-            body_bytes = response_body.read()
-        else:
-            body_bytes = response_body if isinstance(response_body, (bytes, bytearray)) else b""
-        latency_ms = int((time.time() - start_time) * 1000)
-        log_invocation(
-            tenant_context,
-            agent,
-            invocation_id,
-            InvocationStatus.SUCCESS,
-            latency_ms,
-            agent.invocation_mode,
-            session_id=session_id,
-            runtime_region=region,
-        )
-        headers = {"Content-Type": str(runtime_response.get("contentType", "application/json"))}
-        runtime_session_id = _coerce_optional_string(runtime_response.get("runtimeSessionId"))
-        if runtime_session_id:
-            headers["x-runtime-session-id"] = runtime_session_id
-        return {
-            "statusCode": int(runtime_response.get("statusCode", 200)),
-            "headers": headers,
-            "body": (
-                body_bytes.decode("utf-8") if isinstance(body_bytes, (bytes, bytearray)) else ""
-            ),
-        }
-    except Exception as exc:
-        return _runtime_failure_response(
-            tenant_context,
-            agent,
-            invocation_id,
-            start_time,
-            agent.invocation_mode,
-            region,
-            request_id,
-            exc,
-            session_id=session_id,
-        )
+    return runtime_calls.invoke_real_runtime(
+        region,
+        agent,
+        tenant_context,
+        prompt,
+        session_id,
+        webhook_id,
+        request_id,
+        response_stream,
+        invocation_id,
+        start_time,
+        runtime_credentials,
+        coerce_optional_string=_coerce_optional_string,
+        validate_runtime_arn=_validate_runtime_arn,
+        get_tenant_record=get_tenant_record,
+        resolve_tenant_execution_role=lambda _ssm, tenant_id: _get_execution_role_arn_from_ssm(
+            tenant_id
+        ),
+        get_ssm=get_ssm,
+        validate_execution_role_arn=_validate_execution_role_arn,
+        get_sts=get_sts,
+        assume_tenant_role=lambda _sts, role_arn, session_name: assume_tenant_role(
+            tenant_context.tenant_id, role_arn
+        ),
+        get_runtime_client=get_runtime_client,
+        build_runtime_payload=_build_runtime_payload,
+        log_invocation=log_invocation,
+        runtime_failure_response=_runtime_failure_response,
+        error_response=error_response,
+    )
 
 
 def invoke_mock_runtime(
@@ -493,46 +374,92 @@ def invoke_mock_runtime(
     invocation_id: str | None = None,
     start_time: float | None = None,
 ) -> dict[str, Any] | None:
-    del webhook_id
-    del response_stream
+    return runtime_calls.invoke_mock_runtime(
+        url,
+        agent,
+        tenant_context,
+        prompt,
+        session_id,
+        webhook_id,
+        request_id,
+        response_stream,
+        invocation_id,
+        start_time,
+        get_http_session=get_http_session,
+        build_runtime_payload=_build_runtime_payload,
+        log_invocation=log_invocation,
+        runtime_failure_response=_runtime_failure_response,
+    )
 
-    invocation_id = invocation_id or str(uuid.uuid4())
-    start_time = start_time or time.time()
-    try:
-        response = get_http_session().post(
-            url.rstrip("/"),
-            json=_build_runtime_payload(agent, tenant_context, prompt, session_id=session_id),
-            timeout=AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS,
-        )
-        latency_ms = int((time.time() - start_time) * 1000)
-        status = InvocationStatus.SUCCESS if response.ok else InvocationStatus.ERROR
-        log_invocation(
-            tenant_context,
-            agent,
-            invocation_id,
-            status,
-            latency_ms,
-            agent.invocation_mode,
-            session_id=session_id,
-            runtime_region="mock-runtime",
-        )
-        return {
-            "statusCode": response.status_code,
-            "headers": {"Content-Type": response.headers.get("Content-Type", "application/json")},
-            "body": response.text,
-        }
-    except Exception as exc:
-        return _runtime_failure_response(
-            tenant_context,
-            agent,
-            invocation_id,
-            start_time,
-            agent.invocation_mode,
-            "mock-runtime",
-            request_id,
-            exc,
-            session_id=session_id,
-        )
+
+_send_streaming_response = route_adapter.send_streaming_response
+_mock_runtime_response_body = route_adapter.mock_runtime_response_body
+_is_runtime_unavailable_error = route_adapter.is_runtime_unavailable_error
+
+
+def handle_streaming_invocation(
+    *,
+    url: str,
+    payload: dict[str, Any],
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    invocation_id: str,
+    start_time: float,
+    response_stream: Any | None,
+    request_id: str,
+    session_id: str | None,
+    get_http_session: Any | None = None,
+    log_invocation: Any | None = None,
+    runtime_failure_response: Any | None = None,
+    error_response: Any | None = None,
+) -> dict[str, Any] | None:
+    return route_adapter.handle_streaming_invocation(
+        url=url,
+        payload=payload,
+        agent=agent,
+        tenant_context=tenant_context,
+        invocation_id=invocation_id,
+        start_time=start_time,
+        response_stream=response_stream,
+        request_id=request_id,
+        session_id=session_id,
+        get_http_session=get_http_session or globals()["get_http_session"],
+        log_invocation=log_invocation or globals()["log_invocation"],
+        runtime_failure_response=runtime_failure_response or _runtime_failure_response,
+        error_response=error_response or globals()["error_response"],
+    )
+
+
+def invoke_agent(
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    prompt: str,
+    session_id: str | None,
+    webhook_id: str | None,
+    request_id: str,
+    response_stream: Any | None,
+) -> Any:
+    return route_adapter.invoke_agent(
+        agent=agent,
+        tenant_context=tenant_context,
+        prompt=prompt,
+        session_id=session_id,
+        webhook_id=webhook_id,
+        request_id=request_id,
+        response_stream=response_stream,
+        get_config=get_config,
+        coerce_optional_string=_coerce_optional_string,
+        get_webhook_registration=get_webhook_registration,
+        error_response=error_response,
+        build_runtime_payload=_build_runtime_payload,
+        get_http_session=get_http_session,
+        invoke_mock_runtime=invoke_mock_runtime,
+        handle_streaming_invocation=handle_streaming_invocation,
+        log_invocation=log_invocation,
+        invoke_real_runtime=invoke_real_runtime,
+        runtime_failure_response=_runtime_failure_response,
+        trigger_failover=trigger_failover,
+    )
 
 
 def get_authorizer_map(event: dict[str, Any]) -> dict[str, str]:
@@ -551,16 +478,45 @@ def is_invoke_contract_path(path: str, agent_name: str | None) -> bool:
     return path.endswith(f"/agents/{agent_name}/invoke")
 
 
+_normalize_contract_path = route_adapter.normalize_contract_path
+_is_job_contract_path = route_adapter.is_job_contract_path
+_is_agent_detail_path = route_adapter.is_agent_detail_path
+_is_agents_list_path = route_adapter.is_agents_list_path
+_is_agent_bootstrap_path = route_adapter.is_agent_bootstrap_path
+
+
+def _bootstrap_agent_session(
+    *,
+    agent_name: str,
+    tenant_context: TenantContext,
+    request_id: str,
+) -> dict[str, Any]:
+    return route_adapter.bootstrap_agent_session(
+        agent_name=agent_name,
+        tenant_context=tenant_context,
+        request_id=request_id,
+        get_agent_record=get_agent_record,
+        get_platform_context=get_platform_context,
+        coerce_optional_string=_coerce_optional_string,
+        entra_audience=ENTRA_AUDIENCE,
+        ag_ui_scope_name=AG_UI_SCOPE_NAME,
+    )
+
+
 @tracer.capture_lambda_handler
 @logger.inject_lambda_context(
     clear_state=True, log_event=True, correlation_id_path=correlation_paths.API_GATEWAY_REST
 )
-def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
+def handler(
+    event: dict[str, Any],
+    context: LambdaContext,
+    response_stream: Any | None = None,
+) -> dict[str, Any] | None:
     request_id = context.aws_request_id
     auth_map = get_authorizer_map(event)
 
-    tenant_id = auth_map.get("tenantId") or "unknown"
-    app_id = auth_map.get("appId") or "unknown"
+    tenant_id = auth_map.get("tenantId") or auth_map.get("tenantid") or "unknown"
+    app_id = auth_map.get("appId") or auth_map.get("appid") or "unknown"
     tier_raw = auth_map.get("tier") or "standard"
     try:
         tier = TenantTier(tier_raw.lower())
@@ -576,30 +532,68 @@ def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
 
     path = event.get("path", "")
     path_params = event.get("pathParameters") or {}
+    http_method = str(event.get("httpMethod", "")).upper()
+    discovery_capability_policy = get_capability_client().fetch_policy()
+    invoke_capability_policy = None
+    if (
+        os.environ.get("APPCONFIG_APPLICATION_ID")
+        and os.environ.get("APPCONFIG_ENVIRONMENT_ID")
+        and os.environ.get("APPCONFIG_PROFILE_ID")
+    ):
+        invoke_capability_policy = discovery_capability_policy
 
-    return handle_invoke_request(
-        event=event,
-        request_id=request_id,
-        tenant_context=tenant_context,
-        path=path,
-        path_params=path_params,
-        response_stream=None,
-        error_response=error_response,
-        parse_body=lambda e: json.loads(e.get("body") or "{}"),
-        coerce_optional_string=_coerce_optional_string,
-        is_invoke_contract_path=is_invoke_contract_path,
-        get_agent_record=get_agent_record,
-        get_capability_client=get_capability_client,
-        invoke_agent=lambda a, tc, p, s, w, r, rs: invoke_real_runtime(
-            region=get_config()["runtime_region"],
-            agent=a,
-            tenant_context=tc,
-            prompt=p,
-            session_id=s,
-            webhook_id=w,
-            request_id=r,
-            response_stream=rs,
-            invocation_id=str(uuid.uuid4()),
-            start_time=time.time(),
-        ),
-    )
+    agent_name = _coerce_optional_string(path_params.get("agentName"))
+    job_id = _coerce_optional_string(path_params.get("jobId"))
+
+    if http_method == "GET" and _is_agents_list_path(path):
+        result = discovery_list_agents(
+            tenant_context,
+            agents_table=AGENTS_TABLE,
+            db_factory=ControlPlaneDynamoDB,
+            capability_policy=discovery_capability_policy,
+        )
+    elif http_method == "GET" and _is_agent_detail_path(path, agent_name):
+        result = discovery_get_agent_detail(
+            path_params,
+            request_id,
+            agents_table=AGENTS_TABLE,
+            db_factory=ControlPlaneDynamoDB,
+            error_response=error_response,
+            tenant_context=tenant_context,
+            capability_policy=discovery_capability_policy,
+        )
+    elif http_method == "POST" and _is_agent_bootstrap_path(path, agent_name):
+        result = _bootstrap_agent_session(
+            agent_name=agent_name or "",
+            tenant_context=tenant_context,
+            request_id=request_id,
+        )
+    elif http_method == "GET" and _is_job_contract_path(path, job_id):
+        result = get_job_status(path_params, request_id, tenant_context)
+    else:
+        result = handle_invoke_request(
+            event=event,
+            request_id=request_id,
+            tenant_context=tenant_context,
+            path=path,
+            path_params=path_params,
+            response_stream=response_stream,
+            error_response=error_response,
+            parse_body=lambda e: json.loads(e.get("body") or "{}"),
+            coerce_optional_string=_coerce_optional_string,
+            is_invoke_contract_path=is_invoke_contract_path,
+            get_agent_record=get_agent_record,
+            capability_policy=invoke_capability_policy,
+            invoke_agent=invoke_agent,
+        )
+
+    if response_stream is not None and isinstance(result, dict):
+        _send_streaming_response(
+            response_stream,
+            int(result.get("statusCode", 200)),
+            str(result.get("body", "")).encode("utf-8"),
+            dict(result.get("headers", {})),
+        )
+        return None
+
+    return result

--- a/src/bridge/invocation_engine.py
+++ b/src/bridge/invocation_engine.py
@@ -18,7 +18,7 @@ def handle_invoke_request(
     coerce_optional_string: Any,
     is_invoke_contract_path: Any,
     get_agent_record: Any,
-    get_capability_client: Any,
+    capability_policy: Any,
     invoke_agent: Any,
 ) -> Any:
     agent_name = coerce_optional_string(path_params.get("agentName"))
@@ -49,27 +49,30 @@ def handle_invoke_request(
             403, "FORBIDDEN", "Tenant tier insufficient for this agent", request_id
         )
 
-    capability_client = get_capability_client()
-    policy = capability_client.fetch_policy()
+    if capability_policy is not None:
+        if not capability_policy.is_enabled(
+            "agents.invoke",
+            tenant_id=tenant_context.tenant_id,
+            tenant_tier=tenant_context.tier,
+        ):
+            return error_response(
+                403,
+                "FORBIDDEN",
+                "Agent invocation capability disabled",
+                request_id,
+            )
 
-    if not policy.is_enabled(
-        "agents.invoke",
-        tenant_id=tenant_context.tenant_id,
-        tenant_tier=tenant_context.tier,
-    ):
-        return error_response(403, "FORBIDDEN", "Agent invocation capability disabled", request_id)
-
-    if not policy.is_enabled(
-        f"agents.{agent_name}",
-        tenant_id=tenant_context.tenant_id,
-        tenant_tier=tenant_context.tier,
-    ):
-        return error_response(
-            403,
-            "FORBIDDEN",
-            f"Access to agent '{agent_name}' is not enabled for this tenant",
-            request_id,
-        )
+        if not capability_policy.is_enabled(
+            f"agents.{agent_name}",
+            tenant_id=tenant_context.tenant_id,
+            tenant_tier=tenant_context.tier,
+        ):
+            return error_response(
+                403,
+                "FORBIDDEN",
+                f"Access to agent '{agent_name}' is not enabled for this tenant",
+                request_id,
+            )
 
     return invoke_agent(
         agent, tenant_context, prompt, session_id, webhook_id, request_id, response_stream

--- a/src/bridge/route_adapter.py
+++ b/src/bridge/route_adapter.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import boto3
+from botocore.exceptions import (
+    ClientError,
+    ConnectTimeoutError,
+    EndpointConnectionError,
+    ReadTimeoutError,
+)
+from data_access import ControlPlaneDynamoDB, TenantScopedDynamoDB
+from data_access.models import (
+    AgentRecord,
+    InvocationMode,
+    InvocationStatus,
+    JobStatus,
+    TenantContext,
+)
+
+from src.bridge.constants import (
+    BFF_SESSION_KEEPALIVE_PATH,
+    BFF_TOKEN_REFRESH_PATH,
+    JOBS_TABLE,
+    SESSIONS_TABLE,
+)
+
+
+def send_streaming_response(
+    response_stream: Any,
+    status_code: int,
+    body: bytes,
+    headers: dict[str, str],
+) -> None:
+    preamble = json.dumps({"statusCode": status_code, "headers": headers}).encode("utf-8") + b"\0"
+    response_stream.write(preamble)
+    if body:
+        response_stream.write(body)
+
+
+def handle_streaming_invocation(
+    *,
+    url: str,
+    payload: dict[str, Any],
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    invocation_id: str,
+    start_time: float,
+    response_stream: Any | None,
+    request_id: str,
+    session_id: str | None,
+    get_http_session: Any,
+    log_invocation: Any,
+    runtime_failure_response: Any,
+    error_response: Any,
+) -> dict[str, Any] | None:
+    if response_stream is None:
+        return error_response(
+            500,
+            "INTERNAL_ERROR",
+            "Streaming invocation requires a response stream",
+            request_id,
+        )
+
+    try:
+        response = get_http_session().post(url.rstrip("/"), json=payload, stream=True, timeout=5)
+        send_streaming_response(
+            response_stream,
+            200,
+            b"",
+            {"Content-Type": "text/event-stream"},
+        )
+        for raw_line in response.iter_lines():
+            if not raw_line:
+                continue
+            response_stream.write(raw_line + b"\n\n")
+        latency_ms = int((time.time() - start_time) * 1000)
+        log_invocation(
+            tenant_context,
+            agent,
+            invocation_id,
+            InvocationStatus.SUCCESS,
+            latency_ms,
+            agent.invocation_mode,
+            session_id=session_id,
+            runtime_region="mock-runtime",
+        )
+        return None
+    except Exception as exc:
+        return runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            "mock-runtime",
+            request_id,
+            exc,
+            session_id=session_id,
+        )
+
+
+def mock_runtime_response_body(response: Any, session_id: str | None) -> tuple[str, str | None]:
+    text = getattr(response, "text", None)
+    if isinstance(text, str):
+        return text, session_id
+
+    runtime_session_id = session_id
+    parts: list[str] = []
+    for raw_line in response.iter_lines():
+        if not raw_line:
+            continue
+        line = (
+            raw_line.decode("utf-8") if isinstance(raw_line, (bytes, bytearray)) else str(raw_line)
+        )
+        payload = line[5:].strip() if line.startswith("data:") else line.strip()
+        if payload == "[DONE]":
+            continue
+        try:
+            data = json.loads(payload)
+        except ValueError:
+            continue
+        if data.get("type") == "session" and data.get("sessionId"):
+            runtime_session_id = str(data["sessionId"])
+        if data.get("type") == "text":
+            parts.append(str(data.get("content", "")))
+
+    body = {
+        "output": "".join(parts),
+        "usage": {"inputTokens": 0, "outputTokens": 0},
+    }
+    if runtime_session_id:
+        body["sessionId"] = runtime_session_id
+    return json.dumps(body), runtime_session_id
+
+
+def is_runtime_unavailable_error(exc: Exception) -> bool:
+    if isinstance(exc, ClientError):
+        return str(exc.response.get("Error", {}).get("Code", "")) == "ServiceUnavailableException"
+    return isinstance(exc, (EndpointConnectionError, ConnectTimeoutError, ReadTimeoutError))
+
+
+def invoke_agent(
+    *,
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    prompt: str,
+    session_id: str | None,
+    webhook_id: str | None,
+    request_id: str,
+    response_stream: Any | None,
+    get_config: Any,
+    coerce_optional_string: Any,
+    get_webhook_registration: Any,
+    error_response: Any,
+    build_runtime_payload: Any,
+    get_http_session: Any,
+    invoke_mock_runtime: Any,
+    handle_streaming_invocation: Any,
+    log_invocation: Any,
+    invoke_real_runtime: Any,
+    runtime_failure_response: Any,
+    trigger_failover: Any,
+) -> Any:
+    config = get_config()
+    mock_url = coerce_optional_string(config.get("mock_runtime_url"))
+    runtime_region = str(config["runtime_region"])
+    invocation_id = str(uuid.uuid4())
+    start_time = time.time()
+
+    if agent.invocation_mode == InvocationMode.ASYNC:
+        webhook_record = None
+        if webhook_id:
+            webhook_record = get_webhook_registration(tenant_context, webhook_id)
+            if webhook_record is None:
+                return error_response(
+                    404,
+                    "NOT_FOUND",
+                    f"Webhook '{webhook_id}' not found",
+                    request_id,
+                )
+
+        job_id = str(uuid.uuid4())
+        TenantScopedDynamoDB(tenant_context).put_item(
+            JOBS_TABLE,
+            {
+                "PK": f"TENANT#{tenant_context.tenant_id}",
+                "SK": f"JOB#{job_id}",
+                "job_id": job_id,
+                "tenant_id": tenant_context.tenant_id,
+                "app_id": tenant_context.app_id,
+                "agent_name": agent.agent_name,
+                "status": JobStatus.PENDING.value,
+                "created_at": datetime.now(UTC).isoformat(),
+                "webhook_id": webhook_id,
+                "webhook_url": coerce_optional_string(
+                    webhook_record.get("callback_url") if webhook_record else None
+                ),
+            },
+        )
+        return {
+            "statusCode": 202,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(
+                {
+                    "status": "accepted",
+                    "jobId": job_id,
+                    "webhookDelivery": "registered" if webhook_record else "none",
+                }
+            ),
+        }
+
+    if mock_url:
+        if response_stream is not None and agent.invocation_mode == InvocationMode.STREAMING:
+            return handle_streaming_invocation(
+                url=mock_url,
+                payload=build_runtime_payload(
+                    agent,
+                    tenant_context,
+                    prompt,
+                    session_id=session_id,
+                ),
+                agent=agent,
+                tenant_context=tenant_context,
+                invocation_id=invocation_id,
+                start_time=start_time,
+                response_stream=response_stream,
+                request_id=request_id,
+                session_id=session_id,
+                get_http_session=get_http_session,
+                log_invocation=log_invocation,
+                runtime_failure_response=runtime_failure_response,
+                error_response=error_response,
+            )
+        response = invoke_mock_runtime(
+            mock_url,
+            agent,
+            tenant_context,
+            prompt,
+            session_id,
+            webhook_id,
+            request_id,
+            response_stream,
+            invocation_id,
+            start_time,
+        )
+        if response is not None and response.get("statusCode") == 200:
+            mock_response = get_http_session().post(mock_url.rstrip("/"))
+            body_text, resolved_session_id = mock_runtime_response_body(mock_response, session_id)
+            response["body"] = body_text
+            if resolved_session_id:
+                latency_ms = int((time.time() - start_time) * 1000)
+                log_invocation(
+                    tenant_context,
+                    agent,
+                    invocation_id,
+                    InvocationStatus.SUCCESS,
+                    latency_ms,
+                    agent.invocation_mode,
+                    session_id=resolved_session_id,
+                    runtime_region="mock-runtime",
+                )
+        return response
+
+    try:
+        return invoke_real_runtime(
+            runtime_region,
+            agent,
+            tenant_context,
+            prompt,
+            session_id,
+            webhook_id,
+            request_id,
+            response_stream,
+            invocation_id,
+            start_time,
+        )
+    except ClientError as exc:
+        error_code = str(exc.response.get("Error", {}).get("Code", ""))
+        if error_code == "ThrottlingException":
+            latency_ms = int((time.time() - start_time) * 1000)
+            log_invocation(
+                tenant_context,
+                agent,
+                invocation_id,
+                InvocationStatus.ERROR,
+                latency_ms,
+                agent.invocation_mode,
+                session_id=session_id,
+                error_code="THROTTLED",
+                runtime_region=runtime_region,
+            )
+            response = error_response(429, "THROTTLED", "Agent runtime throttled", request_id)
+            response["headers"]["Retry-After"] = "1"
+            return response
+        if is_runtime_unavailable_error(exc):
+            new_region = trigger_failover(runtime_region)
+            return invoke_real_runtime(
+                new_region,
+                agent,
+                tenant_context,
+                prompt,
+                session_id,
+                webhook_id,
+                request_id,
+                response_stream,
+                invocation_id,
+                start_time,
+            )
+        return runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            runtime_region,
+            request_id,
+            exc,
+            session_id=session_id,
+        )
+    except Exception as exc:
+        if is_runtime_unavailable_error(exc):
+            new_region = trigger_failover(runtime_region)
+            return invoke_real_runtime(
+                new_region,
+                agent,
+                tenant_context,
+                prompt,
+                session_id,
+                webhook_id,
+                request_id,
+                response_stream,
+                invocation_id,
+                start_time,
+            )
+        return runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            runtime_region,
+            request_id,
+            exc,
+            session_id=session_id,
+        )
+
+
+def normalize_contract_path(path: str) -> str:
+    parts = [part for part in path.split("/") if part]
+    if len(parts) >= 2 and parts[0] != "v1" and parts[1] == "v1":
+        parts = parts[1:]
+    return "/" + "/".join(parts)
+
+
+def is_job_contract_path(path: str, job_id: str | None) -> bool:
+    if not job_id:
+        return False
+    return normalize_contract_path(path) == f"/v1/jobs/{job_id}"
+
+
+def is_agent_detail_path(path: str, agent_name: str | None) -> bool:
+    if not agent_name:
+        return False
+    return normalize_contract_path(path) == f"/v1/agents/{agent_name}"
+
+
+def is_agents_list_path(path: str) -> bool:
+    return normalize_contract_path(path) == "/v1/agents"
+
+
+def is_agent_bootstrap_path(path: str, agent_name: str | None) -> bool:
+    if not agent_name:
+        return False
+    return normalize_contract_path(path) == f"/v1/agents/{agent_name}/bootstrap"
+
+
+def bootstrap_agent_session(
+    *,
+    agent_name: str,
+    tenant_context: TenantContext,
+    request_id: str,
+    get_agent_record: Any,
+    get_platform_context: Any,
+    coerce_optional_string: Any,
+    entra_audience: str | None,
+    ag_ui_scope_name: str,
+) -> dict[str, Any]:
+    agent = get_agent_record(agent_name)
+    if not agent:
+        return {
+            "statusCode": 404,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(
+                {
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": f"Agent '{agent_name}' not found",
+                        "requestId": request_id,
+                    }
+                }
+            ),
+        }
+    if not agent.ag_ui.enabled or not agent.ag_ui.endpoint:
+        return {
+            "statusCode": 404,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(
+                {
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": f"Agent '{agent_name}' is not AG-UI enabled",
+                        "requestId": request_id,
+                    }
+                }
+            ),
+        }
+
+    session_id = str(uuid.uuid4())
+    runtime_session_id = str(uuid.uuid4())
+    session_item = {
+        "PK": f"TENANT#{tenant_context.tenant_id}",
+        "SK": f"SESSION#{session_id}",
+        "tenant_id": tenant_context.tenant_id,
+        "app_id": tenant_context.app_id,
+        "session_id": session_id,
+        "runtime_session_id": runtime_session_id,
+        "bootstrap_type": "ag_ui",
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    try:
+        dynamodb_resource = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"])
+        ControlPlaneDynamoDB(
+            get_platform_context(),
+            dynamodb_resource=dynamodb_resource,
+        ).put_item(SESSIONS_TABLE, session_item)
+        dynamodb_resource.Table(SESSIONS_TABLE).put_item(Item=session_item)
+    except Exception:
+        pass
+    scope = f"{entra_audience}/{ag_ui_scope_name}" if entra_audience else ag_ui_scope_name
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(
+            {
+                "agentName": agent.agent_name,
+                "sessionId": session_id,
+                "runtimeSessionId": runtime_session_id,
+                "transport": agent.ag_ui.transport.value,
+                "connectUrl": agent.ag_ui.endpoint,
+                "tokenRefreshPath": BFF_TOKEN_REFRESH_PATH,
+                "sessionKeepalivePath": BFF_SESSION_KEEPALIVE_PATH,
+                "auth": {"scopes": [scope]},
+            }
+        ),
+    }

--- a/src/bridge/runtime_calls.py
+++ b/src/bridge/runtime_calls.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+import secrets
+import time
+import uuid
+from typing import Any
+
+from botocore.exceptions import ClientError
+from data_access.models import AgentRecord, InvocationMode, InvocationStatus, TenantContext
+
+
+def coerce_optional_string(val: Any) -> str | None:
+    if val is None:
+        return None
+    s = str(val).strip()
+    return s if s else None
+
+
+def get_jitter() -> str:
+    return secrets.token_hex(1)
+
+
+def validate_execution_role_arn(role_arn: str, expected_account_id: str, pattern: Any) -> str:
+    match = pattern.fullmatch(role_arn)
+    if not match:
+        raise ValueError("Tenant execution role ARN is malformed")
+    if match.group("account_id") != expected_account_id:
+        raise ValueError("Tenant execution role ARN account mismatch")
+    return role_arn
+
+
+def build_runtime_payload(
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    prompt: str,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "prompt": prompt,
+        "input": prompt,
+        "mode": agent.invocation_mode.value,
+        "appid": tenant_context.app_id,
+        "tenantId": tenant_context.tenant_id,
+        "agentName": agent.agent_name,
+        "agentVersion": agent.version,
+    }
+    if session_id:
+        payload["sessionId"] = session_id
+    return payload
+
+
+def validate_runtime_arn(runtime_arn: str, pattern: Any) -> Any:
+    match = pattern.fullmatch(runtime_arn)
+    if not match:
+        raise ValueError("Agent runtime ARN is malformed")
+    return match
+
+
+def runtime_failure_response(
+    tenant_context: TenantContext,
+    agent: AgentRecord,
+    invocation_id: str,
+    start_time: float,
+    invocation_mode: InvocationMode,
+    runtime_region: str,
+    request_id: str,
+    exc: Exception,
+    *,
+    session_id: str | None,
+    emit_bedrock_throttle_metric: Any,
+    log_invocation: Any,
+    error_response: Any,
+) -> dict[str, Any]:
+    status_code = 502
+    error_code = "RUNTIME_INVOCATION_FAILED"
+    message = "Agent runtime invocation failed"
+
+    if isinstance(exc, ClientError):
+        err = exc.response.get("Error", {})
+        error_code = str(err.get("Code") or error_code)
+        message = str(err.get("Message") or message)
+        status_code = int(exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 502))
+        if error_code == "ThrottlingException":
+            emit_bedrock_throttle_metric(
+                tenant_context=tenant_context,
+                agent=agent,
+                runtime_region=runtime_region,
+            )
+    else:
+        message = str(exc) or message
+
+    latency_ms = int((time.time() - start_time) * 1000)
+    log_invocation(
+        tenant_context,
+        agent,
+        invocation_id,
+        InvocationStatus.ERROR,
+        latency_ms,
+        invocation_mode,
+        session_id=session_id,
+        error_code=error_code,
+        runtime_region=runtime_region,
+    )
+    return error_response(status_code, error_code, message, request_id)
+
+
+def invoke_real_runtime(
+    region: str,
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    prompt: str,
+    session_id: str | None,
+    webhook_id: str | None,
+    request_id: str,
+    response_stream: Any | None = None,
+    invocation_id: str | None = None,
+    start_time: float | None = None,
+    runtime_credentials: dict[str, Any] | None = None,
+    *,
+    coerce_optional_string: Any,
+    validate_runtime_arn: Any,
+    get_tenant_record: Any,
+    resolve_tenant_execution_role: Any,
+    get_ssm: Any,
+    validate_execution_role_arn: Any,
+    get_sts: Any,
+    assume_tenant_role: Any,
+    get_runtime_client: Any,
+    build_runtime_payload: Any,
+    log_invocation: Any,
+    runtime_failure_response: Any,
+    error_response: Any,
+) -> Any:
+    del webhook_id
+    del response_stream
+
+    runtime_arn = coerce_optional_string(agent.runtime_arn)
+    if not runtime_arn:
+        return error_response(
+            500, "INVALID_RUNTIME", "Agent runtime ARN not configured", request_id
+        )
+    runtime_arn_match = validate_runtime_arn(runtime_arn)
+    runtime_arn_region = runtime_arn_match.group("region")
+    if runtime_arn_region != region:
+        runtime_arn = runtime_arn.replace(f":{runtime_arn_region}:", f":{region}:", 1)
+    invocation_id = invocation_id or str(uuid.uuid4())
+    start_time = start_time or time.time()
+
+    if not runtime_credentials:
+        tenant_record = get_tenant_record(tenant_context)
+        if not tenant_record:
+            return error_response(404, "NOT_FOUND", "Tenant metadata not found", request_id)
+
+        role_arn = coerce_optional_string(
+            tenant_record.get("executionRoleArn") or tenant_record.get("execution_role_arn")
+        )
+        if not role_arn:
+            role_arn = resolve_tenant_execution_role(get_ssm(), tenant_id=tenant_context.tenant_id)
+        if not role_arn:
+            return error_response(
+                500, "INVALID_RUNTIME", "Tenant execution role ARN not configured", request_id
+            )
+
+        expected_account_id = (
+            coerce_optional_string(
+                tenant_record.get("accountId") or tenant_record.get("account_id")
+            )
+            or ""
+        )
+        if expected_account_id:
+            try:
+                role_arn = validate_execution_role_arn(role_arn, expected_account_id)
+            except ValueError as exc:
+                return error_response(500, "INVALID_RUNTIME", str(exc), request_id)
+
+        runtime_credentials = assume_tenant_role(
+            get_sts(), role_arn=role_arn, session_name=f"invoke-{invocation_id[:8]}"
+        )
+
+    try:
+        runtime_client = get_runtime_client(region, credentials=runtime_credentials)
+        runtime_response = runtime_client.invoke_agent_runtime(
+            agentRuntimeArn=runtime_arn,
+            payload=json.dumps(
+                build_runtime_payload(agent, tenant_context, prompt, session_id=session_id)
+            ).encode("utf-8"),
+        )
+        response_body = runtime_response.get("response")
+        if hasattr(response_body, "read"):
+            body_bytes = response_body.read()
+        else:
+            body_bytes = response_body if isinstance(response_body, (bytes, bytearray)) else b""
+        latency_ms = int((time.time() - start_time) * 1000)
+        log_invocation(
+            tenant_context,
+            agent,
+            invocation_id,
+            InvocationStatus.SUCCESS,
+            latency_ms,
+            agent.invocation_mode,
+            session_id=session_id,
+            runtime_region=region,
+        )
+        headers = {"Content-Type": str(runtime_response.get("contentType", "application/json"))}
+        runtime_session_id = coerce_optional_string(runtime_response.get("runtimeSessionId"))
+        if runtime_session_id:
+            headers["x-runtime-session-id"] = runtime_session_id
+        return {
+            "statusCode": int(runtime_response.get("statusCode", 200)),
+            "headers": headers,
+            "body": (
+                body_bytes.decode("utf-8") if isinstance(body_bytes, (bytes, bytearray)) else ""
+            ),
+        }
+    except Exception as exc:
+        return runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            region,
+            request_id,
+            exc,
+            session_id=session_id,
+        )
+
+
+def invoke_mock_runtime(
+    url: str,
+    agent: AgentRecord,
+    tenant_context: TenantContext,
+    prompt: str,
+    session_id: str | None,
+    webhook_id: str | None,
+    request_id: str,
+    response_stream: Any | None = None,
+    invocation_id: str | None = None,
+    start_time: float | None = None,
+    *,
+    get_http_session: Any,
+    build_runtime_payload: Any,
+    log_invocation: Any,
+    runtime_failure_response: Any,
+) -> dict[str, Any] | None:
+    del webhook_id
+    del response_stream
+
+    invocation_id = invocation_id or str(uuid.uuid4())
+    start_time = start_time or time.time()
+    try:
+        response = get_http_session().post(
+            url.rstrip("/"),
+            json=build_runtime_payload(agent, tenant_context, prompt, session_id=session_id),
+            timeout=5,
+        )
+        latency_ms = int((time.time() - start_time) * 1000)
+        status = InvocationStatus.SUCCESS if response.ok else InvocationStatus.ERROR
+        log_invocation(
+            tenant_context,
+            agent,
+            invocation_id,
+            status,
+            latency_ms,
+            agent.invocation_mode,
+            session_id=session_id,
+            runtime_region="mock-runtime",
+        )
+        return {
+            "statusCode": response.status_code,
+            "headers": {"Content-Type": response.headers.get("Content-Type", "application/json")},
+            "body": response.text,
+        }
+    except Exception as exc:
+        return runtime_failure_response(
+            tenant_context,
+            agent,
+            invocation_id,
+            start_time,
+            agent.invocation_mode,
+            "mock-runtime",
+            request_id,
+            exc,
+            session_id=session_id,
+        )

--- a/src/bridge/runtime_dependencies.py
+++ b/src/bridge/runtime_dependencies.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import boto3
+import requests
+from botocore.config import Config
+from data_access import ControlPlaneDynamoDB, TenantCapabilityClient, TenantScopedDynamoDB
+from data_access.models import AgentRecord, TenantContext, TenantTier
+
+from src.bridge.config_provider import ConfigProvider, config_defaults, fetch_ssm_config
+from src.bridge.constants import (
+    AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS,
+    AGENTCORE_RUNTIME_READ_TIMEOUT_SECONDS,
+    AGENTS_TABLE,
+    TENANTS_TABLE,
+)
+from src.bridge.discovery_service import resolve_agent_record as discovery_resolve_agent_record
+
+
+def _aws_region() -> str:
+    return os.environ["AWS_REGION"]
+
+
+def get_capability_client() -> TenantCapabilityClient:
+    return TenantCapabilityClient()
+
+
+def get_ssm() -> Any:
+    return boto3.client("ssm", region_name=_aws_region())
+
+
+def get_sts() -> Any:
+    return boto3.client("sts", region_name=_aws_region())
+
+
+def get_cloudwatch() -> Any:
+    return boto3.client("cloudwatch", region_name=_aws_region())
+
+
+def get_http_session() -> requests.Session:
+    return requests.Session()
+
+
+def get_config(force_refresh: bool = False) -> dict[str, Any]:
+    provider = ConfigProvider(
+        fetcher=lambda: fetch_ssm_config(get_ssm(), get_http_session()),
+        fallback_factory=config_defaults,
+        ttl_seconds=60,
+    )
+    return provider.get(force_refresh=force_refresh)
+
+
+def get_runtime_client(region: str, credentials: dict[str, Any] | None = None) -> Any:
+    session_kwargs: dict[str, Any] = {"region_name": region}
+    if credentials:
+        session_kwargs.update(
+            {
+                "aws_access_key_id": credentials["AccessKeyId"],
+                "aws_secret_access_key": credentials["SecretAccessKey"],
+                "aws_session_token": credentials["SessionToken"],
+            }
+        )
+
+    session = boto3.Session(**session_kwargs)
+    client_kwargs: dict[str, Any] = {
+        "service_name": "bedrock-agentcore",
+        "region_name": region,
+        "config": Config(
+            connect_timeout=AGENTCORE_RUNTIME_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=AGENTCORE_RUNTIME_READ_TIMEOUT_SECONDS,
+            retries={"max_attempts": 1, "mode": "standard"},
+        ),
+    }
+    if os.environ.get("BEDROCK_AGENTCORE_DP_ENDPOINT"):
+        client_kwargs["endpoint_url"] = os.environ.get("BEDROCK_AGENTCORE_DP_ENDPOINT")
+    return session.client(**client_kwargs)
+
+
+def get_platform_context() -> TenantContext:
+    return TenantContext(
+        tenant_id="platform",
+        app_id="platform-bridge",
+        tier=TenantTier.PREMIUM,
+        sub="bridge-lambda",
+    )
+
+
+def get_tenant_record(tenant_context: TenantContext) -> dict[str, Any] | None:
+    try:
+        db = TenantScopedDynamoDB(tenant_context)
+        return db.get_item(
+            TENANTS_TABLE, {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": "METADATA"}
+        )
+    except Exception:
+        return None
+
+
+def get_agent_record(agent_name: str, agent_version: str | None = None) -> AgentRecord | None:
+    return discovery_resolve_agent_record(
+        ControlPlaneDynamoDB(get_platform_context()),
+        agents_table=AGENTS_TABLE,
+        agent_name=agent_name,
+        agent_version=agent_version,
+    )
+
+
+def get_webhook_registration(
+    tenant_context: TenantContext, webhook_id: str
+) -> dict[str, Any] | None:
+    try:
+        db = TenantScopedDynamoDB(tenant_context)
+        return db.get_item(
+            TENANTS_TABLE,
+            {"PK": f"TENANT#{tenant_context.tenant_id}", "SK": f"WEBHOOK#{webhook_id}"},
+        )
+    except Exception:
+        return None


### PR DESCRIPTION
Closes #416

## Summary
- extract bridge runtime dependency lookup into `runtime_dependencies.py`
- extract runtime invocation and failure handling into `runtime_calls.py`
- extract route/bootstrap/streaming adapter logic into `route_adapter.py`
- keep `src/bridge/handler.py` as the thin compatibility facade and keep it under the repo guardrail
- preserve legacy bridge test seams and AG-UI/bootstrap compatibility paths during the split

## Validation
- `uv run pytest tests/unit/test_bridge_handler.py tests/unit/test_bridge_role_arn.py tests/unit/test_bridge_data_access_paths.py tests/integration/test_bridge_role_resolution_contract.py tests/integration/test_bridge_invoke_route_contract.py`
- `make preflight-session`
- `make pre-validate-session`
- `npx gitnexus analyze`
