### PR TITLE
#475 Parallelize fast local validation and define fast/full split

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,42 @@
     }
   ],
   "results": {
+    "docs/DOCS_SYNC.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/DOCS_SYNC.json",
+        "hashed_secret": "5daa5a205140a516e8866c2f5ed2b112fd12f1d4",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "infra/cdk/test/observability-stack.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "infra/cdk/test/observability-stack.test.ts",
+        "hashed_secret": "bf0f467ff755606468a0eb7cdec06cc9e9a9107c",
+        "is_verified": false,
+        "line_number": 164
+      }
+    ],
+    "tests/unit/test_bff_handler.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_bff_handler.py",
+        "hashed_secret": "c90c79a7365da1f535d56a7cc120d3e10565670b",
+        "is_verified": false,
+        "line_number": 164
+      }
+    ],
+    "tests/unit/test_dev_bootstrap.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/unit/test_dev_bootstrap.py",
+        "hashed_secret": "6b199114903ef946cc5c87ffd34ff41f36029716",
+        "is_verified": false,
+        "line_number": 318
+      }
+    ],
     "tests/unit/test_models.py": [
       {
         "type": "Secret Keyword",
@@ -144,5 +180,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-22T04:05:46Z"
+  "generated_at": "2026-04-05T02:38:57Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Before writing any code:
 6. Start from a known fresh issue worktree based on current `main`/`origin/main`; do not begin implementation in a stale resumed worktree without first refreshing or recreating it
 7. If not already in that fresh issue worktree, start via `make worktree` / `make worktree-next-issue` unless the operator explicitly instructs in-place work
 8. If you are in local WSL with the repo checked out, run `make validate-local` — confirm it passes
-   (use `make validate-local-full` when a full-repo secret scan is required)
+   (`validate-local` is the fast default path; use `make validate-local-full` when a full-repo secret scan is required)
 9. State which issue/task you are working on explicitly
 10. Do not use `make task-*` unless the operator explicitly asks for the legacy snapshot workflow.
 11. If branch validation exposes unrelated breakage outside the active issue scope, do not bundle it into the same branch; queue/fix it separately or restart from a mainline that already contains that fix.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # =============================================================================
 
 .PHONY: help help-all bootstrap ensure-tools validate-local validate-local-full
-.PHONY: validate-local-prereqs validate-python validate-openapi validate-guardrails validate-cdk validate-cdk-ts validate-cdk-ts-push validate-cdk-synth
+.PHONY: validate-local-prereqs validate-python validate-openapi validate-guardrails validate-cdk validate-cdk-ts validate-cdk-ts-prereqs validate-cdk-ts-local validate-cdk-ts-push validate-cdk-synth validate-cdk-synth-prereqs
 .PHONY: validate-pre-push validate-secrets-diff validate-secrets-push validate-secrets-full
 .PHONY: docs-sync-audit docs-sync-stamp rules-sync-audit
 .PHONY: dev dev-stop dev-logs dev-invoke
@@ -171,21 +171,11 @@ ensure-tools:
 ## validate-local: Run local validation checks before commit (fast path)
 ## Uses diff-only secret detection for speed. Run `make validate-local-full` for full repo secret scan.
 validate-local: validate-local-prereqs
-	@echo "==> Running local validation (fast)"
-	@$(MAKE) --no-print-directory rules-sync-audit
-	@$(MAKE) --no-print-directory validate-python
-	@$(MAKE) --no-print-directory validate-cdk
-	@$(MAKE) --no-print-directory validate-secrets-diff
-	@echo "==> Validation passed"
+	uv run python scripts/validate_local.py fast
 
 ## validate-local-full: Full local validation including full-repo secret scan
 validate-local-full: validate-local-prereqs
-	@echo "==> Running local validation (full)"
-	@$(MAKE) --no-print-directory rules-sync-audit
-	@$(MAKE) --no-print-directory validate-python
-	@$(MAKE) --no-print-directory validate-cdk
-	@$(MAKE) --no-print-directory validate-secrets-full
-	@echo "==> Validation passed"
+	uv run python scripts/validate_local.py full
 
 ## docs-sync-audit: Check docs/code semver sync and drift heuristics
 ## Usage: make docs-sync-audit [JSON=1]
@@ -244,9 +234,28 @@ validate-cdk:
 	@$(MAKE) --no-print-directory validate-cdk-synth
 	@$(MAKE) --no-print-directory validate-cfn-guard
 
+## validate-cdk-ts-prereqs: Ensure local TypeScript compiler is available
+validate-cdk-ts-prereqs:
+	@cd infra/cdk && npx --no-install tsc --version >/dev/null 2>&1 || \
+		(echo "ERROR: typescript not installed in infra/cdk. Run: make ensure-tools" && exit 1)
+
 ## validate-cdk-ts: TypeScript compile only (no synth)
-validate-cdk-ts:
+validate-cdk-ts: validate-cdk-ts-prereqs
 	cd infra/cdk && npx --no-install tsc --noEmit
+
+## validate-cdk-ts-local: Run CDK TypeScript compile only when local working tree has CDK/TS changes
+validate-cdk-ts-local:
+	@files="$$( \
+		(git diff --name-only --diff-filter=ACMR; \
+		 git diff --name-only --cached --diff-filter=ACMR; \
+		 git ls-files --others --exclude-standard) | sort -u \
+	)"; \
+	if ! printf '%s\n' "$$files" | grep -Eq '^(infra/cdk/|pyrightconfig\.json$$|tsconfig\.json$$|package\.json$$|package-lock\.json$$|pnpm-lock\.yaml$$|yarn\.lock$$)'; then \
+		echo "==> validate-cdk-ts-local: skipped (no local CDK/TS changes)"; \
+		exit 0; \
+	fi; \
+	echo "==> validate-cdk-ts-local: running (local CDK/TS changes detected)"; \
+	$(MAKE) --no-print-directory validate-cdk-ts
 
 ## validate-cdk-ts-push: Run CDK TypeScript compile only when CDK paths changed in commits-to-push
 validate-cdk-ts-push:
@@ -270,7 +279,12 @@ validate-cdk-ts-push:
 	$(MAKE) --no-print-directory validate-cdk-ts
 
 ## validate-cdk-synth: CDK synth only
-validate-cdk-synth:
+validate-cdk-synth-prereqs:
+	@cd infra/cdk && npx --no-install cdk --version >/dev/null 2>&1 || \
+		(echo "ERROR: aws-cdk not installed in infra/cdk. Run: make ensure-tools" && exit 1)
+
+## validate-cdk-synth: CDK synth only
+validate-cdk-synth: validate-cdk-synth-prereqs
 	cd infra/cdk && npx --no-install cdk synth --context env=dev --context entraTenantId=00000000-0000-0000-0000-000000000000 --quiet > /dev/null
 
 ## validate-cfn-guard: Run cfn-guard against synthesised templates

--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ make bootstrap                # One-time: check prerequisites and install depend
 make install-git-hooks        # One-time: install pre-push hook
 make dev                      # Start LocalStack and mock services
 make test-unit                # Run all unit tests
-make validate-local           # ruff + pyright + tsc + cdk synth + detect-secrets
+make validate-local           # fast local validation (parallel rules/python/diff-aware cdk-ts/diff-secrets)
+make validate-local-full      # full local validation (parallel fast checks + full cdk validation + full repo secret scan)
 ```
 
 ### Working on issues

--- a/scripts/validate_local.py
+++ b/scripts/validate_local.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ValidationTask:
+    label: str
+    target: str
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    label: str
+    target: str
+    returncode: int
+    duration_seconds: float
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+FAST_TASKS = (
+    ValidationTask("Rules sync", "rules-sync-audit"),
+    ValidationTask("Python", "validate-python"),
+    ValidationTask("CDK TypeScript", "validate-cdk-ts-local"),
+    ValidationTask("Secrets diff", "validate-secrets-diff"),
+)
+
+FULL_TASKS = (
+    ValidationTask("Rules sync", "rules-sync-audit"),
+    ValidationTask("Python", "validate-python"),
+    ValidationTask("CDK", "validate-cdk"),
+    ValidationTask("Secrets full", "validate-secrets-full"),
+)
+
+
+def build_task_set(mode: str) -> tuple[ValidationTask, ...]:
+    if mode == "fast":
+        return FAST_TASKS
+    if mode == "full":
+        return FULL_TASKS
+    raise ValueError(f"Unsupported validation mode: {mode}")
+
+
+def run_task(
+    task: ValidationTask,
+    *,
+    repo_root: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> ValidationResult:
+    started = time.perf_counter()
+    completed = runner(
+        ["make", "--no-print-directory", task.target],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    duration = time.perf_counter() - started
+    return ValidationResult(
+        label=task.label,
+        target=task.target,
+        returncode=completed.returncode,
+        duration_seconds=duration,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def print_summary(results: list[ValidationResult]) -> None:
+    print("==> Validation summary")
+    for result in results:
+        status = "PASS" if result.ok else "FAIL"
+        print(f"[{status}] {result.label} ({result.target}) {result.duration_seconds:.1f}s")
+
+
+def print_failures(results: list[ValidationResult]) -> None:
+    failures = [result for result in results if not result.ok]
+    if not failures:
+        return
+    print()
+    print("==> Failure details")
+    for result in failures:
+        print(f"--- {result.label} ({result.target}) ---")
+        output = result.stdout.strip()
+        error = result.stderr.strip()
+        if output:
+            print(output)
+        if error:
+            print(error)
+
+
+def run_validation_mode(
+    *,
+    mode: str,
+    repo_root: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> int:
+    tasks = build_task_set(mode)
+    print(f"==> Running local validation ({mode})")
+    print("==> Launching parallel tasks")
+    for task in tasks:
+        print(f" - {task.label}: make {task.target}")
+
+    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+        futures = [
+            executor.submit(run_task, task, repo_root=repo_root, runner=runner) for task in tasks
+        ]
+        results = [future.result() for future in futures]
+
+    task_order = [task.target for task in tasks]
+    ordered = sorted(results, key=lambda result: task_order.index(result.target))
+    print()
+    print_summary(ordered)
+    print_failures(ordered)
+
+    if any(not result.ok for result in ordered):
+        return 1
+
+    print()
+    print("==> Validation passed")
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run fast or full local validation")
+    parser.add_argument("mode", choices=("fast", "full"))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    return run_validation_mode(mode=args.mode, repo_root=repo_root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_validate_local.py
+++ b/tests/unit/test_validate_local.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_validate_local_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "validate_local", repo_root / "scripts" / "validate_local.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validate_local = _load_validate_local_module()
+
+
+class _Completed:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_build_task_set_fast_and_full() -> None:
+    fast = validate_local.build_task_set("fast")
+    full = validate_local.build_task_set("full")
+
+    assert [task.target for task in fast] == [
+        "rules-sync-audit",
+        "validate-python",
+        "validate-cdk-ts-local",
+        "validate-secrets-diff",
+    ]
+    assert [task.target for task in full] == [
+        "rules-sync-audit",
+        "validate-python",
+        "validate-cdk",
+        "validate-secrets-full",
+    ]
+
+
+def test_run_validation_mode_fails_when_one_subtask_fails(tmp_path: Path, capsys) -> None:
+    seen: list[str] = []
+
+    def _runner(cmd, *, cwd, text, capture_output, check):
+        _ = cwd, text, capture_output, check
+        target = cmd[-1]
+        seen.append(target)
+        if target == "validate-cdk-ts-local":
+            return _Completed(2, stdout="cdk failed")
+        return _Completed(0, stdout=f"{target} ok")
+
+    exit_code = validate_local.run_validation_mode(mode="fast", repo_root=tmp_path, runner=_runner)
+
+    assert exit_code == 1
+    assert seen == [
+        "rules-sync-audit",
+        "validate-python",
+        "validate-cdk-ts-local",
+        "validate-secrets-diff",
+    ]
+    output = capsys.readouterr().out
+    assert "[FAIL] CDK TypeScript (validate-cdk-ts-local)" in output
+    assert "cdk failed" in output
+
+
+def test_run_validation_mode_prints_summary_for_success(tmp_path: Path, capsys) -> None:
+    def _runner(cmd, *, cwd, text, capture_output, check):
+        _ = cwd, text, capture_output, check
+        return _Completed(0, stdout=f"{cmd[-1]} ok")
+
+    exit_code = validate_local.run_validation_mode(mode="full", repo_root=tmp_path, runner=_runner)
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "==> Validation summary" in output
+    assert "[PASS] Rules sync (rules-sync-audit)" in output
+    assert "[PASS] Secrets full (validate-secrets-full)" in output


### PR DESCRIPTION
## Summary
- introduce a script-backed `validate-local` orchestration path with parallel task summaries
- keep `validate-local` fast by making CDK TypeScript validation diff-aware while preserving a heavier `validate-local-full`
- harden the full path with explicit CDK tool prerequisite errors and refresh the secret baseline for current known false positives

## Validation
- `uv run pytest tests/unit/test_validate_local.py`
- `make validate-local`
- `make validate-local-full`
- `make preflight-session`
- `make pre-validate-session`

Closes #475