### PR TITLE
Add shared utility helpers for time, jitter, JSON, and coercion

### DIFF
--- a/gateway/interceptors/request_interceptor.py
+++ b/gateway/interceptors/request_interceptor.py
@@ -15,7 +15,6 @@ ADRs: ADR-004
 """
 
 import hashlib
-import json
 import os
 import time
 from collections.abc import Callable
@@ -32,6 +31,7 @@ from aws_lambda_powertools.utilities.parameters import get_secret
 from jwt import PyJWKClient
 
 from gateway.interceptors import request_idempotency, request_tier, request_token
+from src.platform_utils import coerce_positive_int, parse_json_object_or_empty
 
 try:
     from data_access import ControlPlaneDynamoDB, TenantCapabilityClient, TenantContext, TenantTier
@@ -86,10 +86,17 @@ _scoped_token_signing_key_expiry: float = 0
 
 
 def _scoped_token_ttl_seconds() -> int:
-    return request_token.scoped_token_ttl_seconds(
-        os.environ.get("SCOPED_TOKEN_TTL_SECONDS"),
-        logger=logger,
-    )
+    raw_value = os.environ.get("SCOPED_TOKEN_TTL_SECONDS")
+    if raw_value is None:
+        return 300
+    parsed = coerce_positive_int(raw_value, default=300)
+    if str(parsed) != str(raw_value).strip():
+        logger.warning(
+            "Invalid SCOPED_TOKEN_TTL_SECONDS, falling back to 300",
+            extra={"value": raw_value},
+        )
+        return 300
+    return parsed
 
 
 def get_jwk_client() -> PyJWKClient | None:
@@ -129,16 +136,7 @@ def _normalized_headers(headers: Any) -> dict[str, str]:
 
 
 def _parse_body(body: Any) -> dict[str, Any]:
-    if isinstance(body, dict):
-        return dict(body)
-    if isinstance(body, str):
-        try:
-            parsed = json.loads(body)
-            if isinstance(parsed, dict):
-                return parsed
-        except json.JSONDecodeError:
-            return {}
-    return {}
+    return parse_json_object_or_empty(body)
 
 
 def _build_interceptor_response(

--- a/src/bridge/discovery_service.py
+++ b/src/bridge/discovery_service.py
@@ -14,14 +14,11 @@ from data_access.models import (
     is_invokable_agent_status,
 )
 
+from src.platform_utils import coerce_optional_string as _shared_coerce_optional_string
+
 
 def _coerce_optional_string(value: Any) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    if not text:
-        return None
-    return text
+    return _shared_coerce_optional_string(value)
 
 
 def _agent_summary_from_item(item: dict[str, Any]) -> dict[str, Any]:

--- a/src/bridge/runtime_calls.py
+++ b/src/bridge/runtime_calls.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import secrets
 import time
 import uuid
 from typing import Any
@@ -9,16 +8,16 @@ from typing import Any
 from botocore.exceptions import ClientError
 from data_access.models import AgentRecord, InvocationMode, InvocationStatus, TenantContext
 
+from src.platform_utils import coerce_optional_string as _coerce_optional_string
+from src.platform_utils import get_hex_jitter as _get_hex_jitter
+
 
 def coerce_optional_string(val: Any) -> str | None:
-    if val is None:
-        return None
-    s = str(val).strip()
-    return s if s else None
+    return _coerce_optional_string(val)
 
 
 def get_jitter() -> str:
-    return secrets.token_hex(1)
+    return _get_hex_jitter()
 
 
 def validate_execution_role_arn(role_arn: str, expected_account_id: str, pattern: Any) -> str:

--- a/src/bridge/utils.py
+++ b/src/bridge/utils.py
@@ -1,34 +1,40 @@
 from __future__ import annotations
 
-import secrets
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
+
+from src.platform_utils import (
+    coerce_optional_int as _coerce_optional_int,
+)
+from src.platform_utils import (
+    coerce_optional_string as _coerce_optional_string,
+)
+from src.platform_utils import (
+    get_retry_jitter as _get_retry_jitter,
+)
+from src.platform_utils import (
+    iso_utc as _iso_utc,
+)
+from src.platform_utils import (
+    now_utc as _now_utc,
+)
 
 
 def now_utc() -> datetime:
-    return datetime.now(UTC)
+    return _now_utc()
 
 
 def iso(ts: datetime) -> str:
-    return ts.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return _iso_utc(ts)
 
 
 def get_retry_jitter(base_delay: float) -> float:
-    """Return a random jittered delay between 0 and base_delay using Full Jitter strategy."""
-    return secrets.SystemRandom().uniform(0, base_delay)
+    return _get_retry_jitter(base_delay)
 
 
 def coerce_optional_string(val: Any) -> str | None:
-    if val is None:
-        return None
-    s = str(val).strip()
-    return s if s else None
+    return _coerce_optional_string(val)
 
 
 def coerce_optional_int(val: Any) -> int | None:
-    if val is None:
-        return None
-    try:
-        return int(val)
-    except (ValueError, TypeError):
-        return None
+    return _coerce_optional_int(val)

--- a/src/platform_utils.py
+++ b/src/platform_utils.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+
+def now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def iso_utc(ts: datetime) -> str:
+    return ts.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def get_retry_jitter(base_delay: float) -> float:
+    """Return a random jittered delay between 0 and base_delay using Full Jitter strategy."""
+    return secrets.SystemRandom().uniform(0, base_delay)
+
+
+def get_hex_jitter(num_bytes: int = 1) -> str:
+    return secrets.token_hex(num_bytes)
+
+
+def coerce_optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def coerce_optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def coerce_positive_int(value: Any, *, default: int) -> int:
+    parsed = coerce_optional_int(value)
+    if parsed is None:
+        return default
+    return max(1, parsed)
+
+
+def json_default(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        if value == value.to_integral_value():
+            return int(value)
+        return float(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def parse_json_object_or_empty(body: Any) -> dict[str, Any]:
+    if isinstance(body, dict):
+        return dict(body)
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}

--- a/src/tenant_api/utils.py
+++ b/src/tenant_api/utils.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
-import secrets
-from datetime import UTC, datetime
-from decimal import Decimal
+from datetime import datetime
 from typing import Any
+
+from src.platform_utils import (
+    coerce_optional_string as _coerce_optional_string,
+)
+from src.platform_utils import (
+    coerce_positive_int as _coerce_positive_int,
+)
+from src.platform_utils import (
+    get_retry_jitter as _get_retry_jitter,
+)
+from src.platform_utils import (
+    iso_utc as _iso_utc,
+)
+from src.platform_utils import (
+    json_default as _json_default,
+)
+from src.platform_utils import (
+    now_utc as _now_utc,
+)
 
 _OVERRIDE_NOW: datetime | None = None
 
@@ -11,31 +28,23 @@ _OVERRIDE_NOW: datetime | None = None
 def now_utc() -> datetime:
     if _OVERRIDE_NOW:
         return _OVERRIDE_NOW
-    return datetime.now(UTC)
+    return _now_utc()
 
 
 def get_retry_jitter(base_delay: float) -> float:
-    """Return a random jittered delay between 0 and base_delay using Full Jitter strategy."""
-    return secrets.SystemRandom().uniform(0, base_delay)
+    return _get_retry_jitter(base_delay)
 
 
 def iso(dt: datetime) -> str:
-    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return _iso_utc(dt)
 
 
 def str_or_none(value: Any) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
+    return _coerce_optional_string(value)
 
 
 def json_default(value: Any) -> Any:
-    if isinstance(value, Decimal):
-        if value == value.to_integral_value():
-            return int(value)
-        return float(value)
-    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+    return _json_default(value)
 
 
 def as_float(value: Any, *, field: str) -> float:
@@ -48,8 +57,4 @@ def as_float(value: Any, *, field: str) -> float:
 
 
 def coerce_positive_int(value: Any, *, default: int) -> int:
-    try:
-        parsed = int(str(value))
-    except (TypeError, ValueError):
-        return default
-    return max(1, parsed)
+    return _coerce_positive_int(value, default=default)

--- a/src/webhook_delivery/events.py
+++ b/src/webhook_delivery/events.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from boto3.dynamodb.types import TypeDeserializer
 
+from src.platform_utils import coerce_optional_string as _coerce_optional_string
+
 WEBHOOK_SIGNATURE_HEADER = "X-Platform-Signature"
 WEBHOOK_SIGNATURE_ALGORITHM = "HMAC-SHA256"
 
@@ -99,9 +101,4 @@ def build_signed_request(
 
 
 def coerce_optional_string(value: Any) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        stripped = value.strip()
-        return stripped or None
-    return str(value)
+    return _coerce_optional_string(value)

--- a/tests/unit/test_platform_utils.py
+++ b/tests/unit/test_platform_utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from src import platform_utils
+
+
+def test_iso_utc_strips_microseconds_and_uses_z_suffix() -> None:
+    value = datetime(2026, 4, 4, 12, 0, 1, 999999, tzinfo=UTC)
+    assert platform_utils.iso_utc(value) == "2026-04-04T12:00:01Z"
+
+
+def test_coerce_optional_string_trims_and_empty_to_none() -> None:
+    assert platform_utils.coerce_optional_string(" hi ") == "hi"
+    assert platform_utils.coerce_optional_string("   ") is None
+    assert platform_utils.coerce_optional_string(None) is None
+
+
+def test_coerce_positive_int_uses_default_on_invalid_and_minimum_one() -> None:
+    assert platform_utils.coerce_positive_int("7", default=3) == 7
+    assert platform_utils.coerce_positive_int("0", default=3) == 1
+    assert platform_utils.coerce_positive_int("bad", default=3) == 3
+
+
+def test_json_default_serializes_decimal() -> None:
+    assert platform_utils.json_default(Decimal("2")) == 2
+    assert platform_utils.json_default(Decimal("2.5")) == 2.5
+
+
+def test_parse_json_object_or_empty_handles_invalid_or_non_object() -> None:
+    assert platform_utils.parse_json_object_or_empty('{"a":1}') == {"a": 1}
+    assert platform_utils.parse_json_object_or_empty("[]") == {}
+    assert platform_utils.parse_json_object_or_empty("bad") == {}


### PR DESCRIPTION
Closes #438

## Summary
- add `src/platform_utils.py` for shared UTC time, retry jitter, JSON-default, and coercion helpers
- migrate request interceptor, bridge, tenant-api utils, and webhook delivery helpers to that shared utility surface
- keep helper semantics stable while removing duplicated boring utility code
- add focused direct tests for the extracted shared utility module

## Validation
- `PYTHONPATH=. uv run pytest tests/unit/test_platform_utils.py tests/unit/test_request_interceptor.py tests/integration/test_request_interceptor_integration.py tests/unit/test_issue_119.py tests/unit/test_bridge_services.py tests/unit/test_webhook_delivery_services.py`
- `make preflight-session`
- `make pre-validate-session`
- `npx gitnexus analyze`
