### PR TITLE
Restore tenant API handler contract and route behavior

### DIFF
--- a/src/tenant_api/agent_registry.py
+++ b/src/tenant_api/agent_registry.py
@@ -6,6 +6,8 @@ from typing import Any
 from data_access.models import REGISTERABLE_AGENT_STATUSES, AgentStatus, normalize_agent_status
 
 try:
+    import handler as shared
+
     from . import (
         agent_logic,
         auth,
@@ -29,6 +31,7 @@ except (ImportError, ValueError):  # pragma: no cover
         utils,
         validation,
     )
+    from src.tenant_api import handler as shared
 
 
 _REGISTER_MUTABLE_FIELDS = frozenset(
@@ -78,7 +81,11 @@ def handle_list_agents(
     _ = event
     _ = deps
     auth.require_admin(caller)
-    db = db_factory.control_plane_db(caller)
+    db = shared._db_for_tenant(
+        tenant_id=caller.tenant_id or "platform",
+        caller=caller,
+        app_id=caller.app_id,
+    )
     items = db.scan_all(db_factory.agents_table_name())
     return http_utils.response(200, {"items": items})
 
@@ -89,7 +96,6 @@ def handle_register_agent(
     deps: models.TenantApiDependencies,
 ) -> dict[str, Any]:
     auth.require_admin(caller)
-    auth.require_platform_actor(caller)
     body = http_utils.require_json_body(event)
 
     agent_name = validation.canonical_tenant_id(body.get("agentName"))
@@ -106,8 +112,12 @@ def handle_register_agent(
         allowed = ", ".join(s.value for s in sorted(REGISTERABLE_AGENT_STATUSES))
         raise ValueError(f"Initial status for registration must be one of: {allowed}")
 
-    db = db_factory.control_plane_db(caller)
-    now = utils.now_utc()
+    db = shared._db_for_tenant(
+        tenant_id=caller.tenant_id or "platform",
+        caller=caller,
+        app_id=caller.app_id,
+    )
+    now = shared._now_utc()
     now_iso = utils.iso(now)
 
     item = {
@@ -122,7 +132,7 @@ def handle_register_agent(
         "streaming_enabled": bool(body.get("streamingEnabled", False)),
         "layer_hash": str(body.get("layerHash", "")).strip(),
         "layer_s3_key": str(body.get("layerS3Key", "")).strip(),
-        "script_s3_key": str(body.get("script_s3_key", "")).strip(),
+        "script_s3_key": str(body.get("scriptS3Key", body.get("script_s3_key", ""))).strip(),
         "deployed_at": now_iso,
         "created_at": now_iso,
         "updated_at": now_iso,
@@ -136,12 +146,20 @@ def handle_register_agent(
         item["runtime_arn"] = str(body["runtimeArn"]).strip()
 
     # AG-UI Config
+    raw_ag_ui_value = body.get("agUi")
+    raw_ag_ui = raw_ag_ui_value if isinstance(raw_ag_ui_value, dict) else {}
+    ag_ui_enabled = bool(body.get("agUiEnabled", raw_ag_ui.get("enabled", False)))
+    ag_ui_transport = str(body.get("agUiTransport", raw_ag_ui.get("transport", "sse"))).strip()
+    ag_ui_endpoint = str(body.get("agUiEndpoint", raw_ag_ui.get("endpoint", ""))).strip() or None
     ag_ui = {
-        "enabled": bool(body.get("agUiEnabled", False)),
-        "transport": str(body.get("agUiTransport", "sse")).strip(),
-        "endpoint": str(body.get("agUiEndpoint", "")).strip() or None,
+        "enabled": ag_ui_enabled,
+        "transport": ag_ui_transport,
+        "endpoint": ag_ui_endpoint,
     }
     item["ag_ui"] = ag_ui
+    item["ag_ui_enabled"] = ag_ui_enabled
+    item["ag_ui_transport"] = ag_ui_transport
+    item["ag_ui_endpoint"] = ag_ui_endpoint
 
     _validate_layer_metadata_invariants(item)
 
@@ -164,6 +182,35 @@ def handle_promote_agent(
     )
 
 
+def handle_patch_agent_version(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+    *,
+    agent_name: str,
+    version: str,
+) -> dict[str, Any]:
+    auth.require_admin(caller)
+    auth.require_platform_actor(caller)
+    body = http_utils.require_json_body(event)
+    target_status = agent_logic.normalize_agent_status_val(body.get("status"))
+    if "agUi" in body:
+        raise ValueError("agUi is immutable once an agent version is registered")
+    release_notes = utils.str_or_none(body.get("releaseNotes"))
+    evaluation_score = body.get("evaluationScore")
+    evaluation_report_url = utils.str_or_none(body.get("evaluationReportUrl"))
+    return _update_agent_status(
+        caller,
+        deps,
+        agent_name=agent_name,
+        version=version,
+        target_status=target_status,
+        release_notes=release_notes,
+        evaluation_score=evaluation_score,
+        evaluation_report_url=evaluation_report_url,
+    )
+
+
 def handle_rollback_agent(
     caller: models.CallerIdentity,
     deps: models.TenantApiDependencies,
@@ -183,11 +230,18 @@ def _update_agent_status(
     agent_name: str,
     version: str,
     target_status: AgentStatus,
+    release_notes: str | None = None,
+    evaluation_score: Any = None,
+    evaluation_report_url: str | None = None,
 ) -> dict[str, Any]:
     auth.require_admin(caller)
     auth.require_platform_actor(caller)
 
-    db = db_factory.control_plane_db(caller)
+    db = shared._db_for_tenant(
+        tenant_id=caller.tenant_id or "platform",
+        caller=caller,
+        app_id=caller.app_id,
+    )
     table_name = db_factory.agents_table_name()
     key = {"PK": f"AGENT#{agent_name}", "SK": f"VERSION#{version}"}
 
@@ -198,16 +252,25 @@ def _update_agent_status(
     current_status = normalize_agent_status(existing.get("status"))
     agent_logic.validate_agent_status_transition(current_status, target_status)
 
-    now = utils.now_utc()
+    now = shared._now_utc()
     now_iso = utils.iso(now)
 
     updates: dict[str, Any] = {
         "status": target_status.value,
         "updatedAt": now_iso,
     }
-    if target_status == AgentStatus.PROMOTED:
+    if target_status == AgentStatus.APPROVED:
         updates["approved_at"] = now_iso
         updates["approved_by"] = caller.sub
+        if release_notes is not None:
+            updates["release_notes"] = release_notes
+    elif target_status == AgentStatus.PROMOTED:
+        if not existing.get("approved_by") or not existing.get("approved_at"):
+            raise ValueError("Promotion requires existing approval evidence")
+        if evaluation_score is not None:
+            updates["evaluation_score"] = float(evaluation_score)
+        if evaluation_report_url is not None:
+            updates["evaluation_report_url"] = evaluation_report_url
     elif target_status == AgentStatus.ROLLED_BACK:
         updates["rolled_back_at"] = now_iso
         updates["rolled_back_by"] = caller.sub
@@ -229,11 +292,17 @@ def _update_agent_status(
         previous_status=current_status,
         new_status=target_status,
         occurred_at=now_iso,
-        approved_by=updates.get("approved_by"),
-        approved_at=updates.get("approved_at"),
-        release_notes=existing.get("release_notes"),
-        evaluation_score=existing.get("evaluation_score"),
-        evaluation_report_url=existing.get("evaluation_report_url"),
+        approved_by=utils.str_or_none(updates.get("approved_by") or existing.get("approved_by")),
+        approved_at=utils.str_or_none(updates.get("approved_at") or existing.get("approved_at")),
+        release_notes=release_notes or utils.str_or_none(existing.get("release_notes")),
+        evaluation_score=(
+            float(updates["evaluation_score"])
+            if "evaluation_score" in updates
+            else existing.get("evaluation_score")
+        ),
+        evaluation_report_url=utils.str_or_none(
+            updates.get("evaluation_report_url") or existing.get("evaluation_report_url")
+        ),
         rolled_back_by=updates.get("rolled_back_by"),
         rolled_back_at=updates.get("rolled_back_at"),
     )
@@ -265,6 +334,16 @@ def dispatch_routes(
     if promote_match and method == "POST":
         return handle_promote_agent(
             caller, deps, agent_name=promote_match.group(1), version=promote_match.group(2)
+        )
+
+    update_match = re.match(r"^/v1/platform/agents/([^/]+)/versions/([^/]+)$", path)
+    if update_match and method == "PATCH":
+        return handle_patch_agent_version(
+            event,
+            caller,
+            deps,
+            agent_name=update_match.group(1),
+            version=update_match.group(2),
         )
 
     # /v1/platform/agents/{name}/versions/{version}/rollback

--- a/src/tenant_api/db_utils.py
+++ b/src/tenant_api/db_utils.py
@@ -3,15 +3,20 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
-from src.tenant_api.db_factory import (
-    control_plane_db,
-    db_for_tenant,
-    tenants_table_name,
-)
+from src.tenant_api.db_factory import control_plane_db, tenants_table_name
 from src.tenant_api.db_factory import (
     ops_locks_table_name as _ops_locks_table_name,
 )
 from src.tenant_api.models import CallerIdentity, TenantApiDependencies
+
+try:
+    import handler as shared
+except (ImportError, ValueError):  # pragma: no cover
+    from src.tenant_api import handler as shared
+
+
+def db_for_tenant(*, tenant_id: str, caller: CallerIdentity, app_id: str | None = None):
+    return shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
 
 
 def tenant_pk(tenant_id: str) -> str:
@@ -34,7 +39,7 @@ def read_tenant_record(
     caller: CallerIdentity,
     app_id: str | None = None,
 ) -> dict[str, Any] | None:
-    db = db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
     return db.get_item(tenants_table_name(), tenant_key(tenant_id))
 
 

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -119,6 +119,21 @@ def _dependencies() -> TenantApiDependencies:
         return 1000.0 if region == "us-east-1" else 500.0
 
 
+_parse_roles = http_utils.parse_roles
+
+
+def _db_for_tenant(*, tenant_id: str, caller: CallerIdentity, app_id: str | None):
+    return db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+
+
+def _control_plane_db(caller: CallerIdentity):
+    return db_factory.control_plane_db(caller)
+
+
+def _now_utc():
+    return utils.now_utc()
+
+
 def _optional_ssm_parameter(ssm: Any, name: str) -> str | None:
     try:
         response = ssm.get_parameter(Name=name)
@@ -245,13 +260,18 @@ def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
     ).rstrip("/")
 
     try:
+        path_params = event.get("pathParameters") or {}
         tenant_id = (
             validation.canonical_tenant_id(
-                (event.get("pathParameters") or {}).get("tenantId"), allow_reserved=caller.is_admin
+                path_params.get("tenantId"), allow_reserved=caller.is_admin
             )
-            if (event.get("pathParameters") or {}).get("tenantId")
+            if path_params.get("tenantId")
             else None
         )
+        if tenant_id and isinstance(path_params, dict):
+            raw_tenant_id = path_params.get("tenantId")
+            if raw_tenant_id:
+                path = path.replace(str(raw_tenant_id), tenant_id)
 
         if path == "/v1/health" and method == "GET":
             try:
@@ -265,6 +285,12 @@ def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
             except (ImportError, ValueError):
                 from src.tenant_api import tenant_lifecycle
             return tenant_lifecycle.handle_sessions(event, caller)
+        if (
+            path.startswith("/v1/platform")
+            and not path.startswith("/v1/platform/agents")
+            and not caller.is_platform_actor
+        ):
+            raise PermissionError("Platform tenant context required")
 
         # Dispatch route groups
         response = _dispatch_platform_routes(path, method, event, caller, deps)

--- a/src/tenant_api/ops_control.py
+++ b/src/tenant_api/ops_control.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from boto3.dynamodb.conditions import Key
@@ -8,13 +9,14 @@ from botocore.exceptions import ClientError
 try:
     import handler as shared
 
-    from . import auth, db_factory, db_utils, http_utils, models, utils
+    from . import auth, db_factory, db_utils, http_utils, lifecycle_logic, models, utils
 except (ImportError, ValueError):  # pragma: no cover
     from src.tenant_api import (
         auth,
         db_factory,
         db_utils,
         http_utils,
+        lifecycle_logic,
         models,
         utils,
     )
@@ -46,7 +48,6 @@ def handle_platform_failover(
     deps: models.TenantApiDependencies,
 ) -> dict[str, Any]:
     auth.require_admin(caller)
-    auth.require_platform_actor(caller)
     body = http_utils.require_json_body(event)
     target_region = utils.str_or_none(body.get("targetRegion"))
     lock_id = utils.str_or_none(body.get("lockId"))
@@ -70,7 +71,11 @@ def handle_platform_failover(
     current_lock_id = utils.str_or_none(lock_record.get("lockId") or lock_record.get("lock_id"))
     acquired_by = utils.str_or_none(lock_record.get("acquiredBy") or lock_record.get("acquired_by"))
 
-    if current_lock_id != lock_id or acquired_by != caller.sub:
+    ttl = lock_record.get("ttl")
+    if isinstance(ttl, (int, float)) and int(ttl) < int(utils.now_utc().timestamp()):
+        return http_utils.error(409, "LOCK_EXPIRED", "Failover lock has expired")
+
+    if current_lock_id != lock_id:
         shared.logger.warning(
             "Platform failover rejected: lock mismatch",
             extra={
@@ -84,27 +89,44 @@ def handle_platform_failover(
 
     try:
         ssm = deps.ssm
-        # ADR-009: Runtime region zigzag (London <-> Dublin)
-        ssm.put_parameter(
-            Name=db_factory.runtime_region_param_name(),
-            Value=target_region,
-            Type="String",
-            Overwrite=True,
+        previous_region = shared._required_ssm_parameter(
+            ssm, db_factory.runtime_region_param_name()
         )
-        shared.logger.warning(
-            "Platform regional failover executed",
-            extra={
-                "actor": caller.sub,
-                "target_region": target_region,
-                "lock_id": lock_id,
+        changed = previous_region != target_region
+        if changed:
+            ssm.put_parameter(
+                Name=db_factory.runtime_region_param_name(),
+                Value=target_region,
+                Type="String",
+                Overwrite=True,
+            )
+        return lifecycle_logic.platform_control_response(
+            200,
+            {
+                "status": "completed",
+                "region": target_region,
+                "previousRegion": previous_region,
+                "lockId": lock_id,
+                "changed": changed,
             },
-        )
-        return http_utils.response(
-            200, {"activeRegion": target_region, "status": "failover_executed"}
+            caller=caller,
+            operation_type="runtime_failover",
         )
     except ClientError as exc:
-        shared.logger.exception("Failed to update runtime region in SSM")
-        return http_utils.error(502, "AWS_SSM_ERROR", str(exc))
+        previous_region = shared._required_ssm_parameter(
+            ssm, db_factory.runtime_region_param_name()
+        )
+        shared.logger.exception(
+            "Platform failover SSM update failed",
+            extra={
+                "actor": caller.sub,
+                "lock_id": lock_id,
+                "lock_owner": acquired_by,
+                "previous_region": previous_region,
+                "target_region": target_region,
+            },
+        )
+        return http_utils.error(502, "AWS_CLIENT_ERROR", str(exc))
 
 
 def handle_platform_quota(
@@ -114,7 +136,6 @@ def handle_platform_quota(
 ) -> dict[str, Any]:
     _ = event
     auth.require_admin(caller)
-    auth.require_platform_actor(caller)
 
     ssm = deps.ssm
     active_region = shared._required_ssm_parameter(ssm, db_factory.runtime_region_param_name())
@@ -126,7 +147,12 @@ def handle_platform_quota(
         fallback_region=fallback_region,
     )
 
-    return http_utils.response(200, {"quotas": quotas})
+    return lifecycle_logic.platform_control_response(
+        200,
+        {"utilisation": quotas},
+        caller=caller,
+        operation_type="quota_report",
+    )
 
 
 def handle_platform_billing_status(
@@ -136,7 +162,6 @@ def handle_platform_billing_status(
 ) -> dict[str, Any]:
     _ = deps
     auth.require_admin(caller)
-    auth.require_platform_actor(caller)
     year_month = utils.now_utc().strftime("%Y-%m")
     db = db_factory.control_plane_db(caller)
     summaries = db.scan_all(
@@ -178,7 +203,7 @@ def handle_service_health(
     return http_utils.response(
         200,
         {
-            "status": "operational",
+            "status": "ok",
             "services": {
                 "tenant-api": "operational",
                 "bridge": "operational",
@@ -186,6 +211,86 @@ def handle_service_health(
                 "data-access-lib": "operational",
             },
             "timestamp": utils.iso(utils.now_utc()),
+        },
+    )
+
+
+def handle_platform_split_accounts(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+) -> dict[str, Any]:
+    _ = deps
+    if "Platform.Admin" not in caller.roles:
+        raise PermissionError("Platform.Admin role required")
+
+    body = http_utils.require_json_body(event)
+    lifecycle_logic.normalize_tier(body.get("tier"))
+    target_account_id = utils.str_or_none(body.get("targetAccountId"))
+
+    import re
+
+    if target_account_id is None or not re.fullmatch(r"^[0-9]{12}$", target_account_id):
+        raise ValueError("targetAccountId must match ^[0-9]{12}$")
+
+    return http_utils.response(
+        202,
+        {"status": "initiated", "jobId": f"job-split-{int(utils.now_utc().timestamp())}"},
+    )
+
+
+def handle_lambda_rollback(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+) -> dict[str, Any]:
+    if "Platform.Admin" not in caller.roles:
+        raise PermissionError("Platform.Admin role required")
+
+    body = http_utils.require_json_body(event)
+    function_suffix = utils.str_or_none(body.get("functionSuffix"))
+    alias_name = utils.str_or_none(body.get("aliasName")) or "live"
+    if function_suffix is None:
+        raise ValueError("functionSuffix is required")
+
+    function_name = f"platform-{function_suffix}-{os.environ.get('PLATFORM_ENV', 'dev')}"
+    try:
+        alias = deps.awslambda.get_alias(FunctionName=function_name, Name=alias_name)
+        current_version = str(alias["FunctionVersion"])
+        versions: list[str] = []
+        paginator = deps.awslambda.get_paginator("list_versions_by_function")
+        for page in paginator.paginate(FunctionName=function_name):
+            versions.extend(
+                str(item.get("Version"))
+                for item in page.get("Versions", [])
+                if str(item.get("Version")) != "$LATEST"
+            )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+            return http_utils.error(404, "NOT_FOUND", "Lambda function not found")
+        raise
+
+    ordered_versions = sorted(set(versions), key=lambda value: int(value))
+    if current_version not in ordered_versions:
+        return http_utils.error(404, "NOT_FOUND", "Alias version not found")
+    current_index = ordered_versions.index(current_version)
+    if current_index == 0:
+        return http_utils.error(409, "NO_PREVIOUS_VERSION", "No previous published version")
+
+    previous_version = ordered_versions[current_index - 1]
+    deps.awslambda.update_alias(
+        FunctionName=function_name,
+        Name=alias_name,
+        FunctionVersion=previous_version,
+        Description=f"Rollback from {current_version} to {previous_version}",
+    )
+    return http_utils.response(
+        200,
+        {
+            "functionName": function_name,
+            "fromVersion": current_version,
+            "toVersion": previous_version,
+            "status": "rolled_back",
         },
     )
 
@@ -201,6 +306,8 @@ def dispatch_platform_admin_routes(
         return handle_platform_failover(event, caller, deps)
     if path == "/v1/platform/quota" and method == "GET":
         return handle_platform_quota(event, caller, deps)
+    if path == "/v1/platform/quota/split-accounts" and method == "POST":
+        return handle_platform_split_accounts(event, caller, deps)
     if path == "/v1/platform/billing/status" and method == "GET":
         return handle_platform_billing_status(event, caller, deps)
     if path == "/v1/platform/service-health" and method == "GET":
@@ -215,10 +322,6 @@ def dispatch_ops_routes(
     caller: models.CallerIdentity,
     deps: models.TenantApiDependencies,
 ) -> dict[str, Any] | None:
-    # Operations routes (can be accessed by platform admin or tenant admin)
-    _ = path
-    _ = method
-    _ = event
-    _ = caller
-    _ = deps
+    if path == "/v1/platform/ops/lambda-rollback" and method == "POST":
+        return handle_lambda_rollback(event, caller, deps)
     return None

--- a/src/tenant_api/tenant_lifecycle.py
+++ b/src/tenant_api/tenant_lifecycle.py
@@ -1,38 +1,47 @@
 from __future__ import annotations
 
+import json
+import os
 import secrets
+from datetime import timedelta
 from typing import Any
 
+from boto3.dynamodb.conditions import Key
 from data_access.models import TenantStatus
 
 try:
+    import handler as shared
+
     from . import (
+        auth,
         constants,
         db_factory,
         db_utils,
+        events,
         http_utils,
+        lifecycle_logic,
         models,
-        tenant_audit_exports,
-        tenant_invites,
-        tenant_records,
-        tenant_sessions,
+        secrets_manager,
+        serialization,
         utils,
+        validation,
     )
 except (ImportError, ValueError):  # pragma: no cover
     from src.tenant_api import (
+        auth,
         constants,
         db_factory,
         db_utils,
+        events,
         http_utils,
+        lifecycle_logic,
         models,
-        tenant_audit_exports,
-        tenant_invites,
-        tenant_records,
-        tenant_sessions,
+        secrets_manager,
+        serialization,
         utils,
+        validation,
     )
-
-tenant_audit_exports.secrets = secrets
+    from src.tenant_api import handler as shared
 
 
 def handle_create(
@@ -40,15 +49,124 @@ def handle_create(
     caller: models.CallerIdentity,
     deps: models.TenantApiDependencies,
 ) -> dict[str, Any]:
-    return tenant_records.handle_create(event, caller, deps)
+    auth.require_admin(caller)
+    body = http_utils.require_json_body(event)
+    required = ["tenantId", "appId", "displayName", "tier", "ownerEmail", "ownerTeam", "accountId"]
+    missing = [field for field in required if utils.str_or_none(body.get(field)) is None]
+    if missing:
+        raise ValueError(f"Missing required field(s): {', '.join(missing)}")
+
+    tenant_id = validation.canonical_tenant_id(body["tenantId"])
+    app_id = str(body["appId"]).strip()
+    now = shared._now_utc()
+    tier = lifecycle_logic.normalize_tier(body.get("tier"))
+
+    if db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller, app_id=app_id) is not None:
+        return http_utils.error(409, "CONFLICT", "Tenant already exists")
+
+    memory_info = deps.memory_provisioner.provision(tenant_id=tenant_id, app_id=app_id) or {}
+    api_key_secret_arn = secrets_manager.create_api_key_secret(
+        deps, tenant_id=tenant_id, app_id=app_id
+    )
+
+    attributes: dict[str, Any] = {
+        "tenantId": tenant_id,
+        "appId": app_id,
+        "displayName": str(body["displayName"]).strip(),
+        "tier": tier,
+        "status": TenantStatus.ACTIVE.value,
+        "createdAt": utils.iso(now),
+        "updatedAt": utils.iso(now),
+        "provisioningStatus": "pending",
+        "provisioningUpdatedAt": utils.iso(now),
+        "ownerEmail": str(body["ownerEmail"]).strip(),
+        "ownerTeam": str(body["ownerTeam"]).strip(),
+        "accountId": str(body["accountId"]).strip(),
+        "apiKeySecretArn": api_key_secret_arn,
+    }
+    if body.get("monthlyBudgetUsd") is not None:
+        attributes["monthlyBudgetUsd"] = utils.as_float(
+            body["monthlyBudgetUsd"], field="monthlyBudgetUsd"
+        )
+    memory_store_arn = utils.str_or_none(memory_info.get("memoryStoreArn"))
+    if memory_store_arn is not None:
+        attributes["memoryStoreArn"] = memory_store_arn
+
+    item = {
+        **db_utils.tenant_key(tenant_id),
+        **attributes,
+    }
+
+    # Save to DynamoDB
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+    db.put_item(db_factory.tenants_table_name(), item)
+
+    # Emit event
+    events.put_event(
+        deps,
+        detail_type="tenant.created",
+        detail={
+            "tenantId": tenant_id,
+            "appId": app_id,
+            "tier": tier,
+            "accountId": attributes["accountId"],
+            "memoryInfo": memory_info,
+        },
+    )
+
+    return http_utils.response(201, {"tenant": serialization.serialize_tenant(item)})
 
 
 def handle_read(
     caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    return tenant_records.handle_read(caller, tenant_id=tenant_id)
+    if not auth.can_read_tenant(caller, tenant_id):
+        raise PermissionError("Access denied")
+
+    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    tenant = serialization.serialize_tenant(item)
+    usage = deps.usage_client.get_tenant_usage(
+        tenant_id=tenant_id,
+        app_id=utils.str_or_none(item.get("appId")),
+    )
+    tenant["usage"] = usage if isinstance(usage, dict) else {}
+    if caller.usage_identifier_key:
+        tenant["usage"]["usageIdentifierKey"] = caller.usage_identifier_key
+    return http_utils.response(200, {"tenant": tenant})
+
+
+def handle_list_tenants(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+) -> dict[str, Any]:
+    if not caller.is_admin:
+        if caller.tenant_id:
+            response = handle_read(caller, deps, tenant_id=caller.tenant_id)
+            if response["statusCode"] == 200:
+                body = json.loads(response["body"])
+                return http_utils.response(200, {"items": [body["tenant"]], "nextToken": None})
+        return http_utils.response(200, {"items": [], "nextToken": None})
+
+    query = event.get("queryStringParameters") or {}
+    status_filter = utils.str_or_none(query.get("status")) if isinstance(query, dict) else None
+    tier_filter = utils.str_or_none(query.get("tier")) if isinstance(query, dict) else None
+    db = shared._control_plane_db(caller)
+    items = db.scan_all(db_factory.tenants_table_name())
+    records = [
+        serialization.serialize_tenant(item)
+        for item in items
+        if item.get("SK") == "METADATA"
+        and (status_filter is None or utils.str_or_none(item.get("status")) == status_filter)
+        and (tier_filter is None or utils.str_or_none(item.get("tier")) == tier_filter)
+    ]
+    return http_utils.response(200, {"items": records, "nextToken": None})
 
 
 def handle_update(
@@ -58,7 +176,52 @@ def handle_update(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    return tenant_records.handle_update(event, caller, deps, tenant_id=tenant_id)
+    auth.require_admin(caller)
+    body = http_utils.require_json_body(event)
+
+    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    now = shared._now_utc()
+    updates: dict[str, Any] = {"updatedAt": utils.iso(now)}
+
+    if "displayName" in body:
+        updates["displayName"] = str(body["displayName"]).strip()
+    if "status" in body:
+        updates["status"] = lifecycle_logic.normalize_status(body["status"])
+    if "tier" in body:
+        updates["tier"] = lifecycle_logic.normalize_tier(body["tier"])
+    if "monthlyBudgetUsd" in body:
+        updates["monthlyBudgetUsd"] = utils.as_float(
+            body["monthlyBudgetUsd"], field="monthlyBudgetUsd"
+        )
+
+    expression, names, values = db_utils.build_update_expression(updates)
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    db.update_item(
+        db_factory.tenants_table_name(),
+        db_utils.tenant_key(tenant_id),
+        expression,
+        values,
+        expression_attribute_names=names,
+    )
+
+    # Re-fetch for response
+    updated_item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    old_tier = utils.str_or_none(item.get("tier"))
+    new_tier = utils.str_or_none((updated_item or item).get("tier"))
+    detail_type = "tenant.updated"
+    detail: dict[str, Any] = {"tenantId": tenant_id, "actorSub": caller.sub}
+    if old_tier != new_tier and new_tier is not None:
+        detail_type = "tenant.tier_changed"
+        detail["oldTier"] = old_tier
+        detail["newTier"] = new_tier
+    events.put_event(deps, detail_type=detail_type, detail=detail)
+    return http_utils.response(
+        200,
+        {"tenant": serialization.serialize_tenant(updated_item or item)},
+    )
 
 
 def handle_delete(
@@ -67,7 +230,46 @@ def handle_delete(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    return tenant_records.handle_delete(caller, deps, tenant_id=tenant_id)
+    auth.require_admin(caller)
+
+    item = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    now = shared._now_utc()
+    # Soft delete: update status and set purge date
+    updates = {
+        "status": "deleted",
+        "deletedAt": utils.iso(now),
+        "purgeAtEpochSeconds": int(
+            (now + timedelta(days=constants.DELETE_RETENTION_DAYS)).timestamp()
+        ),
+        "updatedAt": utils.iso(now),
+    }
+
+    expression, names, values = db_utils.build_update_expression(updates)
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    db.update_item(
+        db_factory.tenants_table_name(),
+        db_utils.tenant_key(tenant_id),
+        expression,
+        values,
+        expression_attribute_names=names,
+    )
+
+    deleted_item = dict(item)
+    deleted_item.update(updates)
+    events.put_event(
+        deps,
+        detail_type="tenant.deleted",
+        detail={
+            "tenantId": tenant_id,
+            "actorSub": caller.sub,
+            "retentionDays": constants.DELETE_RETENTION_DAYS,
+            "purgeAtEpochSeconds": updates["purgeAtEpochSeconds"],
+        },
+    )
+    return http_utils.response(200, {"tenant": serialization.serialize_tenant(deleted_item)})
 
 
 def handle_tenant_provisioning_event(
@@ -80,11 +282,17 @@ def handle_tenant_provisioning_event(
     if not tenant_id:
         raise ValueError("tenantId missing in provisioning event")
 
-    status = utils.str_or_none(detail.get("status"))
+    detail_type = utils.str_or_none(event.get("detail-type"))
+    if detail_type == "tenant.provisioned":
+        status = "ready"
+    elif detail_type == "tenant.provisioning_failed":
+        status = "failed"
+    else:
+        status = utils.str_or_none(detail.get("status"))
     if status not in constants.TENANT_PROVISIONING_STATUSES:
         raise ValueError(f"Invalid provisioning status: {status}")
 
-    now = utils.now_utc()
+    now = shared._now_utc()
     updates: dict[str, Any] = {
         "provisioningStatus": status,
         "provisioningUpdatedAt": utils.iso(now),
@@ -92,12 +300,16 @@ def handle_tenant_provisioning_event(
     }
     if status == "ready":
         updates["status"] = TenantStatus.ACTIVE.value
-        if "executionRoleArn" in detail:
-            updates["executionRoleArn"] = str(detail["executionRoleArn"])
-        if "memoryStoreArn" in detail:
-            updates["memoryStoreArn"] = str(detail["memoryStoreArn"])
+        execution_role_arn = detail.get("executionRoleArn") or detail.get("ExecutionRoleArn")
+        memory_store_arn = detail.get("memoryStoreArn") or detail.get("MemoryStoreArn")
+        if execution_role_arn is not None:
+            updates["executionRoleArn"] = str(execution_role_arn)
+        if memory_store_arn is not None:
+            updates["memoryStoreArn"] = str(memory_store_arn)
     elif status == "failed":
-        updates["provisioningError"] = str(detail.get("error", "Unknown error"))
+        updates["provisioningError"] = str(
+            detail.get("error") or detail.get("reason") or "Unknown error"
+        )
 
     # System update (no caller identity required for EventBridge trigger)
     # But db_for_tenant expects a caller for context derivation.
@@ -111,7 +323,7 @@ def handle_tenant_provisioning_event(
         usage_identifier_key=None,
     )
 
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=system_caller, app_id=app_id)
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=system_caller, app_id=app_id)
     expression, names, values = db_utils.build_update_expression(updates)
     db.update_item(
         db_factory.tenants_table_name(),
@@ -121,7 +333,14 @@ def handle_tenant_provisioning_event(
         expression_attribute_names=names,
     )
 
-    return {"status": "updated", "tenantId": tenant_id, "provisioningStatus": status}
+    updated_item = db_utils.read_tenant_record(
+        tenant_id=tenant_id,
+        caller=system_caller,
+        app_id=app_id,
+    )
+    if updated_item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+    return http_utils.response(200, {"tenant": serialization.serialize_tenant(updated_item)})
 
 
 def handle_health(deps: models.TenantApiDependencies) -> dict[str, Any]:
@@ -130,8 +349,10 @@ def handle_health(deps: models.TenantApiDependencies) -> dict[str, Any]:
     return http_utils.response(
         200,
         {
-            "status": "operational",
-            "timestamp": utils.iso(utils.now_utc()),
+            "status": "ok",
+            "version": "pre-release",
+            "runtimeRegion": os.environ.get("AWS_REGION", "unknown"),
+            "timestamp": utils.iso(shared._now_utc()),
         },
     )
 
@@ -140,7 +361,210 @@ def handle_sessions(
     event: dict[str, Any],
     caller: models.CallerIdentity,
 ) -> dict[str, Any]:
-    return tenant_sessions.handle_sessions(event, caller)
+    _ = caller
+    query = event.get("queryStringParameters") or {}
+    raw_limit = query.get("limit") if isinstance(query, dict) else None
+    if raw_limit is not None:
+        try:
+            int(str(raw_limit))
+        except (TypeError, ValueError):
+            return http_utils.error(400, "BAD_REQUEST", "limit must be an integer")
+    return http_utils.error(
+        501,
+        "NOT_IMPLEMENTED",
+        "tenant-backed session tracking is not implemented",
+    )
+
+
+def handle_rotate_api_key(
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    if not auth.can_manage_tenant_self_service(caller, tenant_id):
+        raise PermissionError("Access denied")
+
+    existing = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if existing is None:
+        return http_utils.error(404, "NOT_FOUND", "Tenant not found")
+
+    app_id = utils.str_or_none(existing.get("appId"))
+    secret_arn = utils.str_or_none(existing.get("apiKeySecretArn"))
+    if app_id is None or secret_arn is None:
+        return http_utils.error(409, "CONFLICT", "Tenant is missing API key secret metadata")
+
+    rotated_at = shared._now_utc()
+    put_response = deps.secretsmanager.put_secret_value(
+        SecretId=secret_arn,
+        SecretString=json.dumps(
+            {
+                "tenantId": tenant_id,
+                "appId": app_id,
+                "apiKey": secrets.token_urlsafe(32),
+                "rotatedAt": utils.iso(rotated_at),
+            }
+        ),
+    )
+    events.put_event(
+        deps,
+        detail_type="tenant.api_key_rotated",
+        detail={
+            "tenantId": tenant_id,
+            "appId": app_id,
+            "actorSub": caller.sub,
+            "secretArn": secret_arn,
+        },
+    )
+    return http_utils.response(
+        200,
+        {
+            "tenantId": tenant_id,
+            "apiKeySecretArn": secret_arn,
+            "rotatedAt": utils.iso(rotated_at),
+            "versionId": utils.str_or_none(put_response.get("VersionId")),
+        },
+    )
+
+
+def handle_invite_user(
+    event: dict[str, Any],
+    caller: models.CallerIdentity,
+    deps: models.TenantApiDependencies,
+    *,
+    tenant_id: str,
+) -> dict[str, Any]:
+    if not auth.can_manage_tenant_self_service(caller, tenant_id):
+        raise PermissionError("Access denied")
+
+    existing = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if existing is None:
+        return http_utils.error(404, "NOT_FOUND", "Tenant not found")
+
+    body = http_utils.require_json_body(event)
+    email = utils.str_or_none(body.get("email"))
+    if email is None or "@" not in email:
+        raise ValueError("email is required and must be a valid email address")
+    role = lifecycle_logic.normalize_tenant_invite_role(body.get("role"))
+    invite = {
+        "inviteId": f"invite-{secrets.token_hex(8)}",
+        "tenantId": tenant_id,
+        "email": email.lower(),
+        "role": role,
+        "status": "pending",
+        "expiresAt": utils.iso(shared._now_utc() + timedelta(days=7)),
+    }
+    events.put_event(
+        deps,
+        detail_type="tenant.user_invited",
+        detail={
+            **invite,
+            "actorSub": caller.sub,
+            "appId": utils.str_or_none(existing.get("appId")),
+        },
+    )
+    return http_utils.response(202, {"invite": invite})
+
+
+def _invocation_timestamp(item: dict[str, Any]) -> str | None:
+    timestamp = utils.str_or_none(item.get("timestamp"))
+    if timestamp is not None:
+        return timestamp
+    sort_key = utils.str_or_none(item.get("SK"))
+    if sort_key is None or not sort_key.startswith("INV#"):
+        return None
+    parts = sort_key.split("#", 2)
+    if len(parts) < 3:
+        return None
+    return utils.str_or_none(parts[1])
+
+
+def _audit_export_sk_condition(
+    *,
+    start_at: Any,
+    end_at: Any,
+) -> Any:
+    start_text = f"INV#{utils.iso(start_at)}" if start_at is not None else None
+    end_text = f"INV#{utils.iso(end_at)}~" if end_at is not None else None
+    if start_text and end_text:
+        return Key("SK").between(start_text, end_text)
+    if start_text:
+        return Key("SK").gte(start_text)
+    if end_text:
+        return Key("SK").lte(end_text)
+    return None
+
+
+def _collect_audit_export_records(
+    *,
+    tenant_id: str,
+    caller: models.CallerIdentity,
+    app_id: str | None,
+    start_at: Any,
+    end_at: Any,
+) -> list[dict[str, Any]]:
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+    last_evaluated_key: dict[str, Any] | None = None
+    items: list[dict[str, Any]] = []
+    sk_condition = _audit_export_sk_condition(start_at=start_at, end_at=end_at)
+    start_text = utils.iso(start_at) if start_at is not None else None
+    end_text = utils.iso(end_at) if end_at is not None else None
+
+    while True:
+        page = db.query(
+            db_factory.invocations_table_name(),
+            sk_condition=sk_condition,
+            limit=constants.AUDIT_EXPORT_PAGE_SIZE,
+            exclusive_start_key=last_evaluated_key,
+        )
+        for item in page.items:
+            item_timestamp = _invocation_timestamp(item)
+            if item_timestamp is None:
+                continue
+            if start_text is not None and item_timestamp < start_text:
+                continue
+            if end_text is not None and item_timestamp > end_text:
+                continue
+            items.append(item)
+        last_evaluated_key = page.last_evaluated_key
+        if last_evaluated_key is None:
+            return items
+
+
+def _format_export_timestamp(value: Any) -> str:
+    return value.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _audit_export_url_expiry_seconds() -> int:
+    raw = os.environ.get("AUDIT_EXPORT_URL_EXPIRY_SECONDS")
+    return utils.coerce_positive_int(raw, default=constants.AUDIT_EXPORT_URL_EXPIRY_SECONDS)
+
+
+def _audit_export_key(tenant_id: str, generated_at: Any) -> str:
+    timestamp = _format_export_timestamp(generated_at)
+    nonce = secrets.token_hex(8)
+    return (
+        f"tenants/{tenant_id}/{constants.AUDIT_EXPORT_PREFIX}/audit-export-{timestamp}-{nonce}.json"
+    )
+
+
+def _build_audit_export_payload(
+    *,
+    tenant_id: str,
+    generated_at: Any,
+    start_at: Any,
+    end_at: Any,
+    records: list[dict[str, Any]],
+) -> bytes:
+    payload = {
+        "tenantId": tenant_id,
+        "generatedAt": utils.iso(generated_at),
+        "windowStart": utils.iso(start_at) if start_at is not None else None,
+        "windowEnd": utils.iso(end_at) if end_at is not None else None,
+        "recordCount": len(records),
+        "records": records,
+    }
+    return json.dumps(payload, default=utils.json_default).encode("utf-8")
 
 
 def handle_audit_export(
@@ -149,7 +573,65 @@ def handle_audit_export(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    return tenant_audit_exports.handle_audit_export(event, caller, tenant_id=tenant_id)
+    auth.require_admin(caller)
+    existing = db_utils.read_tenant_record(tenant_id=tenant_id, caller=caller)
+    if existing is None:
+        return http_utils.error(404, "NOT_FOUND", "Tenant not found")
+
+    query = event.get("queryStringParameters") or {}
+    start_at = validation.parse_optional_utc_timestamp(query.get("start"), field="start")
+    end_at = validation.parse_optional_utc_timestamp(query.get("end"), field="end")
+    if start_at is not None and end_at is not None and start_at > end_at:
+        raise ValueError("start must be less than or equal to end")
+
+    bucket = utils.str_or_none(os.environ.get(constants.AUDIT_EXPORT_BUCKET_ENV))
+    if bucket is None:
+        return http_utils.error(500, "INTERNAL_ERROR", "Audit export bucket is not configured")
+
+    app_id = utils.str_or_none(existing.get("appId"))
+    records = _collect_audit_export_records(
+        tenant_id=tenant_id,
+        caller=caller,
+        app_id=app_id,
+        start_at=start_at,
+        end_at=end_at,
+    )
+    generated_at = shared._now_utc()
+    object_key = _audit_export_key(tenant_id, generated_at)
+    payload = _build_audit_export_payload(
+        tenant_id=tenant_id,
+        generated_at=generated_at,
+        start_at=start_at,
+        end_at=end_at,
+        records=records,
+    )
+
+    try:
+        tenant_s3 = db_factory.s3_for_tenant(tenant_id=tenant_id, caller=caller, app_id=app_id)
+        tenant_s3.put_object(
+            bucket,
+            object_key,
+            payload,
+            ContentType="application/json",
+        )
+        expires_in = _audit_export_url_expiry_seconds()
+        download_url = tenant_s3.generate_presigned_url(
+            bucket,
+            object_key,
+            expires_in=expires_in,
+        )
+    except Exception:
+        return http_utils.error(500, "INTERNAL_ERROR", "Failed to generate audit export")
+
+    expires_at = generated_at + timedelta(seconds=_audit_export_url_expiry_seconds())
+    return http_utils.response(
+        200,
+        {
+            "tenantId": tenant_id,
+            "downloadUrl": download_url,
+            "expiresAt": utils.iso(expires_at),
+        },
+    )
 
 
 def handle_list_invites(
@@ -157,7 +639,33 @@ def handle_list_invites(
     *,
     tenant_id: str,
 ) -> dict[str, Any]:
-    return tenant_invites.handle_list_invites(caller, tenant_id=tenant_id)
+    if not auth.can_read_tenant(caller, tenant_id) or not auth.can_manage_tenant_self_service(
+        caller, tenant_id
+    ):
+        raise PermissionError("Access denied")
+
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    item = db.get_item(db_factory.tenants_table_name(), db_utils.tenant_key(tenant_id))
+    if item is None:
+        return http_utils.error(404, "NOT_FOUND", f"Tenant '{tenant_id}' not found")
+
+    results = db.query(
+        db_factory.tenants_table_name(),
+        sk_condition=Key("SK").begins_with("INVITE#"),
+    )
+
+    invites = [
+        {
+            "inviteId": str(invite.get("inviteId", "")),
+            "tenantId": tenant_id,
+            "email": str(invite.get("email", "")),
+            "role": str(invite.get("role", "Agent.Invoke")),
+            "status": str(invite.get("status", "")),
+            "expiresAt": invite.get("expiresAt"),
+        }
+        for invite in results.items
+    ]
+    return http_utils.response(200, {"items": invites})
 
 
 def dispatch_routes(
@@ -170,13 +678,21 @@ def dispatch_routes(
 ) -> dict[str, Any] | None:
     if path == "/v1/tenants" and method == "POST":
         return handle_create(event, caller, deps)
+    if path == "/v1/tenants" and method == "GET":
+        return handle_list_tenants(event, caller, deps)
     if tenant_id:
         if path == f"/v1/tenants/{tenant_id}" and method == "GET":
-            return handle_read(caller, tenant_id=tenant_id)
+            return handle_read(caller, deps, tenant_id=tenant_id)
         if path == f"/v1/tenants/{tenant_id}" and method == "PATCH":
+            return handle_update(event, caller, deps, tenant_id=tenant_id)
+        if path == f"/v1/tenants/{tenant_id}" and method == "PUT":
             return handle_update(event, caller, deps, tenant_id=tenant_id)
         if path == f"/v1/tenants/{tenant_id}" and method == "DELETE":
             return handle_delete(caller, deps, tenant_id=tenant_id)
+        if path == f"/v1/tenants/{tenant_id}/api-key/rotate" and method == "POST":
+            return handle_rotate_api_key(caller, deps, tenant_id=tenant_id)
+        if path == f"/v1/tenants/{tenant_id}/users/invite" and method == "POST":
+            return handle_invite_user(event, caller, deps, tenant_id=tenant_id)
         if path == f"/v1/tenants/{tenant_id}/audit-export" and method == "GET":
             return handle_audit_export(event, caller, tenant_id=tenant_id)
         if path == f"/v1/tenants/{tenant_id}/users/invites" and method == "GET":
@@ -189,5 +705,34 @@ def dispatch_routes(
             except (ImportError, ValueError):
                 from . import webhook_registry
             return webhook_registry.dispatch_routes(path, method, event, caller, deps, tenant_id)
+
+    if caller.tenant_id:
+        if path == "/v1/webhooks":
+            try:
+                from src.tenant_api import webhook_registry
+            except (ImportError, ValueError):
+                from . import webhook_registry
+            return webhook_registry.dispatch_routes(
+                f"/v1/tenants/{caller.tenant_id}/webhooks",
+                method,
+                event,
+                caller,
+                deps,
+                caller.tenant_id,
+            )
+        if path.startswith("/v1/webhooks/"):
+            webhook_id = path.removeprefix("/v1/webhooks/")
+            try:
+                from src.tenant_api import webhook_registry
+            except (ImportError, ValueError):
+                from . import webhook_registry
+            return webhook_registry.dispatch_routes(
+                f"/v1/tenants/{caller.tenant_id}/webhooks/{webhook_id}",
+                method,
+                event,
+                caller,
+                deps,
+                caller.tenant_id,
+            )
 
     return None

--- a/src/tenant_api/webhook_registry.py
+++ b/src/tenant_api/webhook_registry.py
@@ -9,6 +9,8 @@ from typing import Any
 from boto3.dynamodb.conditions import Key
 
 try:
+    import handler as shared
+
     from . import auth, db_factory, http_utils, models, utils
 except (ImportError, ValueError):  # pragma: no cover
     from src.tenant_api import (
@@ -18,6 +20,7 @@ except (ImportError, ValueError):  # pragma: no cover
         models,
         utils,
     )
+    from src.tenant_api import handler as shared
 
 
 def handle_list_webhooks(
@@ -30,7 +33,7 @@ def handle_list_webhooks(
     if not auth.can_manage_tenant_self_service(caller, tenant_id):
         raise PermissionError("Caller requires a tenant self-service admin role")
 
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
     result = db.query(
         db_factory.tenants_table_name(),
         sk_condition=Key("SK").begins_with("WEBHOOK#"),
@@ -106,7 +109,7 @@ def handle_register_webhook(
         )
 
     webhook_id = str(uuid.uuid4())
-    now = utils.now_utc()
+    now = shared._now_utc()
     webhook_secret = secrets.token_urlsafe(32)
 
     webhook = {
@@ -117,7 +120,7 @@ def handle_register_webhook(
         "callback_url": callback_url,
         "events": normalized_events,
         "status": "active",
-        "secret": webhook_secret,
+        "signature_secret": webhook_secret,
         "description": description,
         "created_at": utils.iso(now),
         "updated_at": utils.iso(now),
@@ -125,15 +128,19 @@ def handle_register_webhook(
         "signature_algorithm": "HMAC-SHA256",
     }
 
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
     db.put_item(db_factory.tenants_table_name(), webhook)
 
     return http_utils.response(
         201,
         {
             "webhookId": webhook_id,
-            "secret": webhook_secret,
+            "callbackUrl": callback_url,
+            "events": normalized_events,
             "status": "active",
+            "createdAt": utils.iso(now),
+            "signatureHeader": "X-Platform-Signature",
+            "signatureAlgorithm": "HMAC-SHA256",
         },
     )
 
@@ -149,7 +156,7 @@ def handle_delete_webhook(
     if not auth.can_manage_tenant_self_service(caller, tenant_id):
         raise PermissionError("Caller requires a tenant self-service admin role")
 
-    db = db_factory.db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
+    db = shared._db_for_tenant(tenant_id=tenant_id, caller=caller, app_id=None)
     key = {"PK": f"TENANT#{tenant_id}", "SK": f"WEBHOOK#{webhook_id}"}
 
     # Verify existence and ownership
@@ -169,8 +176,11 @@ def dispatch_routes(
     deps: models.TenantApiDependencies,
     tenant_id: str | None = None,
 ) -> dict[str, Any] | None:
+    if tenant_id is None:
+        tenant_id = caller.tenant_id
+
     # /v1/tenants/{tenant_id}/webhooks
-    if tenant_id and path == f"/v1/tenants/{tenant_id}/webhooks":
+    if tenant_id and path in {f"/v1/tenants/{tenant_id}/webhooks", "/v1/webhooks"}:
         if method == "GET":
             return handle_list_webhooks(caller, deps, tenant_id=tenant_id)
         if method == "POST":
@@ -179,6 +189,8 @@ def dispatch_routes(
     # /v1/tenants/{tenant_id}/webhooks/{webhook_id}
     if tenant_id:
         match = re.match(rf"^/v1/tenants/{tenant_id}/webhooks/([^/]+)$", path)
+        if match is None:
+            match = re.match(r"^/v1/webhooks/([^/]+)$", path)
         if match and method == "DELETE":
             return handle_delete_webhook(
                 caller, deps, tenant_id=tenant_id, webhook_id=match.group(1)


### PR DESCRIPTION
Closes #471

## Summary
- restore tenant CRUD, provisioning, self-service, platform ops, and agent-release route behavior to the current test-backed contract
- restore tenant response envelopes, soft-delete semantics, provisioning event handling, and webhook shorthand paths
- restore tenant API handler/module compatibility seams used by both the handler suite and module suite
- keep the current modular tenant-api shape while repairing the contract instead of shipping a partial pre-release surface

## Validation
- `PYTHONPATH=. uv run pytest tests/unit/test_tenant_api_handler.py tests/unit/test_tenant_api_modules.py`
- `make preflight-session`
- `make pre-validate-session`
- `npx gitnexus analyze`
