### PR TITLE
#476 Replace worktree_issues exec shim with canonical package entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ make validate-local-full      # full local validation (parallel fast checks + fu
 
 All work is tracked through [GitHub Issues](https://github.com/j3brns/tf-acore-aas/issues), using `Seq:` for ordering and `Depends on:` for dependency gating.
 
+Canonical issue-tool CLI entrypoint: `uv run python -m scripts.issue_tool ...`
+The legacy `scripts/worktree_issues.py` file remains only as a compatibility shim.
+
 ```bash
 make issue-queue              # Dependency-aware queue ordered by Seq
 make worktree-next-issue      # Create worktree for next runnable issue

--- a/scripts/issue_tool/cli.py
+++ b/scripts/issue_tool/cli.py
@@ -1464,6 +1464,18 @@ def choose_default_launch_agent(pool: tuple[str, ...] = DEFAULT_INTERACTIVE_AGEN
     return random.choice(pool)
 
 
+def resolve_cli_launch_request(
+    args: argparse.Namespace, *, default_agent: str = "gemini"
+) -> tuple[str, str, str, str]:
+    agent, agent_mode, handoff, mux = resolve_launch_request(args)
+    requested_agent = getattr(args, "agent", None)
+    if requested_agent == "random":
+        agent = choose_default_launch_agent()
+    elif requested_agent is None:
+        agent = default_agent
+    return agent, agent_mode, handoff, mux
+
+
 def build_agent_prompt_for_worktree(path: Path, root: Path, repo: str | None) -> str:
     branch = run(["git", "branch", "--show-current"], cwd=path).stdout.strip() or "(detached)"
     issue_id = worktree_issue_id(path)
@@ -2877,7 +2889,7 @@ def cmd_worktree_next(args: argparse.Namespace) -> int:
                 open_shell(existing_wt.path)
                 return 0
             if wants_agent_launch(args) and not args.dry_run:
-                agent, agent_mode, handoff, mux = resolve_launch_request(args)
+                agent, agent_mode, handoff, mux = resolve_cli_launch_request(args)
                 record_issue_handoff_event(
                     root=root,
                     repo=repo,
@@ -2954,7 +2966,7 @@ def cmd_worktree_next(args: argparse.Namespace) -> int:
         open_shell(wt_path)
         return 0
     if wants_agent_launch(args) and not args.dry_run:
-        agent, agent_mode, handoff, mux = resolve_launch_request(args)
+        agent, agent_mode, handoff, mux = resolve_cli_launch_request(args)
         record_issue_handoff_event(
             root=root,
             repo=repo,
@@ -3027,7 +3039,7 @@ def cmd_worktree_create(args: argparse.Namespace) -> int:
             open_shell(existing_wt.path)
             return 0
         if wants_agent_launch(args) and not args.dry_run:
-            agent, agent_mode, handoff, mux = resolve_launch_request(args)
+            agent, agent_mode, handoff, mux = resolve_cli_launch_request(args)
             record_issue_handoff_event(
                 root=root,
                 repo=repo,
@@ -3109,7 +3121,7 @@ def cmd_worktree_create(args: argparse.Namespace) -> int:
             f"wt/{args.scope or infer_scope(issue)}/"
             f"{issue.number}-{args.slug or slugify_text(issue.title)}"
         )
-        agent, agent_mode, handoff, mux = resolve_launch_request(args)
+        agent, agent_mode, handoff, mux = resolve_cli_launch_request(args)
         record_issue_handoff_event(
             root=root,
             repo=repo,
@@ -3198,7 +3210,7 @@ def cmd_worktree_resume(args: argparse.Namespace) -> int:
         )
         open_shell(target.path)
     elif wants_agent_launch(args):
-        agent, agent_mode, handoff, mux = resolve_launch_request(args)
+        agent, agent_mode, handoff, mux = resolve_cli_launch_request(args)
         print_only = bool(getattr(args, "print_only", False))
         record_issue_handoff_event(
             root=root,
@@ -3272,7 +3284,7 @@ def cmd_agent_handoff(args: argparse.Namespace) -> int:
     target_path = Path(args.path).resolve() if args.path else current_path()
     branch = current_branch(target_path)
     issue_id = extract_issue_id_from_branch(branch)
-    agent, agent_mode, handoff, mux = resolve_launch_request(args)
+    agent, agent_mode, handoff, mux = resolve_cli_launch_request(args, default_agent="codex")
     record_issue_handoff_event(
         root=root,
         repo=repo,

--- a/scripts/worktree_issues.py
+++ b/scripts/worktree_issues.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
+"""Legacy compatibility shim for the issue-tool CLI.
+
+Canonical invocation is `python -m scripts.issue_tool ...`.
+This module remains only so older local entry paths keep delegating without
+using an exec-based loader.
+"""
+
+from __future__ import annotations
+
 import sys
-from pathlib import Path
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
-
-_CLI_PATH = _REPO_ROOT / "scripts" / "issue_tool" / "cli.py"
-exec(compile(_CLI_PATH.read_text(encoding="utf-8"), str(_CLI_PATH), "exec"), globals(), globals())
-
+from scripts.issue_tool import main
+from scripts.issue_tool.shared import CliError
 
 if __name__ == "__main__":
-    raise SystemExit(globals()["main"]())
+    try:
+        raise SystemExit(main())
+    except CliError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    except KeyboardInterrupt:
+        raise SystemExit(130)

--- a/scripts/worktree_issues.py
+++ b/scripts/worktree_issues.py
@@ -9,11 +9,16 @@ using an exec-based loader.
 from __future__ import annotations
 
 import sys
-
-from scripts.issue_tool import main
-from scripts.issue_tool.shared import CliError
+from pathlib import Path
 
 if __name__ == "__main__":
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from scripts.issue_tool import main
+    from scripts.issue_tool.shared import CliError
+
     try:
         raise SystemExit(main())
     except CliError as exc:

--- a/tests/unit/test_worktree_issues.py
+++ b/tests/unit/test_worktree_issues.py
@@ -12,20 +12,22 @@ from pathlib import Path
 
 import pytest
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
-def _load_worktree_module():
-    repo_root = Path(__file__).resolve().parents[2]
+worktree_issues = importlib.import_module("scripts.issue_tool.cli")
+
+
+def _load_legacy_shim():
     spec = importlib.util.spec_from_file_location(
-        "worktree_issues", repo_root / "scripts" / "worktree_issues.py"
+        "legacy_worktree_issues", REPO_ROOT / "scripts" / "worktree_issues.py"
     )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
-
-
-worktree_issues = _load_worktree_module()
 
 
 def _issue(
@@ -49,6 +51,26 @@ def _issue(
         seq=seq,
         depends_on=depends_on or [],
     )
+
+
+def test_canonical_issue_tool_entrypoint_help_smoke():
+    proc = subprocess.run(
+        [sys.executable, "-m", "scripts.issue_tool", "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "Issue-driven worktree workflow" in proc.stdout
+
+
+def test_legacy_worktree_shim_delegates_without_exec():
+    shim = _load_legacy_shim()
+
+    assert "exec(" not in Path(shim.__file__).read_text(encoding="utf-8")
+    assert shim.main is worktree_issues.main
 
 
 def test_build_queue_auto_excludes_in_progress_from_candidates():

--- a/tests/unit/test_worktree_issues.py
+++ b/tests/unit/test_worktree_issues.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
+import importlib
 import json
 import os
 import signal
@@ -17,17 +17,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 worktree_issues = importlib.import_module("scripts.issue_tool.cli")
-
-
-def _load_legacy_shim():
-    spec = importlib.util.spec_from_file_location(
-        "legacy_worktree_issues", REPO_ROOT / "scripts" / "worktree_issues.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
 
 
 def _issue(
@@ -67,10 +56,18 @@ def test_canonical_issue_tool_entrypoint_help_smoke():
 
 
 def test_legacy_worktree_shim_delegates_without_exec():
-    shim = _load_legacy_shim()
+    shim_path = REPO_ROOT / "scripts" / "worktree_issues.py"
+    proc = subprocess.run(
+        [sys.executable, str(shim_path), "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
-    assert "exec(" not in Path(shim.__file__).read_text(encoding="utf-8")
-    assert shim.main is worktree_issues.main
+    assert "exec(" not in shim_path.read_text(encoding="utf-8")
+    assert proc.returncode == 0
+    assert "Issue-driven worktree workflow" in proc.stdout
 
 
 def test_build_queue_auto_excludes_in_progress_from_candidates():


### PR DESCRIPTION
## Summary
- replace the `scripts/worktree_issues.py` exec loader with a thin compatibility shim around the package CLI
- make `python -m scripts.issue_tool ...` the explicit canonical entrypoint and document it in the issue-workflow section
- point the worktree-issues unit suite at the real package module and cover the legacy shim with subprocess smoke tests

## Validation
- `uv run pytest tests/unit/test_worktree_issues.py -q`
- `uv run ruff check scripts/worktree_issues.py scripts/issue_tool/cli.py tests/unit/test_worktree_issues.py README.md`
- `make validate-local`
- `make preflight-session`
- `make pre-validate-session`

## Senior Review
- No material findings on the final diff
- Residual risk: the legacy shim is covered as a subprocess smoke path, not a full interactive TTY menu session

Closes #476