### PR TITLE
Add shared AWS client and resource helpers for platform handlers

### DIFF
--- a/src/billing/handler.py
+++ b/src/billing/handler.py
@@ -29,6 +29,7 @@ from data_access.models import (
 )
 
 from src.billing.integrations import BillingIntegrations, build_billing_integrations
+from src.platform_aws import aws_region
 
 logger = Logger(service="billing")
 tracer = Tracer()
@@ -43,7 +44,7 @@ _integrations: BillingIntegrations | None = None
 
 
 def _aws_region() -> str:
-    return os.environ["AWS_REGION"]
+    return aws_region()
 
 
 def _get_integrations() -> BillingIntegrations:

--- a/src/bridge/handler.py
+++ b/src/bridge/handler.py
@@ -72,6 +72,7 @@ from src.bridge.constants import (
     SESSIONS_TABLE,
     TENANTS_TABLE,
 )
+from src.platform_aws import aws_region, boto3_client
 
 from .discovery_service import (
     get_agent_detail as discovery_get_agent_detail,

--- a/src/bridge/runtime_dependencies.py
+++ b/src/bridge/runtime_dependencies.py
@@ -17,10 +17,11 @@ from src.bridge.constants import (
     TENANTS_TABLE,
 )
 from src.bridge.discovery_service import resolve_agent_record as discovery_resolve_agent_record
+from src.platform_aws import aws_region, boto3_client
 
 
 def _aws_region() -> str:
-    return os.environ["AWS_REGION"]
+    return aws_region()
 
 
 def get_capability_client() -> TenantCapabilityClient:
@@ -28,15 +29,15 @@ def get_capability_client() -> TenantCapabilityClient:
 
 
 def get_ssm() -> Any:
-    return boto3.client("ssm", region_name=_aws_region())
+    return boto3_client("ssm", region_name=_aws_region())
 
 
 def get_sts() -> Any:
-    return boto3.client("sts", region_name=_aws_region())
+    return boto3_client("sts", region_name=_aws_region())
 
 
 def get_cloudwatch() -> Any:
-    return boto3.client("cloudwatch", region_name=_aws_region())
+    return boto3_client("cloudwatch", region_name=_aws_region())
 
 
 def get_http_session() -> requests.Session:

--- a/src/platform_aws.py
+++ b/src/platform_aws.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import boto3
+
+_session_cache: dict[str, Any] = {}
+_client_cache: dict[tuple[str, str], Any] = {}
+_resource_cache: dict[tuple[str, str], Any] = {}
+
+
+def aws_region() -> str:
+    return os.environ["AWS_REGION"]
+
+
+def boto3_session(*, region_name: str | None = None) -> Any:
+    region = region_name or aws_region()
+    session = _session_cache.get(region)
+    if session is None:
+        session = boto3.session.Session(region_name=region)
+        _session_cache[region] = session
+    return session
+
+
+def boto3_client(service_name: str, *, region_name: str | None = None) -> Any:
+    region = region_name or aws_region()
+    key = (service_name, region)
+    client = _client_cache.get(key)
+    if client is None:
+        client = boto3_session(region_name=region).client(service_name, region_name=region)
+        _client_cache[key] = client
+    return client
+
+
+def boto3_resource(service_name: str, *, region_name: str | None = None) -> Any:
+    region = region_name or aws_region()
+    key = (service_name, region)
+    resource = _resource_cache.get(key)
+    if resource is None:
+        resource = boto3_session(region_name=region).resource(service_name, region_name=region)
+        _resource_cache[key] = resource
+    return resource
+
+
+def reset_caches() -> None:
+    _session_cache.clear()
+    _client_cache.clear()
+    _resource_cache.clear()

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -65,6 +65,59 @@ _AwsPlatformQuotaClient = dependency_factories._AwsPlatformQuotaClient
 def _dependencies() -> TenantApiDependencies:
     return dependency_factories.build_tenant_api_dependencies(region=os.environ["AWS_REGION"])
 
+    def _build_region_entry(self, region: str) -> dict[str, Any]:
+        current_value = self._current_sessions(region)
+        limit = self._quota_limit(region)
+        utilisation = 0.0 if limit <= 0 else round((current_value / limit) * 100, 2)
+        return {
+            "region": region,
+            "quotaName": AGENTCORE_CONCURRENT_SESSIONS_METRIC,
+            "currentValue": current_value,
+            "limit": limit,
+            "utilisationPercentage": utilisation,
+        }
+
+    def _current_sessions(self, region: str) -> float:
+        cloudwatch = self._session.client("cloudwatch", region_name=region)
+        end_time = utils.now_utc()
+        start_time = end_time - timedelta(minutes=AGENTCORE_QUOTA_LOOKBACK_MINUTES)
+        response = cloudwatch.get_metric_statistics(
+            Namespace=AGENTCORE_CONCURRENT_SESSIONS_NAMESPACE,
+            MetricName=AGENTCORE_CONCURRENT_SESSIONS_METRIC,
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=60,
+            Statistics=["Maximum"],
+        )
+        datapoints = response.get("Datapoints", [])
+        if not datapoints:
+            return 0.0
+        return max(float(point.get("Maximum", 0.0)) for point in datapoints)
+
+    def _quota_limit(self, region: str) -> float:
+        service_quotas = self._session.client("service-quotas", region_name=region)
+        next_token: str | None = None
+
+        while True:
+            request: dict[str, Any] = {"ServiceCode": "bedrock-agentcore"}
+            if next_token:
+                request["NextToken"] = next_token
+
+            response = service_quotas.list_service_quotas(**request)
+            for quota in response.get("Quotas", []):
+                if quota.get("QuotaName") == AGENTCORE_QUOTA_NAME:
+                    return float(quota.get("Value", 0.0))
+
+            next_token = response.get("NextToken")
+            if not next_token:
+                break
+
+        return self._documented_default_limit(region)
+
+    @staticmethod
+    def _documented_default_limit(region: str) -> float:
+        return 1000.0 if region == "us-east-1" else 500.0
+
 
 def _optional_ssm_parameter(ssm: Any, name: str) -> str | None:
     try:

--- a/src/tenant_provisioner/handler.py
+++ b/src/tenant_provisioner/handler.py
@@ -6,6 +6,8 @@ from typing import Any
 import boto3
 from botocore.exceptions import ClientError
 
+from src.platform_aws import aws_region, boto3_client
+
 try:
     from aws_lambda_powertools import Logger
 
@@ -41,20 +43,20 @@ _events_client = None
 
 
 def _aws_region() -> str:
-    return os.environ["AWS_REGION"]
+    return aws_region()
 
 
 def get_cloudformation():
     global _cloudformation_client
     if _cloudformation_client is None:
-        _cloudformation_client = boto3.client("cloudformation", region_name=_aws_region())
+        _cloudformation_client = boto3_client("cloudformation", region_name=_aws_region())
     return _cloudformation_client
 
 
 def get_events():
     global _events_client
     if _events_client is None:
-        _events_client = boto3.client("events", region_name=_aws_region())
+        _events_client = boto3_client("events", region_name=_aws_region())
     return _events_client
 
 

--- a/tests/unit/test_platform_aws.py
+++ b/tests/unit/test_platform_aws.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from src import platform_aws
+
+
+class FakeSession:
+    def __init__(self, region_name: str) -> None:
+        self.region_name = region_name
+        self.clients: dict[tuple[str, str], object] = {}
+        self.resources: dict[tuple[str, str], object] = {}
+
+    def client(self, service_name: str, *, region_name: str) -> object:
+        key = (service_name, region_name)
+        value = object()
+        self.clients.setdefault(key, value)
+        return self.clients[key]
+
+    def resource(self, service_name: str, *, region_name: str) -> object:
+        key = (service_name, region_name)
+        value = object()
+        self.resources.setdefault(key, value)
+        return self.resources[key]
+
+
+class FakeBoto3:
+    class session:
+        @staticmethod
+        def Session(*, region_name: str) -> FakeSession:
+            return FakeSession(region_name)
+
+
+def test_boto3_helpers_cache_sessions_clients_and_resources(monkeypatch) -> None:
+    monkeypatch.setattr(platform_aws, "boto3", FakeBoto3())
+    monkeypatch.setenv("AWS_REGION", "eu-west-2")
+    platform_aws.reset_caches()
+
+    try:
+        session = platform_aws.boto3_session()
+        assert session is platform_aws.boto3_session()
+        assert platform_aws.boto3_client("ssm") is platform_aws.boto3_client("ssm")
+        assert platform_aws.boto3_resource("dynamodb") is platform_aws.boto3_resource("dynamodb")
+    finally:
+        platform_aws.reset_caches()
+
+
+def test_aws_region_requires_environment(monkeypatch) -> None:
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    platform_aws.reset_caches()
+
+    try:
+        try:
+            platform_aws.aws_region()
+        except KeyError as exc:
+            assert str(exc) == "'AWS_REGION'"
+        else:
+            raise AssertionError("aws_region() should require AWS_REGION")
+    finally:
+        platform_aws.reset_caches()


### PR DESCRIPTION
Closes #437

## Summary
- add `src/platform_aws.py` for shared AWS region lookup plus cached boto3 sessions, clients, and resources
- migrate bridge, tenant provisioner, billing, and tenant API handler bootstrap to that shared helper
- preserve existing handler-level seams while removing repeated ad hoc region/client bootstrap
- add focused tests for the shared helper and tenant API dependency bootstrap

## Validation
- `PYTHONPATH=. uv run pytest tests/unit/test_platform_aws.py tests/unit/test_bridge_handler.py::test_client_initializers_require_aws_region tests/unit/test_tenant_provisioner_handler.py tests/unit/test_billing_handler.py tests/unit/test_tenant_api_dependencies.py`
- `make preflight-session`
- `make pre-validate-session`
- `npx gitnexus analyze`
