### PR TITLE
#477 Standardize shared tenant_api platform-state fixtures

### DIFF
--- a/tests/unit/tenant_api_test_support.py
+++ b/tests/unit/tenant_api_test_support.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from data_access.models import PaginatedItems
+
+from src.tenant_api import db_utils as tenant_api_db_utils
+from src.tenant_api import handler as tenant_api_handler
+
+
+class FakeScopedDb:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def get_item(self, _table_name: str, key: dict[str, Any]) -> dict[str, Any] | None:
+        item = self.items.get((str(key["PK"]), str(key["SK"])))
+        if item is None:
+            return None
+        return dict(item)
+
+    def put_item(
+        self,
+        _table_name: str,
+        item: dict[str, Any],
+        *,
+        condition_expression: str | None = None,
+    ) -> dict[str, Any]:
+        pk = str(item["PK"])
+        sk = str(item["SK"])
+        if (
+            condition_expression
+            and "attribute_not_exists" in condition_expression
+            and (pk, sk) in self.items
+        ):
+            raise tenant_api_handler.ClientError(
+                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "exists"}},
+                "PutItem",
+            )
+        self.items[(pk, sk)] = dict(item)
+        return {"Attributes": dict(item)}
+
+    def delete_item(self, _table_name: str, key: dict[str, Any]) -> dict[str, Any]:
+        pk = str(key["PK"])
+        sk = str(key["SK"])
+        self.items.pop((pk, sk), None)
+        return {}
+
+    def update_item(
+        self,
+        _table_name: str,
+        key: dict[str, Any],
+        update_expression: str,
+        expression_attribute_values: dict[str, Any],
+        *,
+        expression_attribute_names: dict[str, str] | None = None,
+        condition_expression: str | None = None,
+    ) -> dict[str, Any]:
+        pk = str(key["PK"])
+        sk = str(key["SK"])
+        storage_key = (pk, sk)
+        existing = self.items.get(storage_key)
+
+        if (
+            condition_expression
+            and "attribute_not_exists" in condition_expression
+            and existing is not None
+        ):
+            raise tenant_api_handler.ClientError(
+                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "exists"}},
+                "UpdateItem",
+            )
+        if condition_expression and "attribute_exists" in condition_expression and existing is None:
+            raise tenant_api_handler.ClientError(
+                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "missing"}},
+                "UpdateItem",
+            )
+
+        names = expression_attribute_names or {}
+        item = dict(existing or {"PK": pk, "SK": sk})
+        assert update_expression.startswith("SET ")
+        for part in update_expression.removeprefix("SET ").split(", "):
+            name_ref, value_ref = [token.strip() for token in part.split("=", 1)]
+            attr_name = names.get(name_ref, name_ref.lstrip("#"))
+            item[attr_name] = expression_attribute_values[value_ref]
+        self.items[storage_key] = item
+        return {"Attributes": dict(item)}
+
+    def scan_all(self, _table_name: str, **kwargs: Any) -> list[dict[str, Any]]:
+        return list(self.items.values())
+
+    def scan(
+        self,
+        _table_name: str | None = None,
+        *,
+        filter_expression: Any | None = None,
+        limit: int | None = None,
+        exclusive_start_key: dict[str, Any] | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+    ) -> PaginatedItems:
+        results = [dict(item) for item in self.items.values()]
+        status_filter = (expression_attribute_values or {}).get(":s")
+        tier_filter = (expression_attribute_values or {}).get(":t")
+        if status_filter:
+            results = [r for r in results if r.get("status") == status_filter]
+        if tier_filter:
+            results = [r for r in results if r.get("tier") == tier_filter]
+
+        last_key = None
+        if limit and len(results) > limit:
+            last_key = {"PK": results[limit - 1]["PK"], "SK": results[limit - 1]["SK"]}
+            results = results[:limit]
+
+        return PaginatedItems(items=results, last_evaluated_key=last_key)
+
+    def query(
+        self,
+        _table_name: str | None = None,
+        *,
+        sk_condition: Any | None = None,
+        filter_expression: Any | None = None,
+        index_name: str | None = None,
+        limit: int | None = None,
+        scan_index_forward: bool = True,
+        exclusive_start_key: dict[str, Any] | None = None,
+    ) -> PaginatedItems:
+        results = [dict(item) for item in self.items.values()]
+        if sk_condition:
+            cls_name = type(sk_condition).__name__
+            if cls_name == "BeginsWith" and hasattr(sk_condition, "_values"):
+                prefix = sk_condition._values[1]
+                results = [r for r in results if str(r.get("SK", "")).startswith(prefix)]
+            elif cls_name == "Between" and hasattr(sk_condition, "_values"):
+                v_min = sk_condition._values[1]
+                v_max = sk_condition._values[2]
+                results = [r for r in results if v_min <= str(r.get("SK", "")) <= v_max]
+            else:
+                cond_str = str(sk_condition)
+                if "INVITE#" in cond_str:
+                    results = [r for r in results if str(r.get("SK", "")).startswith("INVITE#")]
+                elif "WEBHOOK#" in cond_str:
+                    results = [r for r in results if str(r.get("SK", "")).startswith("WEBHOOK#")]
+
+        return PaginatedItems(items=results)
+
+
+class FakeSecretsManager:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.rotate_calls: list[dict[str, Any]] = []
+        self.policy_calls: list[dict[str, Any]] = []
+
+    def create_secret(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"ARN": f"arn:aws:secretsmanager:eu-west-2:111111111111:secret:{kwargs['Name']}"}
+
+    def put_secret_value(self, **kwargs: Any) -> dict[str, Any]:
+        self.rotate_calls.append(kwargs)
+        return {"ARN": str(kwargs.get("SecretId", "")), "VersionId": "ver-rotated-001"}
+
+    def put_resource_policy(self, **kwargs: Any) -> dict[str, Any]:
+        self.policy_calls.append(kwargs)
+        return {
+            "ARN": str(kwargs.get("SecretId", "")),
+            "Name": str(kwargs.get("SecretId", "")).split(":secret:", 1)[-1],
+        }
+
+
+class FakeEvents:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def put_events(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"FailedEntryCount": 0, "Entries": [{"EventId": "evt-1"}]}
+
+
+class FakeUsageClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def get_tenant_usage(self, *, tenant_id: str, app_id: str | None) -> dict[str, Any]:
+        self.calls.append({"tenant_id": tenant_id, "app_id": app_id})
+        return {"requestsToday": 12, "budgetRemainingUsd": 34.5}
+
+
+class FakeMemoryProvisioner:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def provision(self, *, tenant_id: str, app_id: str) -> dict[str, Any]:
+        self.calls.append({"tenant_id": tenant_id, "app_id": app_id})
+        return {"memoryStoreArn": f"arn:aws:memory:eu-west-2::store/{tenant_id}"}
+
+
+class FakePlatformQuotaClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.response = [
+            {
+                "region": "eu-west-1",
+                "quotaName": "ConcurrentSessions",
+                "currentValue": 11.0,
+                "limit": 500.0,
+                "utilisationPercentage": 2.2,
+            },
+            {
+                "region": "eu-central-1",
+                "quotaName": "ConcurrentSessions",
+                "currentValue": 3.0,
+                "limit": 500.0,
+                "utilisationPercentage": 0.6,
+            },
+        ]
+
+    def get_utilisation(
+        self,
+        *,
+        active_region: str,
+        fallback_region: str | None,
+    ) -> list[dict[str, Any]]:
+        self.calls.append(
+            {
+                "active_region": active_region,
+                "fallback_region": fallback_region,
+            }
+        )
+        return [dict(item) for item in self.response]
+
+
+class FakeLambdaClient:
+    def __init__(self) -> None:
+        self.aliases = {"platform-bridge-dev": {"live": "10"}}
+        self.versions = {
+            "platform-bridge-dev": [
+                {"Version": "1"},
+                {"Version": "2"},
+                {"Version": "10"},
+                {"Version": "$LATEST"},
+            ]
+        }
+        self.update_calls: list[dict[str, Any]] = []
+
+    def get_alias(self, FunctionName: str, Name: str) -> dict[str, Any]:
+        if FunctionName in self.aliases and Name in self.aliases[FunctionName]:
+            return {"FunctionVersion": self.aliases[FunctionName][Name]}
+        raise tenant_api_handler.ClientError(
+            {"Error": {"Code": "ResourceNotFoundException"}}, "GetAlias"
+        )
+
+    def get_paginator(self, operation_name: str) -> Any:
+        assert operation_name == "list_versions_by_function"
+        return self
+
+    def paginate(self, FunctionName: str) -> Any:
+        if FunctionName in self.versions:
+            yield {"Versions": self.versions[FunctionName]}
+        else:
+            raise tenant_api_handler.ClientError(
+                {"Error": {"Code": "ResourceNotFoundException"}}, "ListVersions"
+            )
+
+    def update_alias(self, **kwargs: Any) -> dict[str, Any]:
+        self.update_calls.append(kwargs)
+        return {}
+
+
+class FakeLambdaContext:
+    function_name = "tenant-api"
+    memory_limit_in_mb = 256
+    invoked_function_arn = "arn:aws:lambda:eu-west-2:111111111111:function:tenant-api"
+    aws_request_id = "req-123"
+
+
+class FakeSsm:
+    def __init__(self) -> None:
+        self.parameters = {
+            "/platform/config/runtime-region": "eu-west-1",
+            "/platform/config/fallback-region": "eu-central-1",
+        }
+        self.get_calls: list[dict[str, Any]] = []
+        self.put_calls: list[dict[str, Any]] = []
+        self.put_error: Exception | None = None
+
+    def get_parameter(self, *, Name: str) -> dict[str, Any]:  # noqa: N803 - boto3 compatibility
+        self.get_calls.append({"Name": Name})
+        return {"Parameter": {"Name": Name, "Value": self.parameters[Name]}}
+
+    def put_parameter(self, **kwargs: Any) -> dict[str, Any]:
+        self.put_calls.append(dict(kwargs))
+        if self.put_error is not None:
+            raise self.put_error
+        self.parameters[str(kwargs["Name"])] = str(kwargs["Value"])
+        return {"Version": 1}
+
+
+def fixed_now_value() -> datetime:
+    return datetime(2026, 2, 25, 12, 0, 0, tzinfo=UTC)
+
+
+def apply_common_tenant_api_env(monkeypatch: Any, *, include_agents_table: bool = False) -> None:
+    monkeypatch.setenv("AWS_REGION", "eu-west-2")
+    monkeypatch.setenv("TENANTS_TABLE_NAME", "platform-tenants")
+    if include_agents_table:
+        monkeypatch.setenv("AGENTS_TABLE_NAME", "platform-agents")
+    monkeypatch.setenv("INVOCATIONS_TABLE_NAME", "platform-invocations")
+    monkeypatch.setenv("EVENT_BUS_NAME", "platform-bus")
+    monkeypatch.setenv("AUDIT_EXPORT_BUCKET", "platform-audit-exports")
+    monkeypatch.setenv("AUDIT_EXPORT_URL_EXPIRY_SECONDS", "1800")
+    monkeypatch.setenv("TENANT_API_KEY_SECRET_PREFIX", "platform/tenants")
+    monkeypatch.setenv(
+        "TENANT_MGMT_ROLE_ARN",
+        "arn:aws:iam::111111111111:role/platform-tenant-mgmt-dev",
+    )
+    monkeypatch.setenv("OPS_LOCKS_TABLE", "platform-ops-locks")
+    monkeypatch.setenv("RUNTIME_REGION_PARAM", "/platform/config/runtime-region")
+    monkeypatch.setenv("FALLBACK_REGION_PARAM", "/platform/config/fallback-region")
+
+
+def build_tenant_api_dependencies() -> tenant_api_handler.TenantApiDependencies:
+    return tenant_api_handler.TenantApiDependencies(
+        secretsmanager=FakeSecretsManager(),
+        events=FakeEvents(),
+        ssm=FakeSsm(),
+        awslambda=FakeLambdaClient(),
+        usage_client=FakeUsageClient(),
+        memory_provisioner=FakeMemoryProvisioner(),
+        platform_quota_client=FakePlatformQuotaClient(),
+    )
+
+
+def build_handler_state(monkeypatch: Any, fixed_now: datetime) -> dict[str, Any]:
+    db = FakeScopedDb()
+    deps = build_tenant_api_dependencies()
+    apply_common_tenant_api_env(monkeypatch)
+    monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
+    monkeypatch.setattr(tenant_api_handler.db_factory, "db_for_tenant", lambda **_kwargs: db)
+    monkeypatch.setattr(
+        tenant_api_handler.db_factory, "control_plane_db", lambda *_args, **_kwargs: db
+    )
+    monkeypatch.setattr(tenant_api_db_utils, "db_for_tenant", lambda **_kwargs: db)
+    monkeypatch.setattr(tenant_api_db_utils, "control_plane_db", lambda *_args, **_kwargs: db)
+    monkeypatch.setattr(tenant_api_handler.utils, "_OVERRIDE_NOW", fixed_now)
+    return {"db": db, "deps": deps}
+
+
+def build_module_state(monkeypatch: Any, fixed_now: datetime) -> dict[str, Any]:
+    db = FakeScopedDb()
+    deps = build_tenant_api_dependencies()
+    apply_common_tenant_api_env(monkeypatch, include_agents_table=True)
+    monkeypatch.setattr(tenant_api_handler, "_db_for_tenant", lambda **_kwargs: db)
+    monkeypatch.setattr(tenant_api_handler, "_now_utc", lambda: fixed_now)
+    return {"db": db, "deps": deps}
+
+
+def response_body(response: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(response["body"])
+
+
+def invoke_handler(event: dict[str, Any]) -> dict[str, Any]:
+    return tenant_api_handler.lambda_handler(event, FakeLambdaContext())

--- a/tests/unit/test_ops_api.py
+++ b/tests/unit/test_ops_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -10,63 +10,23 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.tenant_api import db_utils as tenant_api_db_utils
-from src.tenant_api import handler as tenant_api_handler
 from src.tenant_api import ops_control
-from tests.unit.test_tenant_api_handler import (
-    FakeEvents,
-    FakeLambdaClient,
-    FakeMemoryProvisioner,
-    FakePlatformQuotaClient,
-    FakeScopedDb,
-    FakeSecretsManager,
-    FakeSsm,
-    FakeUsageClient,
-    _body,
-    _invoke,
+from tests.unit.tenant_api_test_support import (
+    build_handler_state,
+    fixed_now_value,
+    invoke_handler,
+    response_body,
 )
 
 
 @pytest.fixture
 def fixed_now() -> datetime:
-    return datetime(2026, 2, 25, 12, 0, 0, tzinfo=UTC)
+    return fixed_now_value()
 
 
 @pytest.fixture
 def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str, Any]:
-    db = FakeScopedDb()
-    deps = tenant_api_handler.TenantApiDependencies(
-        secretsmanager=FakeSecretsManager(),
-        events=FakeEvents(),
-        ssm=FakeSsm(),
-        awslambda=FakeLambdaClient(),
-        usage_client=FakeUsageClient(),
-        memory_provisioner=FakeMemoryProvisioner(),
-        platform_quota_client=FakePlatformQuotaClient(),
-    )
-    monkeypatch.setenv("AWS_REGION", "eu-west-2")
-    monkeypatch.setenv("TENANTS_TABLE_NAME", "platform-tenants")
-    monkeypatch.setenv("INVOCATIONS_TABLE_NAME", "platform-invocations")
-    monkeypatch.setenv("EVENT_BUS_NAME", "platform-bus")
-    monkeypatch.setenv("AUDIT_EXPORT_BUCKET", "platform-audit-exports")
-    monkeypatch.setenv("AUDIT_EXPORT_URL_EXPIRY_SECONDS", "1800")
-    monkeypatch.setenv("TENANT_API_KEY_SECRET_PREFIX", "platform/tenants")
-    monkeypatch.setenv(
-        "TENANT_MGMT_ROLE_ARN",
-        "arn:aws:iam::111111111111:role/platform-tenant-mgmt-dev",
-    )
-    monkeypatch.setenv("OPS_LOCKS_TABLE", "platform-ops-locks")
-    monkeypatch.setenv("RUNTIME_REGION_PARAM", "/platform/config/runtime-region")
-    monkeypatch.setenv("FALLBACK_REGION_PARAM", "/platform/config/fallback-region")
-    monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
-    monkeypatch.setattr(tenant_api_handler.db_factory, "db_for_tenant", lambda **_kwargs: db)
-    monkeypatch.setattr(
-        tenant_api_handler.db_factory, "control_plane_db", lambda *_args, **_kwargs: db
-    )
-    monkeypatch.setattr(tenant_api_db_utils, "db_for_tenant", lambda **_kwargs: db)
-    monkeypatch.setattr(tenant_api_db_utils, "control_plane_db", lambda *_args, **_kwargs: db)
-    monkeypatch.setattr(tenant_api_handler.utils, "_OVERRIDE_NOW", fixed_now)
-    return {"db": db, "deps": deps}
+    return build_handler_state(monkeypatch, fixed_now)
 
 
 def _ops_event(
@@ -106,10 +66,10 @@ def test_ops_billing_status_returns_real_summary_shape(fake_state: dict[str, Any
         "updatedAt": "2026-02-25T11:00:00Z",
     }
 
-    response = _invoke(_ops_event("GET", "/v1/platform/billing/status"))
+    response = invoke_handler(_ops_event("GET", "/v1/platform/billing/status"))
 
     assert response["statusCode"] == 200
-    assert _body(response) == {
+    assert response_body(response) == {
         "yearMonth": "2026-02",
         "summaries": [
             {
@@ -140,10 +100,10 @@ def test_de_scoped_ops_routes_do_not_expose_placeholder_success(
 ) -> None:
     del fake_state
 
-    response = _invoke(_ops_event(method, path))
+    response = invoke_handler(_ops_event(method, path))
 
     assert response["statusCode"] == 405
-    assert _body(response)["error"]["code"] == "METHOD_NOT_ALLOWED"
+    assert response_body(response)["error"]["code"] == "METHOD_NOT_ALLOWED"
 
 
 def test_platform_agent_read_only_surface_is_bounded_to_authoritative_routes() -> None:

--- a/tests/unit/test_tenant_api_handler.py
+++ b/tests/unit/test_tenant_api_handler.py
@@ -12,273 +12,14 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from data_access.models import PaginatedItems
 
-from src.tenant_api import db_utils as tenant_api_db_utils
 from src.tenant_api import handler as tenant_api_handler
-
-
-class FakeScopedDb:
-    def __init__(self) -> None:
-        self.items: dict[tuple[str, str], dict[str, Any]] = {}
-
-    def get_item(self, _table_name: str, key: dict[str, Any]) -> dict[str, Any] | None:
-        item = self.items.get((str(key["PK"]), str(key["SK"])))
-        if item is None:
-            return None
-        return dict(item)
-
-    def put_item(
-        self,
-        _table_name: str,
-        item: dict[str, Any],
-        *,
-        condition_expression: str | None = None,
-    ) -> dict[str, Any]:
-        pk = str(item["PK"])
-        sk = str(item["SK"])
-        if (
-            condition_expression
-            and "attribute_not_exists" in condition_expression
-            and (pk, sk) in self.items
-        ):
-            raise tenant_api_handler.ClientError(
-                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "exists"}},
-                "PutItem",
-            )
-        self.items[(pk, sk)] = dict(item)
-        return {"Attributes": dict(item)}
-
-    def delete_item(self, _table_name: str, key: dict[str, Any]) -> dict[str, Any]:
-        pk = str(key["PK"])
-        sk = str(key["SK"])
-        self.items.pop((pk, sk), None)
-        return {}
-
-    def update_item(
-        self,
-        _table_name: str,
-        key: dict[str, Any],
-        update_expression: str,
-        expression_attribute_values: dict[str, Any],
-        *,
-        expression_attribute_names: dict[str, str] | None = None,
-        condition_expression: str | None = None,
-    ) -> dict[str, Any]:
-        pk = str(key["PK"])
-        sk = str(key["SK"])
-        storage_key = (pk, sk)
-        existing = self.items.get(storage_key)
-
-        if (
-            condition_expression
-            and "attribute_not_exists" in condition_expression
-            and existing is not None
-        ):
-            raise tenant_api_handler.ClientError(
-                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "exists"}},
-                "UpdateItem",
-            )
-        if condition_expression and "attribute_exists" in condition_expression and existing is None:
-            raise tenant_api_handler.ClientError(
-                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "missing"}},
-                "UpdateItem",
-            )
-
-        names = expression_attribute_names or {}
-        item = dict(existing or {"PK": pk, "SK": sk})
-        assert update_expression.startswith("SET ")
-        for part in update_expression.removeprefix("SET ").split(", "):
-            name_ref, value_ref = [token.strip() for token in part.split("=", 1)]
-            attr_name = names.get(name_ref, name_ref.lstrip("#"))
-            item[attr_name] = expression_attribute_values[value_ref]
-        self.items[storage_key] = item
-        return {"Attributes": dict(item)}
-
-    def scan_all(self, _table_name: str, **kwargs: Any) -> list[dict[str, Any]]:
-        return list(self.items.values())
-
-    def scan(
-        self,
-        _table_name: str | None = None,
-        *,
-        filter_expression: Any | None = None,
-        limit: int | None = None,
-        exclusive_start_key: dict[str, Any] | None = None,
-        expression_attribute_names: dict[str, str] | None = None,
-        expression_attribute_values: dict[str, Any] | None = None,
-    ) -> PaginatedItems:
-        # Match real lib: _table_name is NOT None if we use it correctly
-        results = [dict(item) for item in self.items.values()]
-        # Simple filter implementation for tests
-        status_filter = (expression_attribute_values or {}).get(":s")
-        tier_filter = (expression_attribute_values or {}).get(":t")
-        if status_filter:
-            results = [r for r in results if r.get("status") == status_filter]
-        if tier_filter:
-            results = [r for r in results if r.get("tier") == tier_filter]
-
-        # Paginated results simulation
-        last_key = None
-        if limit and len(results) > limit:
-            # Not really accurate for DynamoDB but enough for tests
-            last_key = {"PK": results[limit - 1]["PK"], "SK": results[limit - 1]["SK"]}
-            results = results[:limit]
-
-        return PaginatedItems(items=results, last_evaluated_key=last_key)
-
-    def query(
-        self,
-        _table_name: str | None = None,
-        *,
-        sk_condition: Any | None = None,
-        filter_expression: Any | None = None,
-        index_name: str | None = None,
-        limit: int | None = None,
-        scan_index_forward: bool = True,
-        exclusive_start_key: dict[str, Any] | None = None,
-    ) -> PaginatedItems:
-        # Mock query — return items matching SK prefix if provided
-        results = [dict(item) for item in self.items.values()]
-        if sk_condition:
-            cls_name = type(sk_condition).__name__
-            if cls_name == "BeginsWith" and hasattr(sk_condition, "_values"):
-                prefix = sk_condition._values[1]
-                results = [r for r in results if str(r.get("SK", "")).startswith(prefix)]
-            elif cls_name == "Between" and hasattr(sk_condition, "_values"):
-                v_min = sk_condition._values[1]
-                v_max = sk_condition._values[2]
-                results = [r for r in results if v_min <= str(r.get("SK", "")) <= v_max]
-            else:
-                # Fallback to string matching if _values not present or unknown type
-                cond_str = str(sk_condition)
-                if "INVITE#" in cond_str:
-                    results = [r for r in results if str(r.get("SK", "")).startswith("INVITE#")]
-                elif "WEBHOOK#" in cond_str:
-                    results = [r for r in results if str(r.get("SK", "")).startswith("WEBHOOK#")]
-
-        return PaginatedItems(items=results)
-
-
-class FakeSecretsManager:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
-        self.rotate_calls: list[dict[str, Any]] = []
-        self.policy_calls: list[dict[str, Any]] = []
-
-    def create_secret(self, **kwargs: Any) -> dict[str, Any]:
-        self.calls.append(kwargs)
-        return {"ARN": f"arn:aws:secretsmanager:eu-west-2:111111111111:secret:{kwargs['Name']}"}
-
-    def put_secret_value(self, **kwargs: Any) -> dict[str, Any]:
-        self.rotate_calls.append(kwargs)
-        return {"ARN": str(kwargs.get("SecretId", "")), "VersionId": "ver-rotated-001"}
-
-    def put_resource_policy(self, **kwargs: Any) -> dict[str, Any]:
-        self.policy_calls.append(kwargs)
-        return {
-            "ARN": str(kwargs.get("SecretId", "")),
-            "Name": str(kwargs.get("SecretId", "")).split(":secret:", 1)[-1],
-        }
-
-
-class FakeEvents:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
-
-    def put_events(self, **kwargs: Any) -> dict[str, Any]:
-        self.calls.append(kwargs)
-        return {"FailedEntryCount": 0, "Entries": [{"EventId": "evt-1"}]}
-
-
-class FakeUsageClient:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
-
-    def get_tenant_usage(self, *, tenant_id: str, app_id: str | None) -> dict[str, Any]:
-        self.calls.append({"tenant_id": tenant_id, "app_id": app_id})
-        return {"requestsToday": 12, "budgetRemainingUsd": 34.5}
-
-
-class FakeMemoryProvisioner:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
-
-    def provision(self, *, tenant_id: str, app_id: str) -> dict[str, Any]:
-        self.calls.append({"tenant_id": tenant_id, "app_id": app_id})
-        return {"memoryStoreArn": f"arn:aws:memory:eu-west-2::store/{tenant_id}"}
-
-
-class FakePlatformQuotaClient:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
-        self.response = [
-            {
-                "region": "eu-west-1",
-                "quotaName": "ConcurrentSessions",
-                "currentValue": 11.0,
-                "limit": 500.0,
-                "utilisationPercentage": 2.2,
-            },
-            {
-                "region": "eu-central-1",
-                "quotaName": "ConcurrentSessions",
-                "currentValue": 3.0,
-                "limit": 500.0,
-                "utilisationPercentage": 0.6,
-            },
-        ]
-
-    def get_utilisation(
-        self,
-        *,
-        active_region: str,
-        fallback_region: str | None,
-    ) -> list[dict[str, Any]]:
-        self.calls.append(
-            {
-                "active_region": active_region,
-                "fallback_region": fallback_region,
-            }
-        )
-        return [dict(item) for item in self.response]
-
-
-class FakeLambdaClient:
-    def __init__(self) -> None:
-        self.aliases = {"platform-bridge-dev": {"live": "10"}}
-        self.versions = {
-            "platform-bridge-dev": [
-                {"Version": "1"},
-                {"Version": "2"},
-                {"Version": "10"},
-                {"Version": "$LATEST"},
-            ]
-        }
-        self.update_calls: list[dict[str, Any]] = []
-
-    def get_alias(self, FunctionName: str, Name: str) -> dict[str, Any]:
-        if FunctionName in self.aliases and Name in self.aliases[FunctionName]:
-            return {"FunctionVersion": self.aliases[FunctionName][Name]}
-        raise tenant_api_handler.ClientError(
-            {"Error": {"Code": "ResourceNotFoundException"}}, "GetAlias"
-        )
-
-    def get_paginator(self, operation_name: str) -> Any:
-        assert operation_name == "list_versions_by_function"
-        return self
-
-    def paginate(self, FunctionName: str) -> Any:
-        if FunctionName in self.versions:
-            yield {"Versions": self.versions[FunctionName]}
-        else:
-            raise tenant_api_handler.ClientError(
-                {"Error": {"Code": "ResourceNotFoundException"}}, "ListVersions"
-            )
-
-    def update_alias(self, **kwargs: Any) -> dict[str, Any]:
-        self.update_calls.append(kwargs)
-        return {}
+from tests.unit.tenant_api_test_support import (
+    build_handler_state,
+    fixed_now_value,
+    invoke_handler,
+    response_body,
+)
 
 
 class _FailingPlatformQuotaClient:
@@ -348,35 +89,6 @@ class FakeDynamoDbResource:
         return self.tables[name]
 
 
-class FakeLambdaContext:
-    function_name = "tenant-api"
-    memory_limit_in_mb = 256
-    invoked_function_arn = "arn:aws:lambda:eu-west-2:111111111111:function:tenant-api"
-    aws_request_id = "req-123"
-
-
-class FakeSsm:
-    def __init__(self) -> None:
-        self.parameters = {
-            "/platform/config/runtime-region": "eu-west-1",
-            "/platform/config/fallback-region": "eu-central-1",
-        }
-        self.get_calls: list[dict[str, Any]] = []
-        self.put_calls: list[dict[str, Any]] = []
-        self.put_error: Exception | None = None
-
-    def get_parameter(self, *, Name: str) -> dict[str, Any]:  # noqa: N803 - boto3 compatibility
-        self.get_calls.append({"Name": Name})
-        return {"Parameter": {"Name": Name, "Value": self.parameters[Name]}}
-
-    def put_parameter(self, **kwargs: Any) -> dict[str, Any]:
-        self.put_calls.append(dict(kwargs))
-        if self.put_error is not None:
-            raise self.put_error
-        self.parameters[str(kwargs["Name"])] = str(kwargs["Value"])
-        return {"Version": 1}
-
-
 class FakeCloudWatchClient:
     def __init__(self, datapoints: list[dict[str, Any]], error: Exception | None = None) -> None:
         self.datapoints = datapoints
@@ -429,47 +141,12 @@ class FakeAwsSession:
 
 @pytest.fixture
 def fixed_now() -> datetime:
-    return datetime(2026, 2, 25, 12, 0, 0, tzinfo=UTC)
+    return fixed_now_value()
 
 
 @pytest.fixture
 def fake_state(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime) -> dict[str, Any]:
-    db = FakeScopedDb()
-    deps = tenant_api_handler.TenantApiDependencies(
-        secretsmanager=FakeSecretsManager(),
-        events=FakeEvents(),
-        ssm=FakeSsm(),
-        awslambda=FakeLambdaClient(),
-        usage_client=FakeUsageClient(),
-        memory_provisioner=FakeMemoryProvisioner(),
-        platform_quota_client=FakePlatformQuotaClient(),
-    )
-    monkeypatch.setenv("AWS_REGION", "eu-west-2")
-    monkeypatch.setenv("TENANTS_TABLE_NAME", "platform-tenants")
-    monkeypatch.setenv("INVOCATIONS_TABLE_NAME", "platform-invocations")
-    monkeypatch.setenv("EVENT_BUS_NAME", "platform-bus")
-    monkeypatch.setenv("AUDIT_EXPORT_BUCKET", "platform-audit-exports")
-    monkeypatch.setenv("AUDIT_EXPORT_URL_EXPIRY_SECONDS", "1800")
-    monkeypatch.setenv("TENANT_API_KEY_SECRET_PREFIX", "platform/tenants")
-    monkeypatch.setenv(
-        "TENANT_MGMT_ROLE_ARN",
-        "arn:aws:iam::111111111111:role/platform-tenant-mgmt-dev",
-    )
-    monkeypatch.setenv("OPS_LOCKS_TABLE", "platform-ops-locks")
-    monkeypatch.setenv("RUNTIME_REGION_PARAM", "/platform/config/runtime-region")
-    monkeypatch.setenv("FALLBACK_REGION_PARAM", "/platform/config/fallback-region")
-    monkeypatch.setattr(tenant_api_handler, "_dependencies", lambda: deps)
-    monkeypatch.setattr(tenant_api_handler.db_factory, "db_for_tenant", lambda **_kwargs: db)
-    monkeypatch.setattr(
-        tenant_api_handler.db_factory, "control_plane_db", lambda *_args, **_kwargs: db
-    )
-    monkeypatch.setattr(tenant_api_db_utils, "db_for_tenant", lambda **_kwargs: db)
-    monkeypatch.setattr(tenant_api_db_utils, "control_plane_db", lambda *_args, **_kwargs: db)
-
-    # Consistently mock time across all modular boundaries
-    monkeypatch.setattr(tenant_api_handler.utils, "_OVERRIDE_NOW", fixed_now)
-
-    return {"db": db, "deps": deps}
+    return build_handler_state(monkeypatch, fixed_now)
 
 
 def _event(
@@ -508,12 +185,8 @@ def _event(
     }
 
 
-def _body(response: dict[str, Any]) -> dict[str, Any]:
-    return json.loads(response["body"])
-
-
-def _invoke(event: dict[str, Any]) -> dict[str, Any]:
-    return tenant_api_handler.lambda_handler(event, FakeLambdaContext())
+_body = response_body
+_invoke = invoke_handler
 
 
 def _last_event_detail(fake_state: dict[str, Any]) -> tuple[str, dict[str, Any]]:

--- a/tests/unit/test_tenant_api_modules.py
+++ b/tests/unit/test_tenant_api_modules.py
@@ -2,65 +2,27 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-
-from test_tenant_api_handler import (
-    FakeEvents,
-    FakeLambdaClient,
-    FakeMemoryProvisioner,
-    FakePlatformQuotaClient,
-    FakeScopedDb,
-    FakeSecretsManager,
-    FakeSsm,
-    FakeUsageClient,
-)
 
 from src.tenant_api import agent_registry, ops_control, tenant_lifecycle, webhook_registry
 from src.tenant_api import handler as tenant_api_handler
+from tests.unit.tenant_api_test_support import build_module_state, fixed_now_value
 
 
 @pytest.fixture
 def fixed_now() -> datetime:
-    return datetime(2026, 2, 25, 12, 0, 0, tzinfo=UTC)
+    return fixed_now_value()
 
 
 @pytest.fixture
 def module_state(monkeypatch: pytest.MonkeyPatch, fixed_now: Any) -> dict[str, Any]:
-    db = FakeScopedDb()
-    deps = tenant_api_handler.TenantApiDependencies(
-        secretsmanager=FakeSecretsManager(),
-        events=FakeEvents(),
-        ssm=FakeSsm(),
-        awslambda=FakeLambdaClient(),
-        usage_client=FakeUsageClient(),
-        memory_provisioner=FakeMemoryProvisioner(),
-        platform_quota_client=FakePlatformQuotaClient(),
-    )
-    monkeypatch.setenv("AWS_REGION", "eu-west-2")
-    monkeypatch.setenv("TENANTS_TABLE_NAME", "platform-tenants")
-    monkeypatch.setenv("AGENTS_TABLE_NAME", "platform-agents")
-    monkeypatch.setenv("INVOCATIONS_TABLE_NAME", "platform-invocations")
-    monkeypatch.setenv("EVENT_BUS_NAME", "platform-bus")
-    monkeypatch.setenv("AUDIT_EXPORT_BUCKET", "platform-audit-exports")
-    monkeypatch.setenv("AUDIT_EXPORT_URL_EXPIRY_SECONDS", "1800")
-    monkeypatch.setenv("TENANT_API_KEY_SECRET_PREFIX", "platform/tenants")
-    monkeypatch.setenv(
-        "TENANT_MGMT_ROLE_ARN",
-        "arn:aws:iam::111111111111:role/platform-tenant-mgmt-dev",
-    )
-    monkeypatch.setenv("OPS_LOCKS_TABLE", "platform-ops-locks")
-    monkeypatch.setenv("RUNTIME_REGION_PARAM", "/platform/config/runtime-region")
-    monkeypatch.setenv("FALLBACK_REGION_PARAM", "/platform/config/fallback-region")
-    monkeypatch.setattr(tenant_api_handler, "_db_for_tenant", lambda **_kwargs: db)
-    monkeypatch.setattr(tenant_api_handler, "_now_utc", lambda: fixed_now)
-    return {"db": db, "deps": deps}
+    return build_module_state(monkeypatch, fixed_now)
 
 
 def _caller(


### PR DESCRIPTION
## Summary
- extract the shared tenant API fake platform-state seam into `tests/unit/tenant_api_test_support.py`
- remove cross-imports from `test_ops_api.py` and `test_tenant_api_modules.py` into `test_tenant_api_handler.py`
- keep the handler, ops, and module dispatch suites on one explicit set of fake builders and helpers

## Validation
- `uv run pytest tests/unit/test_tenant_api_handler.py tests/unit/test_ops_api.py tests/unit/test_tenant_api_modules.py -q`
- `uv run ruff check tests/unit/tenant_api_test_support.py tests/unit/test_tenant_api_handler.py tests/unit/test_ops_api.py tests/unit/test_tenant_api_modules.py`
- `make validate-local`
- `make preflight-session`
- `make pre-validate-session`

## Senior Review
- Independent senior review completed with no findings
- Residual risk: low; the shared support module now affects more suites at once, so fake behavior changes need to stay explicit and narrow

Closes #477