### PR TITLE
#479 Centralize tenant_api environment reads behind TenantApiConfig

### DIFF
--- a/src/tenant_api/config.py
+++ b/src/tenant_api/config.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from src.tenant_api import constants, utils
+
+
+@dataclass(frozen=True)
+class TenantApiConfig:
+    region: str
+    platform_env: str
+    tenants_table_name: str
+    agents_table_name: str
+    invocations_table_name: str
+    event_bus_name: str
+    audit_export_bucket: str | None
+    audit_export_url_expiry_seconds: int
+    api_key_secret_prefix: str
+    tenant_mgmt_role_arn: str | None
+    ops_locks_table_name: str
+    runtime_region_param_name: str
+    fallback_region_param_name: str
+    failover_lock_name: str
+
+
+def from_env(env: Mapping[str, str] | None = None) -> TenantApiConfig:
+    source = env if env is not None else os.environ
+
+    region = utils.str_or_none(source.get("AWS_REGION"))
+    if region is None:
+        raise ValueError("AWS_REGION is required")
+
+    return TenantApiConfig(
+        region=region,
+        platform_env=utils.str_or_none(source.get("PLATFORM_ENV")) or "dev",
+        tenants_table_name=utils.str_or_none(source.get(constants.TENANTS_TABLE_ENV))
+        or "platform-tenants",
+        agents_table_name=utils.str_or_none(source.get(constants.AGENTS_TABLE_ENV))
+        or "platform-agents",
+        invocations_table_name=utils.str_or_none(source.get(constants.INVOCATIONS_TABLE_ENV))
+        or "platform-invocations",
+        event_bus_name=utils.str_or_none(source.get(constants.EVENT_BUS_ENV)) or "default",
+        audit_export_bucket=utils.str_or_none(source.get(constants.AUDIT_EXPORT_BUCKET_ENV)),
+        audit_export_url_expiry_seconds=utils.coerce_positive_int(
+            source.get("AUDIT_EXPORT_URL_EXPIRY_SECONDS"),
+            default=constants.AUDIT_EXPORT_URL_EXPIRY_SECONDS,
+        ),
+        api_key_secret_prefix=utils.str_or_none(source.get(constants.API_KEY_SECRET_PREFIX_ENV))
+        or "platform/tenants",
+        tenant_mgmt_role_arn=utils.str_or_none(source.get(constants.TENANT_MGMT_ROLE_ARN_ENV)),
+        ops_locks_table_name=utils.str_or_none(source.get(constants.OPS_LOCKS_TABLE_ENV))
+        or constants.DEFAULT_OPS_LOCKS_TABLE,
+        runtime_region_param_name=utils.str_or_none(source.get(constants.RUNTIME_REGION_PARAM_ENV))
+        or constants.DEFAULT_RUNTIME_REGION_PARAM,
+        fallback_region_param_name=utils.str_or_none(
+            source.get(constants.FALLBACK_REGION_PARAM_ENV)
+        )
+        or constants.DEFAULT_FALLBACK_REGION_PARAM,
+        failover_lock_name=utils.str_or_none(source.get(constants.FAILOVER_LOCK_NAME_ENV))
+        or constants.DEFAULT_FAILOVER_LOCK_NAME,
+    )
+
+
+def current_config() -> TenantApiConfig:
+    return from_env()

--- a/src/tenant_api/db_factory.py
+++ b/src/tenant_api/db_factory.py
@@ -1,53 +1,42 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
 from data_access import ControlPlaneDynamoDB, TenantContext, TenantScopedDynamoDB, TenantScopedS3
 from data_access.models import TenantTier
 
-from src.tenant_api.constants import (
-    AUDIT_EXPORT_BUCKET_ENV,
-    INVOCATIONS_TABLE_ENV,
-    TENANTS_TABLE_ENV,
-)
+from src.tenant_api import config
 
 if TYPE_CHECKING:
     from src.tenant_api.models import CallerIdentity
 
 
 def tenants_table_name() -> str:
-    return os.environ.get(TENANTS_TABLE_ENV, "platform-tenants")
+    return config.current_config().tenants_table_name
 
 
 def agents_table_name() -> str:
-    return os.environ.get("AGENTS_TABLE_NAME", "platform-agents")
+    return config.current_config().agents_table_name
 
 
 def invocations_table_name() -> str:
-    return os.environ.get(INVOCATIONS_TABLE_ENV, "platform-invocations")
+    return config.current_config().invocations_table_name
 
 
 def audit_export_bucket_name() -> str:
-    return os.environ.get(AUDIT_EXPORT_BUCKET_ENV, "platform-audit-exports")
+    return config.current_config().audit_export_bucket or "platform-audit-exports"
 
 
 def ops_locks_table_name() -> str:
-    from src.tenant_api.constants import DEFAULT_OPS_LOCKS_TABLE, OPS_LOCKS_TABLE_ENV
-
-    return os.environ.get(OPS_LOCKS_TABLE_ENV, DEFAULT_OPS_LOCKS_TABLE)
+    return config.current_config().ops_locks_table_name
 
 
 def runtime_region_param_name() -> str:
-    from src.tenant_api.constants import DEFAULT_RUNTIME_REGION_PARAM, RUNTIME_REGION_PARAM_ENV
-
-    return os.environ.get(RUNTIME_REGION_PARAM_ENV, DEFAULT_RUNTIME_REGION_PARAM)
+    return config.current_config().runtime_region_param_name
 
 
 def fallback_region_param_name() -> str:
-    from src.tenant_api.constants import DEFAULT_FALLBACK_REGION_PARAM, FALLBACK_REGION_PARAM_ENV
-
-    return os.environ.get(FALLBACK_REGION_PARAM_ENV, DEFAULT_FALLBACK_REGION_PARAM)
+    return config.current_config().fallback_region_param_name
 
 
 def _tenant_context_for_scope(

--- a/src/tenant_api/db_utils.py
+++ b/src/tenant_api/db_utils.py
@@ -66,13 +66,11 @@ def build_update_expression(
 def read_failover_lock_record(
     caller: CallerIdentity, deps: TenantApiDependencies
 ) -> dict[str, Any] | None:
-    import os
-
-    from src.tenant_api.constants import DEFAULT_FAILOVER_LOCK_NAME, FAILOVER_LOCK_NAME_ENV
+    from src.tenant_api import config
 
     _ = deps
     db = control_plane_db(caller)
-    lock_name = os.environ.get(FAILOVER_LOCK_NAME_ENV, DEFAULT_FAILOVER_LOCK_NAME)
+    lock_name = config.current_config().failover_lock_name
     return db.get_item(
         _ops_locks_table_name(),
         {"PK": f"LOCK#{lock_name}", "SK": "METADATA"},

--- a/src/tenant_api/events.py
+++ b/src/tenant_api/events.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import json
-import os
 from typing import Any
 
-from src.tenant_api.constants import EVENT_BUS_ENV
+from src.tenant_api import config
 from src.tenant_api.models import TenantApiDependencies
 from src.tenant_api.utils import json_default
 
 
 def event_bus_name() -> str:
-    return os.environ.get(EVENT_BUS_ENV, "default")
+    return config.current_config().event_bus_name
 
 
 def put_event(

--- a/src/tenant_api/handler.py
+++ b/src/tenant_api/handler.py
@@ -11,7 +11,6 @@ ADRs: ADR-012
 from __future__ import annotations
 
 import json
-import os
 import secrets
 from datetime import UTC, datetime
 from typing import Any
@@ -36,6 +35,7 @@ from data_access.models import (
 from src.tenant_api import (
     agent_logic,
     auth,
+    config,
     constants,
     db_factory,
     db_utils,
@@ -63,7 +63,7 @@ _AwsPlatformQuotaClient = dependency_factories._AwsPlatformQuotaClient
 
 
 def _dependencies() -> TenantApiDependencies:
-    return dependency_factories.build_tenant_api_dependencies(region=os.environ["AWS_REGION"])
+    return dependency_factories.build_tenant_api_dependencies(region=config.current_config().region)
 
 
 _parse_roles = http_utils.parse_roles

--- a/src/tenant_api/ops_control.py
+++ b/src/tenant_api/ops_control.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
 from boto3.dynamodb.conditions import Key
@@ -9,10 +8,11 @@ from botocore.exceptions import ClientError
 try:
     import handler as shared
 
-    from . import auth, db_factory, db_utils, http_utils, lifecycle_logic, models, utils
+    from . import auth, config, db_factory, db_utils, http_utils, lifecycle_logic, models, utils
 except (ImportError, ValueError):  # pragma: no cover
     from src.tenant_api import (
         auth,
+        config,
         db_factory,
         db_utils,
         http_utils,
@@ -253,7 +253,7 @@ def handle_lambda_rollback(
     if function_suffix is None:
         raise ValueError("functionSuffix is required")
 
-    function_name = f"platform-{function_suffix}-{os.environ.get('PLATFORM_ENV', 'dev')}"
+    function_name = f"platform-{function_suffix}-{config.current_config().platform_env}"
     try:
         alias = deps.awslambda.get_alias(FunctionName=function_name, Name=alias_name)
         current_version = str(alias["FunctionVersion"])

--- a/src/tenant_api/secrets_manager.py
+++ b/src/tenant_api/secrets_manager.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
 import json
-import os
 import secrets
 
 from aws_lambda_powertools import Logger
 
-from src.tenant_api.constants import (
-    API_KEY_SECRET_PREFIX_ENV,
-    TENANT_MGMT_ROLE_ARN_ENV,
-)
+from src.tenant_api import config
 from src.tenant_api.models import TenantApiDependencies
 
 logger = Logger(service="tenant-api-secrets")
 
 
 def secret_prefix() -> str:
-    return os.environ.get(API_KEY_SECRET_PREFIX_ENV, "platform/tenants")
+    return config.current_config().api_key_secret_prefix
 
 
 def create_api_key_secret(
@@ -58,7 +54,7 @@ def attach_tenant_api_key_secret_policy(
     tenant_id: str,
     app_id: str,
 ) -> None:
-    tenant_mgmt_role_arn = os.environ.get(TENANT_MGMT_ROLE_ARN_ENV, "").strip()
+    tenant_mgmt_role_arn = (config.current_config().tenant_mgmt_role_arn or "").strip()
     if not tenant_mgmt_role_arn:
         logger.warning(
             "Skipping tenant API key secret resource policy: manager role ARN not configured",

--- a/src/tenant_api/tenant_audit_exports.py
+++ b/src/tenant_api/tenant_audit_exports.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import secrets
 from datetime import timedelta
 from typing import Any
@@ -9,10 +8,21 @@ from typing import Any
 from boto3.dynamodb.conditions import Key
 
 try:
-    from . import auth, constants, db_factory, db_utils, http_utils, models, utils, validation
+    from . import (
+        auth,
+        config,
+        constants,
+        db_factory,
+        db_utils,
+        http_utils,
+        models,
+        utils,
+        validation,
+    )
 except (ImportError, ValueError):  # pragma: no cover
     from src.tenant_api import (
         auth,
+        config,
         constants,
         db_factory,
         db_utils,
@@ -89,8 +99,7 @@ def _format_export_timestamp(value: Any) -> str:
 
 
 def _audit_export_url_expiry_seconds() -> int:
-    raw = os.environ.get("AUDIT_EXPORT_URL_EXPIRY_SECONDS")
-    return utils.coerce_positive_int(raw, default=constants.AUDIT_EXPORT_URL_EXPIRY_SECONDS)
+    return config.current_config().audit_export_url_expiry_seconds
 
 
 def _audit_export_key(tenant_id: str, generated_at: Any) -> str:
@@ -137,7 +146,7 @@ def handle_audit_export(
     if start_at is not None and end_at is not None and start_at > end_at:
         raise ValueError("start must be less than or equal to end")
 
-    bucket = utils.str_or_none(os.environ.get(constants.AUDIT_EXPORT_BUCKET_ENV))
+    bucket = config.current_config().audit_export_bucket
     if bucket is None:
         return http_utils.error(500, "INTERNAL_ERROR", "Audit export bucket is not configured")
 

--- a/src/tenant_api/tenant_lifecycle.py
+++ b/src/tenant_api/tenant_lifecycle.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import secrets
 import sys
 from datetime import timedelta
@@ -13,6 +12,7 @@ from data_access.models import TenantStatus
 try:
     from . import (
         auth,
+        config,
         constants,
         db_factory,
         db_utils,
@@ -28,6 +28,7 @@ try:
 except (ImportError, ValueError):  # pragma: no cover
     from src.tenant_api import (
         auth,
+        config,
         constants,
         db_factory,
         db_utils,
@@ -374,7 +375,7 @@ def handle_health(deps: models.TenantApiDependencies) -> dict[str, Any]:
         {
             "status": "ok",
             "version": "pre-release",
-            "runtimeRegion": os.environ.get("AWS_REGION", "unknown"),
+            "runtimeRegion": config.current_config().region,
             "timestamp": utils.iso(_now_utc()),
         },
     )
@@ -559,8 +560,7 @@ def _format_export_timestamp(value: Any) -> str:
 
 
 def _audit_export_url_expiry_seconds() -> int:
-    raw = os.environ.get("AUDIT_EXPORT_URL_EXPIRY_SECONDS")
-    return utils.coerce_positive_int(raw, default=constants.AUDIT_EXPORT_URL_EXPIRY_SECONDS)
+    return config.current_config().audit_export_url_expiry_seconds
 
 
 def _audit_export_key(tenant_id: str, generated_at: Any) -> str:
@@ -607,7 +607,7 @@ def handle_audit_export(
     if start_at is not None and end_at is not None and start_at > end_at:
         raise ValueError("start must be less than or equal to end")
 
-    bucket = utils.str_or_none(os.environ.get(constants.AUDIT_EXPORT_BUCKET_ENV))
+    bucket = config.current_config().audit_export_bucket
     if bucket is None:
         return http_utils.error(500, "INTERNAL_ERROR", "Audit export bucket is not configured")
 

--- a/tests/unit/test_tenant_api_config.py
+++ b/tests/unit/test_tenant_api_config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.tenant_api import config
+
+
+def test_from_env_requires_region() -> None:
+    with pytest.raises(ValueError, match="AWS_REGION is required"):
+        config.from_env({})
+
+
+def test_from_env_uses_defaults_for_optional_values() -> None:
+    cfg = config.from_env({"AWS_REGION": "eu-west-2"})
+
+    assert cfg.region == "eu-west-2"
+    assert cfg.platform_env == "dev"
+    assert cfg.tenants_table_name == "platform-tenants"
+    assert cfg.agents_table_name == "platform-agents"
+    assert cfg.invocations_table_name == "platform-invocations"
+    assert cfg.event_bus_name == "default"
+    assert cfg.audit_export_bucket is None
+    assert cfg.audit_export_url_expiry_seconds == 3600
+    assert cfg.api_key_secret_prefix == "platform/tenants"  # pragma: allowlist secret
+    assert cfg.tenant_mgmt_role_arn is None
+    assert cfg.ops_locks_table_name == "platform-ops-locks"
+    assert cfg.runtime_region_param_name == "/platform/config/runtime-region"
+    assert cfg.fallback_region_param_name == "/platform/config/fallback-region"
+    assert cfg.failover_lock_name == "platform-runtime-failover"
+
+
+def test_from_env_overrides_configured_values() -> None:
+    cfg = config.from_env(
+        {
+            "AWS_REGION": "eu-central-1",
+            "PLATFORM_ENV": "prod",
+            "TENANTS_TABLE_NAME": "tenants-x",
+            "AGENTS_TABLE_NAME": "agents-x",
+            "INVOCATIONS_TABLE_NAME": "invocations-x",
+            "EVENT_BUS_NAME": "bus-x",
+            "AUDIT_EXPORT_BUCKET": "audit-bucket-x",
+            "AUDIT_EXPORT_URL_EXPIRY_SECONDS": "1800",
+            "TENANT_API_KEY_SECRET_PREFIX": "custom/prefix",  # pragma: allowlist secret
+            "TENANT_MGMT_ROLE_ARN": "arn:aws:iam::111111111111:role/custom",
+            "OPS_LOCKS_TABLE": "locks-x",
+            "RUNTIME_REGION_PARAM": "/x/runtime",
+            "FALLBACK_REGION_PARAM": "/x/fallback",
+            "FAILOVER_LOCK_NAME": "lock-x",
+        }
+    )
+
+    assert cfg.region == "eu-central-1"
+    assert cfg.platform_env == "prod"
+    assert cfg.tenants_table_name == "tenants-x"
+    assert cfg.agents_table_name == "agents-x"
+    assert cfg.invocations_table_name == "invocations-x"
+    assert cfg.event_bus_name == "bus-x"
+    assert cfg.audit_export_bucket == "audit-bucket-x"
+    assert cfg.audit_export_url_expiry_seconds == 1800
+    assert cfg.api_key_secret_prefix == "custom/prefix"
+    assert cfg.tenant_mgmt_role_arn == "arn:aws:iam::111111111111:role/custom"
+    assert cfg.ops_locks_table_name == "locks-x"
+    assert cfg.runtime_region_param_name == "/x/runtime"
+    assert cfg.fallback_region_param_name == "/x/fallback"
+    assert cfg.failover_lock_name == "lock-x"

--- a/tests/unit/test_tenant_api_handler_config.py
+++ b/tests/unit/test_tenant_api_handler_config.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.tenant_api import dependency_factories
+from src.tenant_api import handler as tenant_api_handler
+
+
+def test_dependencies_uses_central_config_region(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        tenant_api_handler.config,
+        "current_config",
+        lambda: tenant_api_handler.config.TenantApiConfig(
+            region="eu-west-2",
+            platform_env="dev",
+            tenants_table_name="platform-tenants",
+            agents_table_name="platform-agents",
+            invocations_table_name="platform-invocations",
+            event_bus_name="platform-bus",
+            audit_export_bucket="platform-audit-exports",
+            audit_export_url_expiry_seconds=1800,
+            api_key_secret_prefix="platform/tenants",  # pragma: allowlist secret
+            tenant_mgmt_role_arn="arn:aws:iam::111111111111:role/platform-tenant-mgmt-dev",
+            ops_locks_table_name="platform-ops-locks",
+            runtime_region_param_name="/platform/config/runtime-region",
+            fallback_region_param_name="/platform/config/fallback-region",
+            failover_lock_name="platform-runtime-failover",
+        ),
+    )
+    monkeypatch.setattr(
+        dependency_factories,
+        "build_tenant_api_dependencies",
+        lambda *, region: captured.setdefault("region", region) or object(),
+    )
+
+    tenant_api_handler._dependencies()
+
+    assert captured["region"] == "eu-west-2"


### PR DESCRIPTION
## Summary
- add a typed `TenantApiConfig` builder and make it the central runtime config assembly point for tenant_api
- route existing tenant_api env/config helpers through that config path instead of ad hoc `os.environ` reads
- add focused config construction and dependency-path tests without changing HTTP behavior

## Validation
- `uv run pytest tests/unit/test_tenant_api_config.py tests/unit/test_tenant_api_handler_config.py tests/unit/test_tenant_api_dependency_factories.py tests/unit/test_ops_api.py tests/unit/test_tenant_api_modules.py tests/unit/test_tenant_api_handler.py -q`
- `uv run ruff check src/tenant_api/config.py src/tenant_api/handler.py src/tenant_api/db_factory.py src/tenant_api/events.py src/tenant_api/secrets_manager.py src/tenant_api/db_utils.py src/tenant_api/tenant_lifecycle.py src/tenant_api/tenant_audit_exports.py src/tenant_api/ops_control.py tests/unit/test_tenant_api_config.py tests/unit/test_tenant_api_handler_config.py tests/unit/test_tenant_api_dependency_factories.py tests/unit/test_ops_api.py tests/unit/test_tenant_api_modules.py tests/unit/test_tenant_api_handler.py tests/unit/tenant_api_test_support.py`
- `make validate-local`
- `make preflight-session`
- `make pre-validate-session`

## Senior Review
- Independent senior review completed with no findings
- Residual risk: low; `TenantApiConfig` is now the higher-value config review point, while dependency factories still intentionally take `region` directly to keep the change narrow

Closes #479